### PR TITLE
Fix minor typos in spec

### DIFF
--- a/site/src/_pages/spec/4_appendix-a-styling.mdx
+++ b/site/src/_pages/spec/4_appendix-a-styling.mdx
@@ -2,8 +2,8 @@
 
 <Frame emoji="🚧">
 
-This section is still in progress.
-Advanced comments are welcome.
+This section is still being written.
+Advance comments are welcome.
 
 </Frame>
 

--- a/site/src/_pages/spec/5_appendix-b-accessibility.mdx
+++ b/site/src/_pages/spec/5_appendix-b-accessibility.mdx
@@ -3,6 +3,6 @@
 <Frame emoji="🔜">
 
 This accessibility (a11y) section will be added soon.
-Advanced comments are welcome.
+Advance comments are welcome.
 
 </Frame>

--- a/site/src/_pages/spec/6_appendix-c-internationalization.mdx
+++ b/site/src/_pages/spec/6_appendix-c-internationalization.mdx
@@ -3,6 +3,6 @@
 <Frame emoji="🔜">
 
 This internationalization (i18n) section will be added soon.
-Advanced comments are welcome.
+Advance comments are welcome.
 
 </Frame>


### PR DESCRIPTION
This is a boring PR that changes "advanced comments" to "advance comments" in a few places, where there are sections yet to be written and we're soliciting community feedback.