### PR TITLE
[TOOL] make build script x compat

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -14,7 +14,14 @@ Retrieve the 1password document `blockprotocol/site/.env.local` from the 1passwo
 
 Before serving any blocks, they need to be built. Blocks can be registered in the repo's `/registry`
 with a build-config. The build-script `/site/scripts/build-blocks.sh` allows to build blocks
-individually. It requires the commandline tools `curl`, `rsync` and `jq` to be installed.
+individually. It requires the commandline tool:
+
+- `curl`
+- `jq`
+- `md5sha1sum`
+- `rsync`
+
+These can be installed by your cli pkg mngr of choice (use `brew` on macOS).
 
 ```sh
 # build one or more blocks

--- a/site/scripts/build-blocks.sh
+++ b/site/scripts/build-blocks.sh
@@ -19,17 +19,26 @@ set -e          # exit on error
 set -u          # prevent access to yet undeclared variables
 set -o pipefail # prevent error masking in pipes
 
-# conf
-# ----
-DIR=$(readlink -ne "${BASH_SOURCE[0]%/*}")
-REPO_ROOT="$DIR/../.."
-CACHE_DIR="${REPO_ROOT}/site/.next/cache"
-
 # util
 # ----
 function log() {
   printf "[%s][%s] %s\n" "$1" "$(date +"%FT%T")" "$2" >&2
 }
+
+## x-platform readline (linux, macOS)
+function abs() {
+  if [[ -d "$1" ]]; then
+    echo $(cd "$1"; echo "$PWD")
+  else
+    echo $(cd "${1%/*}"; echo "$PWD/${1##*/}")
+  fi
+}
+
+# conf
+# ----
+DIR=$(abs "${BASH_SOURCE[0]%/*}")
+REPO_ROOT="$DIR/../.."
+CACHE_DIR="${REPO_ROOT}/site/.next/cache"
 
 # deps
 # ----
@@ -170,7 +179,7 @@ if [[ $# -gt 0 ]]; then
   log info "building block configs given as commandline arguments"
 
   for build_config in "${@:1}"; do
-    build_config=$(readlink -n "$build_config")
+    build_config=$(abs "$build_config")
     build_block "$build_config"
   done
 else


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
Make `./site/scripts/build-blocks.sh` cross-compatible w/ linux AND dear macOS.

## 🔗 Related links
none

## 🔍 What does this change?
nothing functionality-wise

## 🛡 Tests
- ✅ Manual Tests

## ❓ How to test this?
`yarn build-blocks`

## 📹 Demo
see how vercel does it ;)