### PR TITLE
[SITE] stop truncating sidebar navigation items, make sidebar scrollable

### DIFF
--- a/site/src/components/PageSidebar.tsx
+++ b/site/src/components/PageSidebar.tsx
@@ -21,9 +21,7 @@ import { Link } from "./Link";
 
 const SidebarLink = styled(Link)(({ theme }) => ({
   display: "block",
-  whiteSpace: "nowrap",
-  overflow: "hidden",
-  textOverflow: "ellipsis",
+  lineHeight: "1.25em",
   transition: theme.transitions.create(["color"]),
   color: theme.palette.gray[70],
   ":hover": {
@@ -73,7 +71,7 @@ const SidebarPageSection: VFC<SidebarPageSectionProps> = ({
 
   return (
     <>
-      <Box mb={1} display="flex" alignItems="center">
+      <Box mb={1.5} display="flex" alignItems="flex-start">
         <SidebarLink
           ref={(ref) => {
             if (ref && isSectionSelected) {
@@ -106,6 +104,7 @@ const SidebarPageSection: VFC<SidebarPageSectionProps> = ({
             sx={(theme) => ({
               padding: 0,
               marginLeft: 1,
+              marginTop: 0.5,
               transition: theme.transitions.create("transform"),
               transform: `rotate(${isSectionOpen ? "90deg" : "0deg"})`,
               "& svg": {
@@ -173,7 +172,7 @@ const SidebarPage: VFC<SidebarPageProps> = ({
 
   return (
     <Fragment key={href}>
-      <Box mb={1} display="flex" alignItems="center">
+      <Box mb={1.5} display="flex" alignItems="flex-start">
         <SidebarLink
           ref={(ref) => {
             if (ref && isSelected) {
@@ -212,6 +211,7 @@ const SidebarPage: VFC<SidebarPageProps> = ({
             sx={(theme) => ({
               padding: 0,
               marginLeft: 1,
+              marginTop: 0.5,
               transition: theme.transitions.create("transform"),
               transform: `rotate(${isOpen ? "90deg" : "0deg"})`,
               "& svg": {

--- a/site/src/components/PageSidebar.tsx
+++ b/site/src/components/PageSidebar.tsx
@@ -1,23 +1,28 @@
 import {
+  Dispatch,
+  Fragment,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  VFC,
+} from "react";
+import { useRouter } from "next/router";
+import {
   Collapse,
   Box,
   Icon,
   IconButton,
   Divider,
   styled,
+  BoxProps,
+  useTheme,
 } from "@mui/material";
-import { useRouter } from "next/router";
-import {
-  Dispatch,
-  Fragment,
-  SetStateAction,
-  useCallback,
-  useEffect,
-  useState,
-  VFC,
-} from "react";
 import { SiteMapPage, SiteMapPageSection } from "../lib/sitemap";
 import { Link } from "./Link";
+import { DESKTOP_NAVBAR_HEIGHT } from "./Navbar";
+import { parseIntFromPixelString } from "../util/muiUtils";
 
 const SidebarLink = styled(Link)(({ theme }) => ({
   display: "block",
@@ -257,7 +262,7 @@ const SidebarPage: VFC<SidebarPageProps> = ({
 type SidebarProps = {
   pages: SiteMapPage[];
   appendices?: SiteMapPage[];
-};
+} & BoxProps;
 
 const getInitialOpenedPages = (params: {
   pages: SiteMapPage[];
@@ -294,8 +299,34 @@ const getInitialOpenedPages = (params: {
   return [];
 };
 
-export const Sidebar: VFC<SidebarProps> = ({ appendices, pages }) => {
+export const Sidebar: VFC<SidebarProps> = ({
+  appendices,
+  pages,
+  ...boxProps
+}) => {
+  const theme = useTheme();
   const { asPath } = useRouter();
+
+  const stickinessDetectorRef = useRef<HTMLDivElement>(null);
+  const [isSticky, setIsSticky] = useState<boolean>(false);
+
+  // Approach inspired by: https://stackoverflow.com/questions/16302483/event-to-detect-when-positionsticky-is-triggered
+  useEffect(() => {
+    const cachedRef = stickinessDetectorRef.current;
+
+    if (cachedRef) {
+      const observer = new IntersectionObserver(
+        ([event]) => setIsSticky(event.intersectionRatio < 1),
+        { threshold: [1] },
+      );
+
+      observer.observe(cachedRef);
+
+      return () => {
+        observer.unobserve(cachedRef);
+      };
+    }
+  }, []);
 
   const [selectedAnchorElement, setSelectedAnchorElement] =
     useState<HTMLAnchorElement>();
@@ -327,60 +358,99 @@ export const Sidebar: VFC<SidebarProps> = ({ appendices, pages }) => {
   }, [asPath, pages]);
 
   return (
-    <Box position="relative">
+    <Box
+      {...boxProps}
+      position="sticky"
+      marginRight={6}
+      width={220}
+      sx={{
+        ...boxProps.sx,
+        top: 0,
+      }}
+    >
       <Box
-        sx={(theme) => ({
+        ref={stickinessDetectorRef}
+        sx={{
           position: "absolute",
-          width: 3,
-          height: 14,
-          backgroundColor: ({ palette }) => palette.purple[600],
-          top: selectedOffsetTop === undefined ? 0 : selectedOffsetTop + 4,
-          opacity: selectedOffsetTop === undefined ? 0 : 1,
-          transition: theme.transitions.create(["top", "opacity"], {
-            duration: 150,
-          }),
-        })}
+          top: "-1px",
+          height: "1px",
+          width: "1px",
+        }}
       />
-      {pages.length > 1
-        ? pages.map((page) => (
-            <SidebarPage
-              key={page.href}
-              page={page}
-              maybeUpdateSelectedOffsetTop={maybeUpdateSelectedOffsetTop}
-              setSelectedAnchorElement={setSelectedAnchorElement}
-              openedPages={openedPages}
-              setOpenedPages={setOpenedPages}
-            />
-          ))
-        : pages.length === 1
-        ? pages[0].sections.map((section, i) => (
-            <SidebarPageSection
-              isSelectedByDefault={i === 0}
-              key={section.anchor}
-              pageHref={pages[0].href}
-              section={section}
-              maybeUpdateSelectedOffsetTop={maybeUpdateSelectedOffsetTop}
-              setSelectedAnchorElement={setSelectedAnchorElement}
-              openedPages={openedPages}
-              setOpenedPages={setOpenedPages}
-            />
-          ))
-        : null}
-      {appendices && appendices.length > 0 ? (
-        <>
-          <Divider sx={{ marginBottom: 2 }} />
-          {appendices.map((page) => (
-            <SidebarPage
-              key={page.href}
-              page={page}
-              maybeUpdateSelectedOffsetTop={maybeUpdateSelectedOffsetTop}
-              setSelectedAnchorElement={setSelectedAnchorElement}
-              openedPages={openedPages}
-              setOpenedPages={setOpenedPages}
-            />
-          ))}
-        </>
-      ) : null}
+      <Box
+        paddingRight={3}
+        sx={{
+          maxHeight: isSticky ? "100vh" : undefined,
+          overflow: isSticky ? "scroll" : undefined,
+          paddingTop: isSticky
+            ? `${
+                DESKTOP_NAVBAR_HEIGHT +
+                parseIntFromPixelString(theme.spacing(1))
+              }px`
+            : 0,
+          paddingBottom: isSticky ? theme.spacing(6) : 0,
+          transition: theme.transitions.create([
+            "padding-top",
+            "padding-bottom",
+          ]),
+        }}
+      >
+        <Box position="relative">
+          <Box
+            sx={{
+              position: "absolute",
+              width: 3,
+              height: 14,
+              backgroundColor: ({ palette }) => palette.purple[600],
+              top: selectedOffsetTop === undefined ? 0 : selectedOffsetTop + 3,
+              opacity: selectedOffsetTop === undefined ? 0 : 1,
+              transition: theme.transitions.create(["top", "opacity"], {
+                duration: 150,
+              }),
+            }}
+          />
+          {pages.length > 1
+            ? pages.map((page) => (
+                <SidebarPage
+                  key={page.href}
+                  page={page}
+                  maybeUpdateSelectedOffsetTop={maybeUpdateSelectedOffsetTop}
+                  setSelectedAnchorElement={setSelectedAnchorElement}
+                  openedPages={openedPages}
+                  setOpenedPages={setOpenedPages}
+                />
+              ))
+            : pages.length === 1
+            ? pages[0].sections.map((section, i) => (
+                <SidebarPageSection
+                  isSelectedByDefault={i === 0}
+                  key={section.anchor}
+                  pageHref={pages[0].href}
+                  section={section}
+                  maybeUpdateSelectedOffsetTop={maybeUpdateSelectedOffsetTop}
+                  setSelectedAnchorElement={setSelectedAnchorElement}
+                  openedPages={openedPages}
+                  setOpenedPages={setOpenedPages}
+                />
+              ))
+            : null}
+          {appendices && appendices.length > 0 ? (
+            <>
+              <Divider sx={{ marginBottom: 2 }} />
+              {appendices.map((page) => (
+                <SidebarPage
+                  key={page.href}
+                  page={page}
+                  maybeUpdateSelectedOffsetTop={maybeUpdateSelectedOffsetTop}
+                  setSelectedAnchorElement={setSelectedAnchorElement}
+                  openedPages={openedPages}
+                  setOpenedPages={setOpenedPages}
+                />
+              ))}
+            </>
+          ) : null}
+        </Box>
+      </Box>
     </Box>
   );
 };

--- a/site/src/components/PageSidebar.tsx
+++ b/site/src/components/PageSidebar.tsx
@@ -24,6 +24,8 @@ import { Link } from "./Link";
 import { DESKTOP_NAVBAR_HEIGHT } from "./Navbar";
 import { parseIntFromPixelString } from "../util/muiUtils";
 
+export const SIDEBAR_WIDTH = 220;
+
 const SidebarLink = styled(Link)(({ theme }) => ({
   display: "block",
   lineHeight: "1.25em",
@@ -361,8 +363,8 @@ export const Sidebar: VFC<SidebarProps> = ({
     <Box
       {...boxProps}
       position="sticky"
-      marginRight={6}
-      width={220}
+      flexShrink={0}
+      width={SIDEBAR_WIDTH}
       sx={{
         ...boxProps.sx,
         top: 0,

--- a/site/src/pages/docs/[[...docsSlug]].page.tsx
+++ b/site/src/pages/docs/[[...docsSlug]].page.tsx
@@ -11,9 +11,7 @@ import {
 import { GetStaticPaths, GetStaticProps, NextPage } from "next";
 import Head from "next/head";
 import { MDXRemote, MDXRemoteSerializeResult } from "next-mdx-remote";
-import { DESKTOP_NAVBAR_HEIGHT } from "../../components/Navbar";
 import siteMap from "../../../site-map.json";
-import { parseIntFromPixelString } from "../../util/muiUtils";
 import { SiteMap, SiteMapPage } from "../../lib/sitemap";
 import { getSerializedPage } from "../../util/mdxUtils";
 import { mdxComponents } from "../../util/mdxComponents";
@@ -168,22 +166,8 @@ const DocsPage: NextPage<DocsPageProps> = ({
             {DOCS_PAGE_SUBTITLES[title]}
           </Typography>
         ) : null}
-        <Box py={4} display="flex" alignItems="flex-start" marginBottom={8}>
-          {md ? (
-            <Box
-              marginRight={9}
-              width={220}
-              flexGrow={0}
-              sx={{
-                position: "sticky",
-                top:
-                  DESKTOP_NAVBAR_HEIGHT +
-                  parseIntFromPixelString(theme.spacing(1)),
-              }}
-            >
-              <Sidebar pages={[tabPage]} />
-            </Box>
-          ) : null}
+        <Box py={4} display="flex" alignItems="flex-start">
+          {md ? <Sidebar flexGrow={0} pages={[tabPage]} /> : null}
           <Box flexGrow={1}>
             <MDXRemote
               {...tabPageSerializedContent}

--- a/site/src/pages/docs/[[...docsSlug]].page.tsx
+++ b/site/src/pages/docs/[[...docsSlug]].page.tsx
@@ -167,7 +167,9 @@ const DocsPage: NextPage<DocsPageProps> = ({
           </Typography>
         ) : null}
         <Box py={4} display="flex" alignItems="flex-start">
-          {md ? <Sidebar flexGrow={0} pages={[tabPage]} /> : null}
+          {md ? (
+            <Sidebar flexGrow={0} marginRight={6} pages={[tabPage]} />
+          ) : null}
           <Box flexGrow={1}>
             <MDXRemote
               {...tabPageSerializedContent}

--- a/site/src/pages/spec/[[...specSlug]].page.tsx
+++ b/site/src/pages/spec/[[...specSlug]].page.tsx
@@ -14,10 +14,8 @@ import { useRouter } from "next/router";
 import { MDXRemoteSerializeResult } from "next-mdx-remote";
 import { Button } from "../../components/Button";
 import { Link } from "../../components/Link";
-import { DESKTOP_NAVBAR_HEIGHT } from "../../components/Navbar";
 import { Sidebar } from "../../components/PageSidebar";
 import { getAllPageHrefs, getSerializedPage } from "../../util/mdxUtils";
-import { parseIntFromPixelString } from "../../util/muiUtils";
 import SiteMapContext from "../../components/context/SiteMapContext";
 import {
   MDXPageContent,
@@ -237,26 +235,15 @@ const SpecPage: NextPage<SpecPageProps> = ({ serializedPage }) => {
         {GitHubInfoCard}
         <Box mb={4} py={4} display="flex" alignItems="flex-start">
           {md ? (
-            <Box
-              marginRight={9}
-              width={220}
+            <Sidebar
               flexGrow={0}
-              sx={{
-                position: "sticky",
-                top:
-                  DESKTOP_NAVBAR_HEIGHT +
-                  parseIntFromPixelString(theme.spacing(1)),
-              }}
-            >
-              <Sidebar
-                pages={specificationPages.filter(
-                  ({ title }) => !title.startsWith("Appendix"),
-                )}
-                appendices={specificationPages.filter(({ title }) =>
-                  title.startsWith("Appendix"),
-                )}
-              />
-            </Box>
+              pages={specificationPages.filter(
+                ({ title }) => !title.startsWith("Appendix"),
+              )}
+              appendices={specificationPages.filter(({ title }) =>
+                title.startsWith("Appendix"),
+              )}
+            />
           ) : null}
           <MDXPageContent flexGrow={1} serializedPage={serializedPage} />
         </Box>

--- a/site/src/pages/spec/[[...specSlug]].page.tsx
+++ b/site/src/pages/spec/[[...specSlug]].page.tsx
@@ -14,7 +14,7 @@ import { useRouter } from "next/router";
 import { MDXRemoteSerializeResult } from "next-mdx-remote";
 import { Button } from "../../components/Button";
 import { Link } from "../../components/Link";
-import { Sidebar } from "../../components/PageSidebar";
+import { Sidebar, SIDEBAR_WIDTH } from "../../components/PageSidebar";
 import { getAllPageHrefs, getSerializedPage } from "../../util/mdxUtils";
 import SiteMapContext from "../../components/context/SiteMapContext";
 import {
@@ -22,6 +22,7 @@ import {
   MDX_TEXT_CONTENT_MAX_WIDTH,
 } from "../../components/MDXPageContent";
 import { PageNavLinks } from "../../components/PageNavLinks";
+import { parseIntFromPixelString } from "../../util/muiUtils";
 
 const GitHubInfoCard = (
   <Paper
@@ -237,6 +238,7 @@ const SpecPage: NextPage<SpecPageProps> = ({ serializedPage }) => {
           {md ? (
             <Sidebar
               flexGrow={0}
+              marginRight={6}
               pages={specificationPages.filter(
                 ({ title }) => !title.startsWith("Appendix"),
               )}
@@ -253,7 +255,9 @@ const SpecPage: NextPage<SpecPageProps> = ({ serializedPage }) => {
           sx={{
             marginLeft: {
               xs: 0,
-              md: "290px",
+              md: `${
+                SIDEBAR_WIDTH + parseIntFromPixelString(theme.spacing(6))
+              }px`,
             },
             maxWidth: {
               sx: "100%",


### PR DESCRIPTION
This PR stops truncating the link text in the `PageSidebar` on the specification/documentation pages:
![image](https://user-images.githubusercontent.com/42802102/147683072-f37615a5-35e9-4ca8-8b35-2cdf2b967ca8.png)

In addition this PR makes the `PageSidebar` scrollable when its expanded contents exceed the height of the viewport, and it is in the "sticky" state.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201588774378622