### PR TITLE
[SITE] Fix syntax highlighting in mdx

### DIFF
--- a/site/src/components/MDXPageContent.tsx
+++ b/site/src/components/MDXPageContent.tsx
@@ -14,7 +14,7 @@ export const MDXPageContent: VFC<MDXPageContentProps> = ({
 }) => (
   <Box
     {...boxProps}
-    sx={(theme) => ({
+    sx={{
       width: "100%",
       overflow: "scroll",
       "& > :not(.info-card-wrapper), > a:not(.info-card-wrapper) > *": {
@@ -23,20 +23,7 @@ export const MDXPageContent: VFC<MDXPageContentProps> = ({
           sm: `calc(100% - ${INFO_CARD_WIDTH}px)`,
         },
       },
-      '& pre:not([class*="language-"]) > code[class*="language-"]': {
-        overflow: "scroll",
-        display: "block",
-        fontSize: "80%",
-        color: theme.palette.purple[700],
-        background: theme.palette.purple[100],
-        padding: theme.spacing(2),
-        borderColor: theme.palette.purple[200],
-        borderWidth: 1,
-        borderStyle: "solid",
-        borderRadius: "8px",
-        textShadow: "none",
-      },
-    })}
+    }}
   >
     <MDXRemote {...serializedPage} components={mdxComponents} />
   </Box>

--- a/site/src/components/Snippet.tsx
+++ b/site/src/components/Snippet.tsx
@@ -1,11 +1,9 @@
 import React from "react";
 import Prism from "prismjs";
-import "prismjs/components/prism-json";
 
 /**
  * Add support for another language:
  *
- * - add the language string id to the union type below
  * - import the grammar package from "prismjs/components/prism-[language]"
  * - eventually you may have to re-build and download the prism.css
  *   to support the new language at https://prismjs.com/download.html
@@ -14,25 +12,33 @@ import "prismjs/components/prism-json";
  *
  * @see https://prismjs.com
  */
-type Language = "json";
+
+import "prismjs/components/prism-json";
+import "prismjs/components/prism-json5";
 
 interface SnippetProps {
   className?: string;
   source: string;
-  language: Language;
+  language: string;
 }
 
 export const Snippet: React.VFC<SnippetProps> = ({
   className,
   source,
   language,
-}) => (
-  <pre className={className}>
+}) => {
+  const grammar = Prism.languages[language];
+  if (!grammar) {
+    return <code className={className}>source</code>;
+  }
+
+  return (
     <code
+      className={className}
       // eslint-disable-next-line react/no-danger -- trust prism to properly escape the source
       dangerouslySetInnerHTML={{
-        __html: Prism.highlight(source, Prism.languages[language], language),
+        __html: Prism.highlight(source, grammar, language),
       }}
     />
-  </pre>
-);
+  );
+};

--- a/site/src/pages/[org]/[block].page.tsx
+++ b/site/src/pages/[org]/[block].page.tsx
@@ -141,11 +141,12 @@ const Block: NextPage = () => {
               style={{ height: 320, fontSize: 14 }}
               className={tw`rounded-2xl bg-gray-800 p-3 w-full`}
             >
-              <Snippet
-                className={tw`font-mono overflow-scroll h-full`}
-                source={JSON.stringify(schema, null, 2)}
-                language="json"
-              />
+              <pre className={tw`font-mono overflow-scroll h-full`}>
+                <Snippet
+                  source={JSON.stringify(schema, null, 2)}
+                  language="json"
+                />
+              </pre>
             </div>
           </div>
         </div>

--- a/site/src/pages/api/blocks.api.ts
+++ b/site/src/pages/api/blocks.api.ts
@@ -75,7 +75,7 @@ export const readBlocksFromDisk = (): BlockMetadata[] => {
 let cachedBlocksFromDisk: Array<BlockMetadata> | null = null;
 
 const blocks: NextApiHandler<BlockMetadata[]> = (_req, res) => {
-  cachedBlocksFromDisk ??= readBlocksFromDisk();
+  cachedBlocksFromDisk = cachedBlocksFromDisk ?? readBlocksFromDisk();
   res.status(200).json(cachedBlocksFromDisk);
 };
 

--- a/site/src/util/mdxComponents.tsx
+++ b/site/src/util/mdxComponents.tsx
@@ -4,6 +4,7 @@ import { TypographyProps, Typography, Box, Paper } from "@mui/material";
 import { Link } from "../components/Link";
 import { InfoCardWrapper } from "../components/InfoCard/InfoCardWrapper";
 import { InfoCard } from "../components/InfoCard/InfoCard";
+import { Snippet } from "../components/Snippet";
 
 const stringifyChildren = (node: ReactNode): string => {
   if (typeof node === "string") {
@@ -162,6 +163,10 @@ export const mdxComponents: Record<string, React.ReactNode> = {
       {...props}
     />
   ),
+  pre: (props: HTMLAttributes<HTMLElement>) => {
+    // Delegate full control to code for more styling options
+    return props.children;
+  },
   code: (props: HTMLAttributes<HTMLElement>) => {
     const isLanguageBlockFunction =
       props.className === "language-block-function";
@@ -170,21 +175,35 @@ export const mdxComponents: Record<string, React.ReactNode> = {
       return (
         <Box
           id={anchor}
-          sx={{ fontWeight: "bold", color: "#d18d5b", whiteSpace: "normal" }}
+          component="code"
+          sx={{ fontWeight: "bold", color: "#d18d5b" }}
         >
           <Link href={`#${anchor}`}>{props.children}</Link>
         </Box>
       );
     }
-
     return (
       <Box
-        {...props}
-        component="code"
-        sx={{
+        component="pre"
+        sx={(theme) => ({
+          overflow: "scroll",
+          display: "block",
+          fontSize: "80%",
+          color: theme.palette.purple[700],
+          background: "#000",
+          padding: theme.spacing(2),
+          borderWidth: 1,
+          borderStyle: "solid",
+          borderRadius: "8px",
+          textShadow: "none",
           marginBottom: 2,
-        }}
-      />
+        })}
+      >
+        <Snippet
+          source={`${props.children}`}
+          language={props.className?.replace("language-", "") ?? ""}
+        />
+      </Box>
     );
   },
 };


### PR DESCRIPTION
This PR fixes an odd syntax highlighting behaviour which @benwerner01 and I spotted recently. I am not pretending that my fix is perfect, but it gives us what we want for the launch.

Example deployment with odd behaviour: https://vercel.com/hashintel/blockprotocol/Cgm2FdX2xrPAqdHmppVoQqbrHR2q

Syntax highlighting e.g. on `/spec/block-types` works during SSR but fails if the page is client-side rendered.

More recent deployment (e.g. https://vercel.com/hashintel/blockprotocol/Gdfg84vv6NC4heqRKemhwFDxdiV8) lost syntax highlighting in mdx completely, which seems to be related to https://github.com/blockprotocol/blockprotocol/pull/31.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201541645622654