### PR TITLE
[SITE] Fix Hub page block image aspect ratio

### DIFF
--- a/site/src/components/BlockCard.tsx
+++ b/site/src/components/BlockCard.tsx
@@ -11,8 +11,10 @@ type BlockCardProps = {
 };
 
 const blockWidthStyles = {
+  mx: "auto",
   maxWidth: 450,
-  minWidth: 288,
+  /** @todo: set min-width when parent grid has been refactored to use custom breakpoints */
+  // minWidth: 288,
   width: "100%",
 };
 


### PR DESCRIPTION
This PR ensures the images rendered in block card respect 3:2 aspect ratio

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201541645622655