### PR TITLE
[SITE] Add fallback image for block cards

### DIFF
--- a/site/src/components/BlockCard.tsx
+++ b/site/src/components/BlockCard.tsx
@@ -4,6 +4,7 @@ import { formatDistance, subDays } from "date-fns";
 import { Link } from "./Link";
 import { Spacer } from "./Spacer";
 import { BlockMetadata } from "../pages/api/blocks.api";
+import { BlockProtocolLogoIcon } from "./SvgIcon/BlockProtocolLogoIcon";
 
 type BlockCardProps = {
   loading?: boolean;
@@ -118,16 +119,16 @@ export const BlockCard: VFC<BlockCardProps> = ({ loading, data }) => {
               position: "relative",
             }}
           >
-            {image && (
-              <Box
-                sx={{
-                  position: "absolute",
-                  top: 0,
-                  left: 0,
-                  right: 0,
-                  bottom: 0,
-                }}
-              >
+            <Box
+              sx={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+              }}
+            >
+              {image ? (
                 <Box
                   component="img"
                   sx={{
@@ -138,8 +139,21 @@ export const BlockCard: VFC<BlockCardProps> = ({ loading, data }) => {
                   }}
                   src={image}
                 />
-              </Box>
-            )}
+              ) : (
+                <Box
+                  display="flex"
+                  height="100%"
+                  alignItems="center"
+                  justifyContent="center"
+                >
+                  <BlockProtocolLogoIcon
+                    sx={{
+                      color: ({ palette }) => palette.gray[50],
+                    }}
+                  />
+                </Box>
+              )}
+            </Box>
           </Box>
         </Box>
         <Box

--- a/site/src/pages/api/blocks.api.ts
+++ b/site/src/pages/api/blocks.api.ts
@@ -18,14 +18,14 @@ export type BlockMetadata = {
   displayName?: string;
   externals?: Record<string, string>;
   icon?: string;
+  image?: string;
+  lastUpdated?: string;
   license?: string;
   name?: string;
   schema?: string;
   source?: string;
   variants?: BlockVariant[];
   version?: string;
-  lastUpdated?: string;
-  image?: string;
 
   // @todo should be redundant to block's package.json#name
   packagePath: string;


### PR DESCRIPTION
Where blocks do not have an `image` field in their metadata, show the Block Protocol logo as a fallback.

<img width="1255" alt="Screenshot 2021-12-23 at 10 07 37" src="https://user-images.githubusercontent.com/37743469/147225448-26f25db5-837f-4e9a-8d22-929cc6e945ac.png">

