### PR TITLE
Fix block building script + limit Prettier file extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "fix": "npm-run-all --continue-on-error \"fix:*\"",
     "fix:eslint": "eslint --ext .js,.ts,.tsx --fix",
     "fix:markdownlint": "markdownlint --fix \"**/*\"",
-    "fix:prettier": "prettier --write  --ignore-unknown \"**/*\"",
+    "fix:prettier": "prettier --write --ignore-unknown \"**/*.{js,json,ts,yaml}\"",
     "lint": "npm-run-all --continue-on-error \"lint:*\"",
     "lint:eslint": "eslint --ext .js,.ts,.tsx",
     "lint:markdownlint": "markdownlint \"**/*\"",

--- a/registry/@hash/code.json
+++ b/registry/@hash/code.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/dev.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2021-10-29T10:59:11+02:00"
+  "timestamp": "2021-12-06T18:04:00.342Z"
 }

--- a/registry/@hash/divider.json
+++ b/registry/@hash/divider.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/dev.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2021-10-29T10:59:11+02:00"
+  "timestamp": "2021-12-06T18:04:00.342Z"
 }

--- a/registry/@hash/embed.json
+++ b/registry/@hash/embed.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/dev.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2021-11-18T12:19:34.060Z"
+  "timestamp": "2021-12-06T18:04:00.342Z"
 }

--- a/registry/@hash/header.json
+++ b/registry/@hash/header.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/dev.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2021-10-30T11:16:33.492Z"
+  "timestamp": "2021-12-06T18:04:00.342Z"
 }

--- a/registry/@hash/image.json
+++ b/registry/@hash/image.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/dev.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2021-11-18T12:19:34.060Z"
+  "timestamp": "2021-12-06T18:04:00.342Z"
 }

--- a/registry/@hash/paragraph.json
+++ b/registry/@hash/paragraph.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/dev.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2021-10-29T10:59:11+02:00"
+  "timestamp": "2021-12-06T18:04:00.342Z"
 }

--- a/registry/@hash/person.json
+++ b/registry/@hash/person.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/dev.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2021-10-29T10:59:11+02:00"
+  "timestamp": "2021-12-06T18:04:00.342Z"
 }

--- a/registry/@hash/table.json
+++ b/registry/@hash/table.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/dev.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2021-11-18T12:19:34.060Z"
+  "timestamp": "2021-12-06T18:04:00.342Z"
 }

--- a/registry/@hash/video.json
+++ b/registry/@hash/video.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/dev.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2021-11-18T12:19:34.060Z"
+  "timestamp": "2021-12-06T18:04:00.342Z"
 }

--- a/site/scripts/build-blocks.sh
+++ b/site/scripts/build-blocks.sh
@@ -88,7 +88,7 @@ cp -a "${CACHE_DIR}/blocks" "${REPO_ROOT}/site/public"
 #
 # @param build_config - path to any config in <repo-root>/registry
 #
-function build_block() {
+function build_block {
   build_config="$1"
 
   # create block specific subfolder in nextjs' static root


### PR DESCRIPTION
In #4 Prettier incorrectly formatted a function in a Bash script, breaking it. This means no blocks are available on the dev deployment at https://blockprotocol-git-dev-hashintel.vercel.app/gallery

This PR fixes the function and explicitly limits Prettier to the file formats it supports (minus toml since we're unlikely to use it).

**To test**
Go to the Vercel deployment URL for this PR (see comments below) `/gallery` and check blocks are listed there.