### PR TITLE
Fix HTTP 500 for non-existing blocks

### DIFF
--- a/site/src/components/BlockCard.tsx
+++ b/site/src/components/BlockCard.tsx
@@ -79,7 +79,7 @@ export const BlockCard: VFC<BlockCardProps> = ({ loading, data }) => {
   } = data;
 
   return (
-    <Link href={`${packagePath}`}>
+    <Link href={`/${packagePath}`}>
       <Box
         sx={{
           ...blockWidthStyles,


### PR DESCRIPTION
**Before**  
https://blockprotocol-f6y3xupq0-hashintel.vercel.app/@hello/world

**After**  
https://blockprotocol-bcjr91k7x-hashintel.vercel.app/@hello/world

I noticed this bug when working on #60. Opening https://blockprotocol.org/assets/bp_twitter_cover.png before merging returned 500.