### PR TITLE
[SITE] Add contact options. Tweak homepage copy and HTML title

### DIFF
--- a/site/src/components/pages/home/Header.tsx
+++ b/site/src/components/pages/home/Header.tsx
@@ -38,13 +38,17 @@ export const Header = () => {
               textTransform: "uppercase",
               color: ({ palette }) => palette.purple[400],
               mb: 4,
+              fontWeight: 500,
               letterSpacing: "5%",
               width: { lg: "100%" },
               mx: "auto",
             }}
             variant="bpSmallCaps"
           >
-            A powerful {isMobile && <br />} new protocol for developers
+            A powerful{" "}
+            <span style={{ display: "inline-block" }}>
+              new protocol for developers
+            </span>
           </Typography>
           <Typography
             variant="bpHeading1"
@@ -56,7 +60,7 @@ export const Header = () => {
               fontSize: { xs: 40, lg: 60 },
             }}
           >
-            Build interactive blocks connected to the world of{" "}
+            Build and use interactive blocks connected to the world of{" "}
             <Box
               sx={{
                 position: "relative",
@@ -84,10 +88,9 @@ export const Header = () => {
             width={{ xs: "100%", lg: "74%" }}
             textAlign={{ xs: "center", lg: "left" }}
           >
-            An open standard for building
-            <strong> blocks connected to structured data </strong>
-            with <strong>schemas</strong>. Make your applications both human and
-            machine-readable.
+            An open standard for building and using
+            <strong> data-driven blocks</strong>. Make your applications both
+            human and machine-readable.
           </Typography>
           <Button startIcon={<BoltIcon />}>Read the Quickstart Guide</Button>
         </Box>

--- a/site/src/pages/_app.page.tsx
+++ b/site/src/pages/_app.page.tsx
@@ -45,7 +45,7 @@ const MyApp = ({
           <PageLayout>
             <Head>
               <title>
-                Block Protocol - an open standard for an open standard for
+                Block Protocol - an open standard for
                 data-driven blocks
               </title>
             </Head>

--- a/site/src/pages/_app.page.tsx
+++ b/site/src/pages/_app.page.tsx
@@ -44,7 +44,10 @@ const MyApp = ({
           <CssBaseline />
           <PageLayout>
             <Head>
-              <title>Blockprotocol</title>
+              <title>
+                Block Protocol - an open standard for building blocks connected
+                to structured data
+              </title>
             </Head>
             <Component {...pageProps} />
           </PageLayout>

--- a/site/src/pages/_app.page.tsx
+++ b/site/src/pages/_app.page.tsx
@@ -45,8 +45,8 @@ const MyApp = ({
           <PageLayout>
             <Head>
               <title>
-                Block Protocol - an open standard for building blocks connected
-                to structured data
+                Block Protocol - an open standard for an open standard for
+                data-driven blocks
               </title>
             </Head>
             <Component {...pageProps} />

--- a/site/src/pages/contact.page.tsx
+++ b/site/src/pages/contact.page.tsx
@@ -44,7 +44,7 @@ const Partners: NextPage = () => {
           >
             You can also{" "}
             <Link href="mailto:help@blockprotocol.org">email us</Link> or{" "}
-            <Link href="https://hash.ai/discord">chat to us on Discord</Link>.
+            <Link href="https://discord.gg/PefPteFe5j">chat to us on Discord</Link>.
           </Typography>
         </Box>
         <form

--- a/site/src/pages/contact.page.tsx
+++ b/site/src/pages/contact.page.tsx
@@ -3,6 +3,7 @@
 import { Container, Typography, Box } from "@mui/material";
 import { NextPage } from "next";
 import { tw } from "twind";
+import { Link } from "../components/Link";
 
 const labelSubtitleStyles = "text-gray-500 font-light block md:inline";
 
@@ -29,11 +30,21 @@ const Partners: NextPage = () => {
             textAlign="center"
             maxWidth={750}
             variant="bpSubtitle"
-            sx={{ fontSize: 20 }}
+            sx={{ fontSize: 20, marginBottom: 2 }}
           >
             If you’re working on an existing or upcoming block editor, or would
             otherwise like to contribute to the new standard, fill in some
             details below and we’ll be in touch.
+          </Typography>
+          <Typography
+            textAlign="center"
+            maxWidth={750}
+            variant="bpSubtitle"
+            sx={{ fontSize: 20, marginBottom: 2 }}
+          >
+            You can also{" "}
+            <Link href="mailto:help@blockprotocol.org">email us</Link> or{" "}
+            <Link href="https://hash.ai/discord">chat to us on Discord</Link>.
           </Typography>
         </Box>
         <form
@@ -79,17 +90,16 @@ const Partners: NextPage = () => {
 
           <div className={tw`mt-8`}>
             <label htmlFor="PROJECT" className={tw`font-semibold uppercase `}>
-              Project Name <span className={tw`text-blue-600 mr-2`}>*</span>
+              Project Name
             </label>
             <span className={tw`${labelSubtitleStyles}`}>
-              The name of the block editor (or related application) you’re
-              working on
+              The name of the block editor you’re working on or block you'd like
+              to write
             </span>
 
             <input
               id="PROJECT"
               name="PROJECT"
-              required
               type="text"
               className={tw`block border-1 border-gray-300 rounded mt-4 px-5 py-2`}
             />
@@ -142,8 +152,8 @@ const Partners: NextPage = () => {
               Comments
             </label>
             <span className={tw`${labelSubtitleStyles}`}>
-              Let us know what interests you about the standard, or where you
-              think you might be helpful
+              Let us know what interests you about the Block Protocol, what
+              you'd like from us, or where you think you might be helpful
             </span>
 
             <textarea

--- a/site/src/pages/contact.page.tsx
+++ b/site/src/pages/contact.page.tsx
@@ -94,7 +94,7 @@ const Partners: NextPage = () => {
             </label>
             <span className={tw`${labelSubtitleStyles}`}>
               The name of the block editor you’re working on or block you'd like
-              to write
+              to write (if applicable)
             </span>
 
             <input


### PR DESCRIPTION
- Update copy in page title and homepage headers

![Screenshot 2021-12-23 at 13 45 54](https://user-images.githubusercontent.com/37743469/147250363-340a7f08-ddd8-46d1-90b2-c1b7e4444271.png)

- Add email and Discord link to the /contact page

![Screenshot 2021-12-23 at 13 36 23](https://user-images.githubusercontent.com/37743469/147250376-0846ac84-da5a-499d-972c-d5d8cbeaa30d.png)

