### PR TITLE
[SITE] Open external links in new window / fixes

### DIFF
--- a/site/src/components/FooterBanner.tsx
+++ b/site/src/components/FooterBanner.tsx
@@ -63,17 +63,15 @@ const BannerCard: FC<BannerCardProps> = ({
   >
     <Box mb={2}>{contents}</Box>
     <Link href={buttonHref}>
-      <a>
-        <Button
-          sx={{
-            textTransform: "none",
-          }}
-          variant="primary"
-          startIcon={<BoltIcon />}
-        >
-          {buttonText}
-        </Button>
-      </a>
+      <Button
+        sx={{
+          textTransform: "none",
+        }}
+        variant="primary"
+        startIcon={<BoltIcon />}
+      >
+        {buttonText}
+      </Button>
     </Link>
   </Paper>
 );

--- a/site/src/components/Link.tsx
+++ b/site/src/components/Link.tsx
@@ -69,9 +69,12 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
 
     const isExternal =
       typeof href === "string" &&
-      (href.indexOf("http") === 0 || href.indexOf("mailto:") === 0);
+      !/^(mailto:|#|\/|https:\/\/blockprotocol\.org)/.test(href);
 
     if (isExternal) {
+      other.rel = "noopener";
+      other.target = "_blank";
+
       if (noLinkStyle) {
         return (
           <Anchor

--- a/site/src/components/Navbar.tsx
+++ b/site/src/components/Navbar.tsx
@@ -155,7 +155,7 @@ const MobileBreadcrumbs: VFC<MobileBreadcrumbsProps> = ({ crumbs }) => {
             {item.title}
           </Link>
         ) : (
-          <Typography variant="bpSmallCopy" color="inherit">
+          <Typography key={item.title} variant="bpSmallCopy" color="inherit">
             {item.title}
           </Typography>
         ),

--- a/site/src/util/mdxComponents.tsx
+++ b/site/src/util/mdxComponents.tsx
@@ -90,8 +90,7 @@ export const mdxComponents: Record<string, React.ReactNode> = {
     <Typography mb={2} variant="bpBodyCopy" {...props} />
   ),
   a: (props: HTMLProps<HTMLAnchorElement>) => {
-    const { href, ref, ...rest } = props;
-    void ref;
+    const { href, ref: _ref, ...rest } = props;
     return href ? (
       <Link {...rest} href={href} />
     ) : (


### PR DESCRIPTION
Opens external links in a new window and adds `noopener` to them. 

An external in link is one that doesn't start with `/`, `#`, `mailto:` or `https://blockprotocol.org`

Misc fixes:
- add a missing key to array items
- remove extra / redundant `<a>`