### PR TITLE
[SITE] Specification page prev/next page buttons

### DIFF
--- a/site/src/components/PageNavLinks.tsx
+++ b/site/src/components/PageNavLinks.tsx
@@ -1,0 +1,132 @@
+import { VFC } from "react";
+import { Typography, Box, Icon, BoxProps, styled } from "@mui/material";
+import { Link } from "./Link";
+import { SiteMapPage } from "../lib/sitemap";
+
+const NavArrowIcon = styled(Icon)(({ theme }) => ({
+  color: theme.palette.purple[300],
+  fontSize: 15,
+  marginTop: theme.spacing(0.8),
+  position: "relative",
+  left: 0,
+  transition: theme.transitions.create("left"),
+}));
+
+type PageNavLinksProps = {
+  prevPage?: SiteMapPage;
+  nextPage?: SiteMapPage;
+} & BoxProps;
+
+export const PageNavLinks: VFC<PageNavLinksProps> = ({
+  prevPage,
+  nextPage,
+  ...boxProps
+}) => {
+  return (
+    <Box display="flex" justifyContent="space-between" {...boxProps}>
+      <Box>
+        {prevPage && (
+          <Box display="flex" alignItems="flex-end">
+            <Box>
+              <Typography
+                sx={(theme) => ({ color: theme.palette.gray[60] })}
+                component="p"
+                variant="bpSmallCopy"
+              >
+                Previous
+              </Typography>
+              <Box
+                display="flex"
+                sx={(theme) => ({
+                  marginLeft: {
+                    xs: 0,
+                    md: "-31px",
+                  },
+                  ":hover svg": {
+                    left: `-${theme.spacing(1)}`,
+                  },
+                })}
+              >
+                <NavArrowIcon
+                  sx={{
+                    marginRight: 2,
+                    display: {
+                      xs: "none",
+                      md: "inherit",
+                    },
+                  }}
+                  className="fas fa-arrow-left"
+                />
+                <Link
+                  sx={(theme) => ({
+                    maxWidth: {
+                      xs: 150,
+                      sm: 200,
+                    },
+                    ":hover": {
+                      color: theme.palette.purple[800],
+                    },
+                  })}
+                  href={prevPage.href}
+                >
+                  {prevPage.title}
+                </Link>
+              </Box>
+            </Box>
+          </Box>
+        )}
+      </Box>
+      <Box>
+        {nextPage && (
+          <Box display="flex" flexDirection="column" alignItems="flex-end">
+            <Typography
+              sx={(theme) => ({ color: theme.palette.gray[60] })}
+              component="p"
+              variant="bpSmallCopy"
+            >
+              Next
+            </Typography>
+            <Box
+              display="flex"
+              sx={(theme) => ({
+                marginRight: {
+                  xs: 0,
+                  md: "-31px",
+                },
+                ":hover svg": {
+                  left: theme.spacing(1),
+                },
+              })}
+            >
+              <Link
+                sx={(theme) => ({
+                  textAlign: "right",
+                  maxWidth: {
+                    xs: 150,
+                    sm: 200,
+                  },
+                  ":hover": {
+                    color: theme.palette.purple[800],
+                  },
+                })}
+                href={nextPage.href}
+              >
+                {nextPage.title}
+              </Link>
+              <NavArrowIcon
+                sx={{
+                  marginLeft: 2,
+                  display: {
+                    xs: "none",
+                    md: "inherit",
+                  },
+                }}
+                className="fas fa-arrow-right"
+              />
+            </Box>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+};

--- a/site/src/pages/spec/[[...specSlug]].page.tsx
+++ b/site/src/pages/spec/[[...specSlug]].page.tsx
@@ -9,6 +9,7 @@ import {
   useTheme,
 } from "@mui/material";
 import { GetStaticPaths, GetStaticProps, NextPage } from "next";
+import { useRouter } from "next/router";
 import { MDXRemoteSerializeResult } from "next-mdx-remote";
 import { Button } from "../../components/Button";
 import { Link } from "../../components/Link";
@@ -18,6 +19,8 @@ import { getAllPageHrefs, getSerializedPage } from "../../util/mdxUtils";
 import { parseIntFromPixelString } from "../../util/muiUtils";
 import SiteMapContext from "../../components/context/SiteMapContext";
 import { MDXPageContent } from "../../components/MDXPageContent";
+import { INFO_CARD_WIDTH } from "../../components/InfoCard/InfoCardWrapper";
+import { PageNavLinks } from "../../components/PageNavLinks";
 
 const GitHubInfoCard = (
   <Paper
@@ -171,11 +174,23 @@ export const getStaticProps: GetStaticProps<
 
 const SpecPage: NextPage<SpecPageProps> = ({ serializedPage }) => {
   const theme = useTheme();
+  const { asPath } = useRouter();
   const { pages: allPages } = useContext(SiteMapContext);
 
   const { subPages: specificationPages } = allPages.find(
     ({ title }) => title === "Specification",
   )!;
+
+  const currentPageIndex = specificationPages.findIndex(
+    ({ href }) => asPath === href || asPath.startsWith(`${href}#`),
+  );
+
+  const prevPage =
+    currentPageIndex > 0 ? specificationPages[currentPageIndex - 1] : undefined;
+  const nextPage =
+    currentPageIndex < specificationPages.length - 1
+      ? specificationPages[currentPageIndex + 1]
+      : undefined;
 
   const md = useMediaQuery(theme.breakpoints.up("md"));
 
@@ -212,7 +227,7 @@ const SpecPage: NextPage<SpecPageProps> = ({ serializedPage }) => {
         The open-source protocol for creating interactive, data-driven blocks
       </Typography>
       {GitHubInfoCard}
-      <Box py={4} display="flex" alignItems="flex-start">
+      <Box mb={4} py={4} display="flex" alignItems="flex-start">
         {md ? (
           <Box
             paddingRight={4}
@@ -237,6 +252,22 @@ const SpecPage: NextPage<SpecPageProps> = ({ serializedPage }) => {
         ) : null}
         <MDXPageContent flexGrow={1} serializedPage={serializedPage} />
       </Box>
+      <PageNavLinks
+        prevPage={prevPage}
+        nextPage={nextPage}
+        mb={8}
+        sx={{
+          marginLeft: {
+            xs: 0,
+            md: "300px",
+          },
+          maxWidth: {
+            xs: "100%",
+            sm: `calc(100% - ${INFO_CARD_WIDTH}px)`,
+            md: `calc(100% - ${INFO_CARD_WIDTH}px - 300px)`,
+          },
+        }}
+      />
     </Container>
   );
 };


### PR DESCRIPTION
This PR introduces responsive prev/next page buttons on the specification page:

![image](https://user-images.githubusercontent.com/42802102/147076293-d1123f91-504c-4218-93ca-74f0601f7869.png)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201520335396609