### PR TITLE
[SITE] when parsing mdx files make BP site links relative

### DIFF
--- a/site/src/util/mdxComponents.tsx
+++ b/site/src/util/mdxComponents.tsx
@@ -93,7 +93,7 @@ export const mdxComponents: Record<string, React.ReactNode> = {
   a: (props: HTMLProps<HTMLAnchorElement>) => {
     const { href, ref: _ref, ...rest } = props;
     return href ? (
-      <Link {...rest} href={href} />
+      <Link {...rest} href={href.replace("https://blockprotocol.org", "")} />
     ) : (
       // eslint-disable-next-line jsx-a11y/anchor-has-content -- special case for creating bookmarks (for cross-linking)
       <a id={props.id} />


### PR DESCRIPTION
This ensures BP site links on the `/docs` and `/spec` pages are relative, even if they are defined as absolute urls in the markdown.