### PR TITLE
[SITE] populate mobile NavBar with sitemap pages and page sections

### DIFF
--- a/site/src/components/Navbar.tsx
+++ b/site/src/components/Navbar.tsx
@@ -1,4 +1,12 @@
-import { FC, useState, useEffect, Fragment, useContext } from "react";
+import {
+  VFC,
+  useState,
+  useEffect,
+  Fragment,
+  useContext,
+  SetStateAction,
+  Dispatch,
+} from "react";
 import {
   Box,
   Typography,
@@ -17,6 +25,7 @@ import {
   useScrollTrigger,
 } from "@mui/material";
 import { useRouter } from "next/router";
+import { SiteMapPage, SiteMapPageSection } from "../lib/sitemap";
 import { Button } from "./Button";
 import { Link } from "./Link";
 import { BlockProtocolLogoIcon } from "./SvgIcon/BlockProtocolLogoIcon";
@@ -60,109 +69,268 @@ const NAVBAR_LINK_ICONS: Record<string, JSX.Element> = {
   ),
 };
 
+type MobileNavNestedPageProps<T extends SiteMapPage | SiteMapPageSection> = {
+  icon?: JSX.Element;
+  item: T;
+  parentPageHref: T extends SiteMapPageSection ? string : undefined;
+  depth?: number;
+  expandedItems: { href: string; depth: number }[];
+  setExpandedItems: Dispatch<SetStateAction<{ href: string; depth: number }[]>>;
+  onClose: () => void;
+};
+
+const itemIsPage = (
+  item: SiteMapPage | SiteMapPageSection,
+): item is SiteMapPage => "href" in item;
+
+const MobileNavNestedPage = <T extends SiteMapPage | SiteMapPageSection>({
+  icon,
+  depth = 0,
+  expandedItems,
+  parentPageHref,
+  setExpandedItems,
+  item,
+  onClose,
+}: MobileNavNestedPageProps<T>) => {
+  const router = useRouter();
+  const { asPath } = router;
+  const { title } = item;
+
+  const isRoot = depth === 0;
+
+  const href = itemIsPage(item)
+    ? item.href
+    : `${parentPageHref}#${item.anchor}`;
+
+  const isSelected = asPath === href;
+
+  const hasChildren = itemIsPage(item)
+    ? item.subPages.length > 0 || item.sections.length > 0
+    : item.subSections.length > 0;
+
+  const isOpen =
+    hasChildren &&
+    expandedItems.some(
+      (expandedItem) =>
+        expandedItem.href === href && expandedItem.depth === depth,
+    );
+
+  return (
+    <>
+      <Link href={href}>
+        <ListItemButton
+          selected={isSelected}
+          onClick={() => {
+            if (hasChildren && !isOpen) {
+              setExpandedItems((prev) => [...prev, { href, depth }]);
+            }
+            onClose();
+          }}
+          sx={(theme) => ({
+            backgroundColor: isRoot ? undefined : theme.palette.gray[20],
+            "&.Mui-selected": {
+              backgroundColor: isRoot ? undefined : theme.palette.gray[20],
+              "&:hover": {
+                backgroundColor: isRoot ? undefined : theme.palette.gray[40],
+              },
+            },
+            "&:hover": {
+              backgroundColor: isRoot ? undefined : theme.palette.gray[40],
+            },
+            pl: (icon ? 2 : 4) + depth * 2,
+          })}
+        >
+          {icon || !itemIsPage(item) ? (
+            <ListItemIcon
+              sx={(theme) => ({
+                minWidth: isRoot ? undefined : theme.spacing(3),
+              })}
+            >
+              {icon ?? (
+                <Icon
+                  sx={{
+                    fontSize: 15,
+                  }}
+                  color="inherit"
+                  className="fas fa-hashtag"
+                />
+              )}
+            </ListItemIcon>
+          ) : null}
+          <ListItemText
+            primary={title}
+            sx={{
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              "> .MuiListItemText-primary": {
+                display: "inline",
+              },
+            }}
+          />
+          {hasChildren ? (
+            <IconButton
+              sx={{
+                transition: (theme) => theme.transitions.create("transform"),
+                transform: `rotate(${isOpen ? "0deg" : "-90deg"})`,
+              }}
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                setExpandedItems((prev) =>
+                  isOpen
+                    ? prev.filter(
+                        (expandedItem) =>
+                          !(
+                            expandedItem.href === href &&
+                            expandedItem.depth === depth
+                          ),
+                      )
+                    : [...prev, { href, depth }],
+                );
+              }}
+            >
+              <Icon
+                sx={{
+                  fontSize: 15,
+                }}
+                fontSize="inherit"
+                className="fas fa-chevron-down"
+              />
+            </IconButton>
+          ) : null}
+        </ListItemButton>
+      </Link>
+      {hasChildren ? (
+        <Collapse in={isOpen} timeout="auto" unmountOnExit>
+          <List component="div" disablePadding>
+            {itemIsPage(item) ? (
+              <>
+                {item.subPages.map((subPage) => (
+                  <MobileNavNestedPage<SiteMapPage>
+                    key={subPage.href}
+                    depth={depth + 1}
+                    item={subPage}
+                    parentPageHref={undefined}
+                    expandedItems={expandedItems}
+                    setExpandedItems={setExpandedItems}
+                    onClose={onClose}
+                  />
+                ))}
+              </>
+            ) : null}
+            {(itemIsPage(item) ? item.sections : item.subSections).map(
+              (subSection) => (
+                <MobileNavNestedPage<SiteMapPageSection>
+                  key={subSection.anchor}
+                  depth={depth + 1}
+                  parentPageHref={
+                    itemIsPage(item) ? item.href : (parentPageHref as string)
+                  }
+                  item={subSection}
+                  expandedItems={expandedItems}
+                  setExpandedItems={setExpandedItems}
+                  onClose={onClose}
+                />
+              ),
+            )}
+          </List>
+          {depth === 0 ? <Divider /> : null}
+        </Collapse>
+      ) : null}
+    </>
+  );
+};
+
 type MobileNavItemsProps = {
   onClose: () => void;
 };
 
