### PR TITLE
Make text selectable inside FooterBanner.tsx

### DIFF
--- a/site/src/components/FooterBanner.tsx
+++ b/site/src/components/FooterBanner.tsx
@@ -43,8 +43,8 @@ const BannerCard: FC<BannerCardProps> = ({
       alignItems: "flex-start",
       position: "relative",
       "&::before": {
-        position: "absolute",
         pointerEvents: "none",
+        position: "absolute",
         top: 0,
         right: 0,
         left: 0,


### PR DESCRIPTION
A quick fix that follows a discussion with @benwerner01 

<img width="955" alt="Screenshot 2021-12-16 at 14 18 51" src="https://user-images.githubusercontent.com/608862/146404217-7d658374-2d0e-494b-9585-a235dc1d1b3d.png">


Before: https://blockprotocol-4alak6dgm-hashintel.vercel.app/docs/quick-start
After: https://blockprotocol-pd5zt7gl9-hashintel.vercel.app/docs/quick-start