### PR TITLE
[SITE] Add 'embedding blocks' guide. Tweaks to spec

### DIFF
--- a/site/src/_pages/docs/2_embedding-application.mdx
+++ b/site/src/_pages/docs/2_embedding-application.mdx
@@ -1,1 +1,0 @@
-## Embedding Application

--- a/site/src/_pages/docs/2_embedding-blocks.mdx
+++ b/site/src/_pages/docs/2_embedding-blocks.mdx
@@ -1,0 +1,159 @@
+## Overview
+
+This guide covers a few key points to consider when writing or updating an application to use blocks,
+and is a companion to the [embedding application section of the block protocol specification](https://blockprotocol.org/spec/embedding-application-implementation).
+
+## Discovering blocks
+
+You can browse prototype blocks in the [block hub](https://blockprotocol.org/hub) right now.
+You can view their schema (the structure of data they accept), and see how they look given different data.
+
+We will launch an API to search blocks in January. As well as listing blocks and searching by name,
+this will enable you to provide a data object, and be told which blocks can display or edit it.
+
+For example, if you provide `{ "name": "Bob", email: "bob@test.com" }`, the API will suggest the
+[person block](https://blockprotocol.org/@hash/person).
+
+Once your app implements the block protocol, your users can search and use blocks to work with a
+wide variety of data structures, without further effort on your part.
+
+If you want to know when the API launches, please [register your interest](https://blockprotocol.org/partners).
+
+## Building the block's properties
+
+Applications need to provide blocks with:
+
+- the entity data that the block will allow users to visualize or edit,
+- links between entities, and
+- functions and ids to use when updating entities.
+
+These are described in detail in [the specification](https://blockprotocol-git-dev-hashintel.vercel.app/spec/block-types#data-provided-to-blocks),
+and we draw out some key points below.
+
+### Providing data
+
+The block protocol deals with things called _entities_ and separate things called _links_,
+which link entities together.
+
+This data model is intended to be generic and extensible: to allow new entity types to be defined on the fly
+and linked to any other arbitrary entity, and to enable translation back and forth between a range of other data models.
+
+You may need to normalize data to the expected format. Some points to consider:
+
+**1. Each entity should have an `entityId` and an `entityTypeId`, both of which must be strings.**
+
+These will be provided by blocks when requesting updates to an entity (see [handling block actions](#handling-block-actions)).
+
+For example, a row in a `companies` table like the following:
+
+| id  | name |
+| --- | ---- |
+| 456 | Acme |
+
+...might become:
+
+```json
+{
+  "entityId": "456",
+  "entityTypeId": "Company",
+  "name": "ACME"
+}
+```
+
+**2. Links between entities are represented as separate records, rather than as properties on an entity.**
+
+If you want blocks to allow users to visualize or edit links between entities, you should provide them to blocks.
+
+This might mean translating links encoded on your records directly into separate objects.
+
+If you don't have separate links in your own data model, you would ideally give the links you create
+a unique, stable id so that blocks can track them across time.
+
+For example, a row in your `users` table:
+
+| id  | name | companyId |
+| --- | ---- | --------- |
+| 41  | Bob  | 456       |
+
+...might become the following entity:
+
+```json
+{
+  "entityId": "41",
+  "entityTypeId": "User",
+  "name": "Bob"
+}
+```
+
+...and the following link (assuming you didn't already have a `linkId` and generate one):
+
+```json
+{
+  "linkId": "user-42-company-456",
+  "sourceEntityId": "42",
+  "destinationEntityId": "456",
+  "path": "company"
+}
+```
+
+Links should be provided to blocks under the `linkGroups` field, [as described in the spec](https://blockprotocol.org/spec/block-types#linking-entities).
+
+### Handling requests
+
+Blocks request the creation or updating of _entities_ and _links_, via the functions you provide.
+
+Blocks will send requests to update entities with the `entityId` and `entityTypeId` you provide with them,
+and a payload which represents the properties to be assigned to that entity.
+
+As blocks should be portable, they are not tied to a particular embedding context, and you will need to
+provide functions which are a level of abstraction on top of your API or datastore.
+
+For example, you may need to translate a call to `createEntity` with an `entityTypeId` of `"Company"`,
+to a `POST` request to your `/companies` endpoint.
+
+Depending on your data model, you may also need to translate requests related to links.
+
+For example, you may need to translate a call to `createLink` with the following payload:
+
+```json
+{
+  "sourceEntityId": "42",
+  "sourceEntityTypeId": "User",
+  "destinationEntityId": "789",
+  "destinationEntityTypeId": "Company"
+}
+```
+
+...into a call to set `companyId: "789"` on a user with id `42`, whether that's via a `PUT` request to `/users`,
+a dedicated endpoint for assigning users to companies, or any other number of possible implementations.
+
+## Rendering blocks
+
+Once you have discovered a block you want to use, and have the data in the form it needs,
+you need to put the two together on a webpage.
+
+How exactly this is done will depend on your own application, and how the block is written.
+
+A block will use the `externals` field in its `block-metadata.json` to indicate the key dependencies it
+expects to be provided with (to keep block bundle size down), and this can also be used to infer how
+it expects to be rendered.
+
+For example, a block with `react` in its externals, and a JavaScript entry point, is likely a React component,
+and the source can be used to create a function which is then rendered like any other React component,
+with the required functions and properties passed in as `props`. Any dependencies it expects could be provided
+by giving a `requires` function when creating the function.
+
+A block with an HTML entry point could be added to the page like any other HTML element. Any dependencies it
+expects could be attached to the scope of the document (we assume blocks are [sandboxed](#security)).
+
+We will be releasing source code in January which demonstrates how all this can be done.
+
+If you want to know when the example application code is available, please [register your interest](https://blockprotocol.org/partners).
+
+## Security
+
+You should take suitable precautions to ensure that block code is unable to compromise
+your systems or take unexpected action on behalf of your users.
+
+We will be providing source code for an example application which demonstrates one
+potential approach to sandboxing block execution.

--- a/site/src/_pages/spec/1_block-types.mdx
+++ b/site/src/_pages/spec/1_block-types.mdx
@@ -25,7 +25,7 @@ A block package SHOULD contain:
 
     - a `name` for the block
     - any libraries the block expects the embedding application to supply it with under `externals` – i.e. libraries which the block depends on but does not include in its package – using the name of the library as it is usually distributed (e.g. via npm), and the expected version (or version range).
-      For example, a block may SPO rely on React (`"externals": [{ "react": "^16.0.0" }]`), but assume that the embedding application will provide it, to save loading it multiple times on a page.
+      For example, a block may rely on React (`"externals": [{ "react": "^16.0.0" }]`), but assume that the embedding application will provide it, to save loading it multiple times on a page. This is also a useful way of indicating how the block expects to be rendered.
     - the path or URL to the entrypoint source file (e.g. `index.html`, `index.js`) under `source`
     - the `version` of the block, which SHOULD use [semantic versioning](https://semver.org/)
     - `protocol`: the applicable block protocol version
@@ -44,8 +44,7 @@ A block package SHOULD contain:
   - MAY specify:
 
     - `variants` – an array of objects, each with a `name`, `description`, `icon`, and `properties`, which represents different variants of the block that the user can create. As a simple example, a ‘header’ block might have variants called ‘Heading 1’ and ‘Heading 2’, which start with `{ level: 1 }` and `{ level: 2 }` as properties, respectively.
-    - `image` – a preview image of the block for users to see it in action
-      before using it
+    - `image` – a preview image of the block for users to see it in action before using it. This would ideally have a 3:2 width:height ratio and be a minimum of 900x1170px.
 
 ## Requesting, creating, and updating data
 
@@ -71,7 +70,7 @@ Blocks should expect the following additional fields related to linked data to b
 
 - a `linkedAggregations` field containing the results of aggregations linked from the block’s entity
 
-- a `links` field which provides the links attached to the block or entities provided in either `linkedEntities` or `linkedAggregations`
+- a `linkGroups` field which provides the links attached to the block or entities provided in either `linkedEntities` or `linkedAggregations`, grouped by entity and path
 
 - where available, an `entityTypes` field containing entity type definitions for any entities sent to the blocks, which can be parsed to understand the constraints on user input for each entity (e.g. which fields are editable, what sort of data they accept).
   Each entry in the array is a JSON schema object with an additional `entityTypeId` field corresponding to the `entityTypeId` of the entities it describes the shape of.
@@ -80,11 +79,11 @@ _\* Embedding applications will want to impose limits on the extent to which lin
 They can be requested using the functions listed below._
 
 Each entity provided under `linkedEntities` or `linkedAggregations` will also have an `entityId` and `entityTypeId` to be used as arguments when updating those entities.
-See [linking entities](#linking-entitites) for a discussion of how links are managed.
+See [linking entities](#linking-entities) for a discussion of how links are managed.
 
 ### Functions provided to blocks
 
-Subject to the permissions granted to them by the embedding application, blocks can expect functions with the names and signatures listed below to be made available to them, i.e. to be passed in along with the properties defined in their schema, or to be otherwise made available in their scope depending on their [implementation](#linking-entitites):
+Subject to the permissions granted to them by the embedding application, blocks can expect functions with the names and signatures listed below to be made available to them, i.e. to be passed in along with the properties defined in their schema, or to be otherwise made available in their scope depending on their [implementation](#linking-entities):
 
 ```block-method
 createEntity<T>(actions: Payload<T>[]): Promise<T[]>
@@ -99,10 +98,10 @@ creates one or more entities
 - `entityTypeId` \[_string_]: the type of entity to create.
 - `data<T>` \[_object_]: the field(s) and value(s) with which to create the entity, i.e. its properties.
 - `links?`: \[_object_]\[_optional_]: any links to create along with this entity.
-  See [linking entities](#linking-entitites).
+  See [linking entities](#linking-entities).
 - `selection?` \[_array_ of _strings_]\[_optional_]: limit the return to only include these fields on the entity.
 - `depth?` \[_integer_]\[_optional_]: limit the depth to which linked data in an entity will be resolved.
-  See [linking entities](#linking-entitites).
+  See [linking entities](#linking-entities).
 
 ```block-method
 updateEntity<T>(actions: Payload<T>[]): Promise<T[]>
@@ -119,7 +118,7 @@ updates one or more entities
 - `entityId` \[_string_]: the id of the entity to update.
 - `selection?` \[_array of strings_]\[_optional_]: limit the return to only include these fields on the entity.
 - `depth?` \[_integer_]\[_optional_]: limit the depth to which linked data in an entity will be resolved.
-  See [linking entities](#linking-entitites).
+  See [linking entities](#linking-entities).
 
 ```block-method
 deleteEntity(actions: Payload[]): Promise<boolean[]>
@@ -134,7 +133,7 @@ deletes one or more entities
 - `entityTypeId` \[_string_]: the type of entity to delete
 - `entityId` \[_string_]: the id of the entity to delete.
 - `depth?` \[_integer_]\[_optional_]: limit the depth to which linked data in an entity will be resolved.
-  See [linking entities](#linking-entitites).
+  See [linking entities](#linking-entities).
 
 ```block-method
 getEntity<T>(actions: Payload<T>[]): Promise<T[]>
@@ -150,7 +149,7 @@ retrieve one or more entities
 - `entityId` \[_string_]: the id of the entity to retrieve.
 - `selection?` \[_array_ of _strings_]\[_optional_]: limit the return to only include these fields on the entity.
 - `depth?` \[_integer_]\[_optional_]: limit the depth to which linked data in an entity will be resolved.
-  See [linking entities](#linking-entitites).
+  See [linking entities](#linking-entities).
 
 ```block-method
 aggregateEntity(action: Payload): Promise<AggregationResult>
@@ -179,7 +178,7 @@ following shape
 - `entityTypeId` \[_object_]: the type of entity to provide aggregated data for
 - `selection?` \[_array_ of _strings_]\[_optional_]: limit the return to only include these fields on the entity.
 - `depth?` \[_integer_]\[_optional_]: limit the depth to which linked data in an entity will be resolved.
-  See [linking entities](#linking-entities-to-other-entities).
+  See [linking entities](#linking-entities).
 - `operation?` <a id="aggregate-entity-operation" /> \[_object_]\[_optional_]: a description of the aggregation operation, which contains at least one of the following fields:
 - `pageNumber?` \[_integer_]\[_optional_]: the page number to request.
 - `itemsPerPage?` \[_integer_]\[_optional_]: the number of results to return.
@@ -220,7 +219,7 @@ updateEntityType(actions: Payload[]): Promise<EntityType>[]>
 
 updates one or more entity types.
 
-**returns:** the updates entity types
+**returns:** the updated entity types
 
 `Payload`: accepts a single _array_ of _objects,_ each with the following shape:
 
@@ -262,23 +261,33 @@ retrieve one or more entity types.
 `Payload` accept an object with a single key, `operation`, which is
 the [same shape as for aggregating entities](#aggregate-entity-operation).
 
-### Linking entities to other entities
+### Linking entities
 
 Another special set of functions provided to blocks relate to managing links between entities.
 
-When creating or updating an entity’s data, including its own, blocks will often wish to express that a certain property on an entity should be a reference to another entity or a collection of entities.
+When creating or updating an entity’s data, including its own, blocks will often wish to express
+that a certain property on an entity should be a reference to another entity.
+
 For example, that a Person’s employer field should point to a particular Company entity.
 
-A block may also wish to link one of its properties to a particular entity or aggregation of entities.
-For example, a table block displaying the Top 10 people sorted by some property of Person, will need a way of encoding this aggregation in its data.
+A block may also wish to link one of its properties to an aggregation of entities.
+
+For example, a table block displaying the Top 10 people sorted by some property of Person,
+will need a way of encoding this aggregation in its data.
 
 In order to create a reference to a separate entity or entities as the desired value of a particular field, blocks should create a `Link` <a id="link-object" />, which:
 
-- MUST contain `sourceId` \[_string_]: the `entityId` of the source entity
+- MUST contain `sourceEntityId` \[_string_]: the `entityId` of the source entity.
+- MAY contain `sourceEntityVersionId` \[_string_]: optionally specify that this link is only from a specific version.
+- MAY contain `sourceEntityTypeId`: \[_string_]: the `entityTypeId` of the source entity.
 - MUST contain `path` \[_string_]: the path to the field on the source entity this link is conceptually made on, expressed as a [JSON path](https://goessner.net/articles/JsonPath/).
 - MUST contain EITHER:
-  - `destinationId` \[_string_] – the id of a single entity the link is made to, OR
+  - `destinationEntityId` \[_string_] – the id of a single entity the link is made to, OR
   - `aggregate` – an aggregation operation which the embedding application should resolve the link to, following the structure of the `operation` object [described above](#aggregate-entity-operation).
+- if `destinationEntityId` is defined:
+  - MAY contain `destinationEntityVersionId` to pin the link to a specific version of the destination entity.
+  - MAY contain `destinationEntityTypeId`: \[_string_]: the `entityTypeId` of the destination entity.
+- MAY contain `index` \[_integer_]: the position of this link in a list (for where ordering of links is important).
 
 Once created, a `Link` includes a `linkId`.
 
@@ -286,8 +295,8 @@ Once created, a `Link` includes a `linkId`.
 
 ```json
 {
-  "sourceId": "user1",
-  "destinationId": "company1",
+  "sourceEntityId": "user1",
+  "destinationEntityId": "company1",
   "path": "employer"
 }
 ```
@@ -296,7 +305,7 @@ Once created, a `Link` includes a `linkId`.
 
 ```json
 {
-  "sourceId": "table1",
+  "sourceEntityId": "table1",
   "path": "rows",
   "aggregate": {
     "entityTypeId": "sales",
@@ -307,7 +316,31 @@ Once created, a `Link` includes a `linkId`.
 }
 ```
 
-An entry in linkedAggregations follows the shape of the [`AggregationResult` object](#aggregation-result-object), with the addition of a `link` field containing the link which generated it (to allow identifying which entity and path the result ‘belongs’ to, where it might otherwise be ambiguous).
+Links will be provided to a block under a `linkGroups` field, which is an array of objects,
+each of which specifies a source entity, a path (field name), and the links on that path.
+
+```json
+{
+  "sourceEntityId": "user1",
+  "path": "company",
+  "links": [
+    {
+      "sourceEntityId": "user1",
+      "destinationEntityId": "company1",
+      "path": "company"
+    }
+  ]
+}
+```
+
+N.B. this data structure has been chosen to allow for later pagination of links on a field.
+
+The entities linked to will be provided under `linkedEntities` and `linkedAggregations`
+(and the entities they link onwards to, depending on the depth the graph is resolved to).
+
+An entry in linkedAggregations follows the shape of the [`AggregationResult` object](#aggregation-result-object),
+with the addition of a `link` field containing the link which generated it (to allow identifying which entity
+and path the result ‘belongs’ to, where it might otherwise be ambiguous).
 
 To create, update and delete links between entities, blocks should expect the following functions to be made available to them:
 

--- a/site/src/_pages/spec/2_embedding-application-implementation.mdx
+++ b/site/src/_pages/spec/2_embedding-application-implementation.mdx
@@ -47,4 +47,4 @@ Users should then be prompted to permit or deny the sort of action the block is 
 
 Where an embedding application supplies a block with data corresponding to structured entities, and the web page and that entity data are for public consumption, the embedding application SHOULD [include machine-readable structured data on the page](https://developers.google.com/search/docs/guides/intro-structured-data).
 
-For example, JSON schema definitions for entities may include a `jsonld:context` [key pointing to a mapping between JSON terms and IRIs](https://www.w3.org/2019/wot/json-schema#defining-a-json-ld-context-for-data-instances), which can be used to construct a JSON-LD representation of the entity which embedding applications can embed on the page.
+For example, JSON schema definitions for entities may include a `jsonld:context` [key pointing to a mapping between JSON terms and IRIs](https://www.w3.org/2019/wot/json-schema#defining-a-json-ld-context-for-data-instances), which can be used to construct a JSON-LD representation of the entity which embedding applications can include in the page's markup.

--- a/site/src/lib/sitemap.ts
+++ b/site/src/lib/sitemap.ts
@@ -32,15 +32,15 @@ export const getDocumentationSubPages = (): SiteMapPage[] => [
       fileName: "1_quick-start-guide.mdx",
     }),
     href: "/docs/quick-start-guide",
-    title: "Quick Start Guide",
+    title: "Authoring Blocks",
   },
   {
     ...getPage({
       pathToDirectory: "docs",
-      fileName: "2_embedding-application.mdx",
+      fileName: "2_embedding-blocks.mdx",
     }),
-    href: "/docs/embedding-application",
-    title: "Embedding Application",
+    href: "/docs/embedding-blocks",
+    title: "Embedding Blocks",
   },
 ];
 

--- a/site/src/pages/[org]/[block].page.tsx
+++ b/site/src/pages/[org]/[block].page.tsx
@@ -17,7 +17,7 @@ const blockDependencies = {
 /* eslint-enable global-require */
 
 type BlockExports = { default: React.FC };
-/** @sync @hashintel/block-protocol */
+/** @todo type as JSON Schema. make part of blockprotocol package and publish. */
 type BlockSchema = Record<string, any>;
 type BlockDependency = keyof typeof blockDependencies;
 

--- a/site/src/pages/api/blocks.api.ts
+++ b/site/src/pages/api/blocks.api.ts
@@ -1,9 +1,9 @@
 import type { NextApiHandler } from "next/";
 
-/** @sync @hashintel/block-protocol */
+/** @todo type as JSON object */
 export type BlockProps = object;
 
-/** @sync @hashintel/block-protocol */
+/** @todo make part of blockprotocol package and publish */
 export type BlockVariant = {
   description?: string;
   displayName?: string;
@@ -11,8 +11,7 @@ export type BlockVariant = {
   properties?: BlockProps;
 };
 
-// move to types.ts
-/** @sync @hashintel/block-protocol */
+/** @todo make part of blockprotocol package and publish */
 export type BlockMetadata = {
   author?: string;
   description?: string;
@@ -44,6 +43,7 @@ export type BlockRegistryInfo = {
  * used to read block metadata from disk.
  *
  * @todo nextjs api endpoints don't have access to nextjs' public folder on vercel
+ *    fix this to fetch from the URL instead (or some other way)
  */
 export const readBlocksFromDisk = (): BlockMetadata[] => {
   /* eslint-disable global-require -- dependencies are required at runtime to avoid bundling them w/ nextjs */

--- a/site/src/pages/docs/[[...docsSlug]].page.tsx
+++ b/site/src/pages/docs/[[...docsSlug]].page.tsx
@@ -24,7 +24,8 @@ const documentationPages = (siteMap as SiteMap).pages.find(
 
 const DOCS_PAGE_SUBTITLES: Record<string, string> = {
   Introduction: "This is the introduction page",
-  "Quick Start Guide": "A quick start guide to developing blocks",
+  "Authoring Blocks": "A quick start guide to developing blocks",
+  "Embedding Blocks": "A guide for embedding applications",
 };
 
 const a11yProps = (index: number) => ({
@@ -164,7 +165,7 @@ const DocsPage: NextPage<DocsPageProps> = ({
         <Box py={4} display="flex" alignItems="flex-start">
           {md ? (
             <Box
-              paddingRight={4}
+              paddingRight={6}
               width={300}
               flexGrow={0}
               sx={{

--- a/site/src/pages/spec/[[...specSlug]].page.tsx
+++ b/site/src/pages/spec/[[...specSlug]].page.tsx
@@ -215,7 +215,7 @@ const SpecPage: NextPage<SpecPageProps> = ({ serializedPage }) => {
       <Box py={4} display="flex" alignItems="flex-start">
         {md ? (
           <Box
-            paddingRight={4}
+            paddingRight={6}
             width={300}
             flexGrow={0}
             sx={{


### PR DESCRIPTION
This PR introduces the first cut of the 'embedding blocks' guide.

In passing it also makes a few other tweaks (included in here to save time):
- update the spec to refer to `linkGroups` rather than `links`
- fixes some links and field names in the spec
- update a few comments

A couple of things for follow-up:
1. Add syntax highlighting
2. Style tables in our markdown