### PR TITLE
Allow commits even if `lint-staged` fixes exit with error

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   },
   "lint-staged": {
     "**/*": [
-      "eslint --fix",
-      "markdownlint --fix",
-      "prettier --write"
+      "suppress-exit-code eslint --fix",
+      "suppress-exit-code markdownlint --fix",
+      "suppress-exit-code prettier --write"
     ]
   },
   "devDependencies": {
@@ -45,6 +45,7 @@
     "prettier": "2.5.0",
     "prettier-plugin-packagejson": "2.2.13",
     "prettier-plugin-sh": "0.7.1",
+    "suppress-exit-code": "1.0.0",
     "yarn-deduplicate": "^3.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2165,7 +2165,7 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
-execa@^5.1.1:
+execa@^5.0.0, execa@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
   integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
@@ -4888,6 +4888,13 @@ supports-color@^9.0.2:
   version "9.2.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-9.2.1.tgz#599dc9d45acf74c6176e0d880bab1d7d718fe891"
   integrity sha512-Obv7ycoCTG51N7y175StI9BlAXrmgZrFhZOb0/PyjHBher/NmsdBgbbQ1Inhq+gIhz6+7Gb+jWF2Vqi7Mf1xnQ==
+
+suppress-exit-code@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/suppress-exit-code/-/suppress-exit-code-1.0.0.tgz#065bf1326b78cf29014ad5f861dfed627539d4ba"
+  integrity sha512-Dc6hENE7PH9ce8fQYoNm5JLbSwpQeyLcOqu48Nd5ItIf0xdQgr2ag2fNXzU53BudOZsnYbVz/H2awt0C2prGgQ==
+  dependencies:
+    execa "^5.0.0"
 
 svgo@^2.0.3:
   version "2.8.0"


### PR DESCRIPTION
The PR responds to feedback on #13.

Full disclosure: I’m the author of [`suppress-exit-code`](https://www.npmjs.com/package/suppress-exit-code), so I am certainly biased. The package was created in 2019 after this discussion: https://github.com/okonet/lint-staged/issues/616.

I see two alternatives to using the package if we want autofixing without error checks:

-  Extract `lint-staged` config into `lint-staged.config.js` and do something like: https://github.com/okonet/lint-staged/issues/616#issuecomment-972764143. This is pretty much the same as implementing `suppress-exit-code` locally, but not in a cross-platform way. The approach looks less readable to me.

- Add `if ! npx lint-staged ; then; exit 0; fi` to `.husky/pre-commit` (like in https://github.com/okonet/lint-staged/issues/616#issuecomment-876496370). This will probably cancel subsequent linters as soon as one has failed, which is not ideal. For example, if `markdonwlint` has exited with error, `prettier --write` will not be invoked and this is a missed opportunity.

Happy to explore alternatives to `suppress-exit-code` if this option feels too tailored. Looks like most folks who use lint-staged are happy with blocking commits and that’s why there is no obvious off-the-shelf solution.