### PR TITLE
Fix broken links in spec

### DIFF
--- a/site/src/_pages/spec/0_index.mdx
+++ b/site/src/_pages/spec/0_index.mdx
@@ -63,13 +63,13 @@ In the context of the protocol, schemas are used both to describe the data a blo
 Field types may be scalar (integer, string etc.), complex objects, collections (lists/arrays), or refer to another schema.
 
 **Block type:** a definition and implementation – i.e. code – for a discrete component on a web page, which provides functionality for structured data (rendering it, editing it).
-A block type specifies the data it accepts via a schema in accordance with [the spec](/spec/embedding-application-implementation).
+A block type specifies the data it accepts via a schema in accordance with [the spec](https://blockprotocol.org/spec/embedding-application-implementation).
 
 **Block:** an instance of a block type inserted into a web page and supplied with data by an embedding application.
 
 **Block package:** a collection of files making a block type available for use by embedding applications, including its source code and accompanying metadata.
 
-**Embedding application:** an application which can take a block type and insert it in a web page, supplying the block with the structured data and dependencies it needs in accordance with the [specification](/spec/embedding-application-implementation).
+**Embedding application:** an application which can take a block type and insert it in a web page, supplying the block with the structured data and dependencies it needs in accordance with the [specification](https://blockprotocol.org/spec/embedding-application-implementation).
 
 When capitalized, the words ‘MUST’, ‘MUST NOT’, ‘SHOULD’, ‘SHOULD NOT’, and ’MAY’ in this document are to be interpreted as described in IETF [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 

--- a/site/src/_pages/spec/1_block-types.mdx
+++ b/site/src/_pages/spec/1_block-types.mdx
@@ -523,6 +523,6 @@ This could be
 
 Blocks SHOULD provide at least basic visual styling to allow them to be embedded and used without modification by any web application.
 
-Blocks SHOULD use the CSS variables listed in [Appendix A](/spec/appendix-a-block-protocol-css-variables) as property values where appropriate, but SHOULD provide [fallback values](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties#custom_property_fallback_values) in case the embedding application does not define them.
+Blocks SHOULD use the CSS variables listed in [Appendix A](/spec/appendix-a-styling) as property values where appropriate, but SHOULD provide [fallback values](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties#custom_property_fallback_values) in case the embedding application does not define them.
 
-Ideally, the embedding application will also provide a `styleVariables` object alongside block data, which includes keys with the same names as the CSS variables listed in [Appendix A](/spec/appendix-a-block-protocol-css-variables) and appropriate values.
+Ideally, the embedding application will also provide a `styleVariables` object alongside block data, which includes keys with the same names as the CSS variables listed in [Appendix A](/spec/appendix-a-styling) and appropriate values.

--- a/site/src/_pages/spec/1_block-types.mdx
+++ b/site/src/_pages/spec/1_block-types.mdx
@@ -8,7 +8,7 @@ A block package MUST contain:
 - **source file or files** (e.g. HTML and JavaScript files), which
 
   - SHOULD contain valid HTML
-  - There are [various tools](/spec/implementation-and-rendering-context) to help in meeting these requirements.
+  - There are [various tools](https://blockprotocol.org/spec/implementation-and-rendering-context) to help in meeting these requirements.
 
 A block package SHOULD contain:
 
@@ -51,7 +51,7 @@ A block package SHOULD contain:
 ### Data provided to blocks
 
 Blocks MUST use the data properties specified in their schema, if any.
-They can expect these properties to be made available to them by the embedding application, exactly how depending on [rendering context](/spec/implementation-and-rendering-context).
+They can expect these properties to be made available to them by the embedding application, exactly how depending on [rendering context](https://blockprotocol.org/spec/implementation-and-rendering-context).
 For example, for a React component block they would be passed as ‘props’.
 In a block with an HTML entrypoint, appropriately sandboxed by the embedding application, the properties would be in the global scope (of the sandbox).
 
@@ -191,7 +191,7 @@ retrieve a subset of entities of a given type
     - `desc?` \[_boolean_]\[_optional_]: whether to sort descending.
 - Embedding apps will provide a default aggregation if not provided.
 
-The functions defined above return entity data, but block authors should note that in many [implementations](/spec/embedding-application-implementation) the embedding application will re-render a block with new entity data whenever it is updated (whether by the block or some other actor), e.g. the block will automatically get sent new data via props when any entity it has previously received via props is updated.
+The functions defined above return entity data, but block authors should note that in many [implementations](https://blockprotocol.org/spec/embedding-application-implementation) the embedding application will re-render a block with new entity data whenever it is updated (whether by the block or some other actor), e.g. the block will automatically get sent new data via props when any entity it has previously received via props is updated.
 
 ### Functions for working with entity types
 
@@ -523,6 +523,6 @@ This could be
 
 Blocks SHOULD provide at least basic visual styling to allow them to be embedded and used without modification by any web application.
 
-Blocks SHOULD use the CSS variables listed in [Appendix A](/spec/appendix-a-styling) as property values where appropriate, but SHOULD provide [fallback values](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties#custom_property_fallback_values) in case the embedding application does not define them.
+Blocks SHOULD use the CSS variables listed in [Appendix A](https://blockprotocol.org/spec/appendix-a-styling) as property values where appropriate, but SHOULD provide [fallback values](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties#custom_property_fallback_values) in case the embedding application does not define them.
 
-Ideally, the embedding application will also provide a `styleVariables` object alongside block data, which includes keys with the same names as the CSS variables listed in [Appendix A](/spec/appendix-a-styling) and appropriate values.
+Ideally, the embedding application will also provide a `styleVariables` object alongside block data, which includes keys with the same names as the CSS variables listed in [Appendix A](https://blockprotocol.org/spec/appendix-a-styling) and appropriate values.

--- a/site/src/_pages/spec/2_embedding-application-implementation.mdx
+++ b/site/src/_pages/spec/2_embedding-application-implementation.mdx
@@ -28,7 +28,7 @@ An embedding application SHOULD be able to read a JSON schema file provided by a
 
 ## Styling
 
-Embedding applications SHOULD define, in the global scope, any of the CSS variables listed in [Appendix A](/spec/appendix-a-block-protocol-css-variables) which they have a preferred value for, and additionally provide these values via a `styleVariables` object passed to the block alongside other data.
+Embedding applications SHOULD define, in the global scope, any of the CSS variables listed in [Appendix A](/spec/appendix-a-styling) which they have a preferred value for, and additionally provide these values via a `styleVariables` object passed to the block alongside other data.
 
 ## Security
 

--- a/site/src/_pages/spec/2_embedding-application-implementation.mdx
+++ b/site/src/_pages/spec/2_embedding-application-implementation.mdx
@@ -15,7 +15,7 @@ In order to be portable anywhere, blocks should not need to have any knowledge o
 To render a block which defines a schema for the data it accepts, embedding applications MUST supply it with any data properties marked as required, SHOULD respect any other constraints expressed in the schema, and MAY supply any further properties expressed in the schema.
 
 Embedding applications SHOULD supply blocks with functions to get, aggregate, create, delete and update entities, entity types, and links between entities (subject to any permissions restrictions).
-These functions MUST conform to the naming conventions and function signatures outlined in [the previous section](/spec/embedding-application-implementation).
+These functions MUST conform to the naming conventions and function signatures outlined in [the previous section](https://blockprotocol.org/spec/embedding-application-implementation).
 Embedding applications SHOULD provide defaults for aggregation operations to handle cases where the block doesn’t specify its own requirements.
 
 To enable blocks to update data of entities, including themselves, embedding applications SHOULD include an `entityId` and `entityTypeId` alongside the data for each entity it supplies the block with (including the `entityId` and `entityTypeId` of the block itself).
@@ -28,7 +28,7 @@ An embedding application SHOULD be able to read a JSON schema file provided by a
 
 ## Styling
 
-Embedding applications SHOULD define, in the global scope, any of the CSS variables listed in [Appendix A](/spec/appendix-a-styling) which they have a preferred value for, and additionally provide these values via a `styleVariables` object passed to the block alongside other data.
+Embedding applications SHOULD define, in the global scope, any of the CSS variables listed in [Appendix A](https://blockprotocol.org/spec/appendix-a-styling) which they have a preferred value for, and additionally provide these values via a `styleVariables` object passed to the block alongside other data.
 
 ## Security
 


### PR DESCRIPTION
In preparation for launch we updated the slug of Appendix A and this PR corrects old broken links which were resulting in 404s.