-const MobileNavItems: FC<MobileNavItemsProps> = ({ onClose }) => {
+const getInitialExpandedItems = ({
+  asPath,
+  parentHref,
+  item,
+  depth = 0,
+}: {
+  asPath: string;
+  parentHref?: string;
+  item: SiteMapPage | SiteMapPageSection;
+  depth?: number;
+}): { href: string; depth: number }[] => {
+  const expandedChildren = [
+    ...(itemIsPage(item)
+      ? item.subPages
+          .map((page) =>
+            getInitialExpandedItems({ item: page, asPath, depth: depth + 1 }),
+          )
+          .flat()
+      : []),
+    ...(itemIsPage(item) ? item.sections : item.subSections)
+      .map((section) =>
+        getInitialExpandedItems({
+          item: section,
+          asPath,
+          depth: depth + 1,
+          parentHref: itemIsPage(item) ? item.href : parentHref,
+        }),
+      )
+      .flat(),
+  ];
+
+  const href = itemIsPage(item) ? item.href : `${parentHref}#${item.anchor}`;
+
+  const isExpanded = asPath === href || expandedChildren.length > 0;
+
+  return isExpanded
+    ? [
+        {
+          href,
+          depth,
+        },
+        ...expandedChildren,
+      ]
+    : [];
+};
+
+const MobileNavItems: VFC<MobileNavItemsProps> = ({ onClose }) => {
   const { asPath } = useRouter();
   const { pages } = useContext(SiteMapContext);
 
-  const [openedNavbarLinks, setOpenedNavbarLinks] = useState<string[]>(
-    pages.map(({ href }) => href).filter((href) => asPath.startsWith(href)),
+  const [expandedItems, setExpandedItems] = useState<
+    { href: string; depth: number }[]
+  >(
+    pages.map((page) => getInitialExpandedItems({ asPath, item: page })).flat(),
   );
 
   useEffect(() => {
-    const newOpenedNavbarLink = pages.find(({ href }) =>
-      asPath.startsWith(href),
-    )?.href;
-
-    if (newOpenedNavbarLink) {
-      setOpenedNavbarLinks([newOpenedNavbarLink]);
-    }
+    setExpandedItems((prev) => [
+      ...prev,
+      ...pages
+        .map((page) => getInitialExpandedItems({ asPath, item: page }))
+        .flat()
+        .filter(
+          (expanded) =>
+            prev.find(
+              ({ depth, href }) =>
+                expanded.depth === depth && expanded.href === href,
+            ) === undefined,
+        ),
+    ]);
   }, [asPath, pages]);
 
   return (
     <List>
-      {pages.map(({ title, href: parentHref, subPages }, i) => (
-        <Fragment key={parentHref}>
-          <Link href={parentHref}>
-            <ListItemButton
-              selected={asPath.startsWith(parentHref)}
-              onClick={() => {
-                setOpenedNavbarLinks([parentHref]);
-                onClose();
-              }}
-            >
-              <ListItemIcon>{NAVBAR_LINK_ICONS[title]}</ListItemIcon>
-              <ListItemText primary={title} />
-              {subPages && subPages.length > 0 ? (
-                <IconButton
-                  sx={{
-                    transition: (theme) =>
-                      theme.transitions.create("transform"),
-                    transform: `rotate(${
-                      openedNavbarLinks.includes(parentHref) ? "0deg" : "-90deg"
-                    })`,
-                  }}
-                  onClick={(event) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    setOpenedNavbarLinks((prev) =>
-                      prev.includes(parentHref)
-                        ? prev.filter((prevHref) => prevHref !== parentHref)
-                        : [...prev, parentHref],
-                    );
-                  }}
-                >
-                  <Icon
-                    sx={{
-                      fontSize: 15,
-                    }}
-                    fontSize="inherit"
-                    className="fas fa-chevron-down"
-                  />
-                </IconButton>
-              ) : null}
-            </ListItemButton>
-          </Link>
-          {subPages && subPages.length > 0 ? (
-            <Collapse
-              in={openedNavbarLinks.includes(parentHref)}
-              timeout="auto"
-              unmountOnExit
-            >
-              <List component="div" disablePadding>
-                {subPages.map(({ title: childTitle, href: childHref }) => (
-                  <Link key={childHref} href={childHref}>
-                    <ListItemButton
-                      selected={asPath.startsWith(childHref)}
-                      onClick={() => {
-                        setOpenedNavbarLinks([parentHref]);
-                        onClose();
-                      }}
-                      sx={{
-                        backgroundColor: (theme) => theme.palette.gray[20],
-                        "&.Mui-selected": {
-                          backgroundColor: (theme) => theme.palette.gray[20],
-                          "&:hover": {
-                            backgroundColor: (theme) => theme.palette.gray[40],
-                          },
-                        },
-                        "&:hover": {
-                          backgroundColor: (theme) => theme.palette.gray[40],
-                        },
-                        pl: 9,
-                      }}
-                    >
-                      <ListItemText primary={childTitle} />
-                    </ListItemButton>
-                  </Link>
-                ))}
-              </List>
-              {i < pages.length - 1 ? <Divider /> : null}
-            </Collapse>
-          ) : null}
+      {pages.map((page) => (
+        <Fragment key={page.href}>
+          <MobileNavNestedPage<SiteMapPage>
+            key={page.href}
+            icon={NAVBAR_LINK_ICONS[page.title]}
+            item={page}
+            parentPageHref={undefined}
+            expandedItems={expandedItems}
+            setExpandedItems={setExpandedItems}
+            onClose={onClose}
+          />
         </Fragment>
       ))}
     </List>
@@ -171,7 +339,7 @@ const MobileNavItems: FC<MobileNavItemsProps> = ({ onClose }) => {
 
 type NavbarProps = {};
 
-export const Navbar: FC<NavbarProps> = () => {
+export const Navbar: VFC<NavbarProps> = () => {
   const theme = useTheme();
   const router = useRouter();
   const { pages } = useContext(SiteMapContext);
@@ -432,9 +600,7 @@ export const Navbar: FC<NavbarProps> = () => {
                 startIcon={<BoltIcon />}
                 onClick={() => setDisplayMobileNav(false)}
               >
-                <Typography sx={{ fontWeight: 500, fontSize: "1.15rem" }}>
-                  {sm ? "Get started building blocks" : "Build a block"}
-                </Typography>
+                {sm ? "Get started building blocks" : "Build a block"}
               </Button>
             </Link>
           </Box>

--- a/site/src/components/theme.ts
+++ b/site/src/components/theme.ts
@@ -723,10 +723,10 @@ export const theme = createTheme({
               backgroundColor: customColors.gray[20],
             },
             "& .MuiListItemIcon-root": {
-              color: defaultTheme.palette.common.black,
+              color: customColors.purple[700],
             },
             "& .MuiListItemText-primary": {
-              color: defaultTheme.palette.common.black,
+              color: customColors.purple[700],
               fontWeight: 600,
             },
           },


### PR DESCRIPTION
This PR updates the mobile NavBar menu to include the pages and page sections defined in the sitemap.

Future tasks:
- [set correct gray for anchor icon](https://app.asana.com/0/0/1201547408490475/f)
- [decide whether or not to automatically close sections in the mobile navbar](https://app.asana.com/0/0/1201547408490476/f)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201503372043158