### PR TITLE
[SITE][FIX] stop MUI button from flashing white on hover

### DIFF
--- a/site/src/components/Navbar.tsx
+++ b/site/src/components/Navbar.tsx
@@ -285,7 +285,7 @@ export const Navbar: FC<NavbarProps> = () => {
           width: "100%",
           position: isNavbarPositionAbsolute ? "absolute" : "fixed",
           top: isNavbarHidden && !isNavbarPositionAbsolute ? -navbarHeight : 0,
-          zIndex: isDesktopSize ? undefined : 1,
+          zIndex: 1,
           py: isDesktopSize ? 2 : 1,
           backgroundColor: isNavbarTransparent
             ? "transparent"

--- a/site/src/components/theme.ts
+++ b/site/src/components/theme.ts
@@ -391,6 +391,10 @@ export const theme = createTheme({
               },
             },
             borderRadius: 34,
+            "& > .MuiButton-startIcon>*:nth-of-type(1), > .MuiButton-endIcon>*:nth-of-type(1)":
+              {
+                fontSize: "inherit",
+              },
           },
         },
         {
@@ -404,6 +408,10 @@ export const theme = createTheme({
             "&:hover": {
               background: customColors.purple[200],
             },
+            "& > .MuiButton-startIcon>*:nth-of-type(1), > .MuiButton-endIcon>*:nth-of-type(1)":
+              {
+                fontSize: 15,
+              },
           },
         },
       ],


### PR DESCRIPTION
This fixes the styling of the primary MUI button. Previously it was flashing on hover like this:

https://user-images.githubusercontent.com/42802102/146143052-4a2485da-daba-43df-b0a9-940bc4df12ee.mov

Now this behaviour is fixed:

https://user-images.githubusercontent.com/42802102/146144224-b1ea08d0-9c06-48f5-8353-807348250009.mov


Additional changes:
- stopped capitalising the button text by default to match Figma designs
- removed the purple border from the primary button to match Figma designs
- reduce the default icon size for start and end icons


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201513556909021