### PR TITLE
Various copy fixes

### DIFF
--- a/site/src/components/pages/home/Section2/index.tsx
+++ b/site/src/components/pages/home/Section2/index.tsx
@@ -47,9 +47,9 @@ const CONTENT = [
       "Blocks created using the Block Protocol can easily move between apps",
     content: (
       <Box>
-        These blocks use structured data which makes it easy to move both block
+        These blocks use structured data which makes it easy to move both blocks
         themselves, and the data within blocks, even if the blocks are in
-        completely seperate applications.
+        completely separate applications.
       </Box>
     ),
     renderComponent: (isMobile: boolean, isActive?: boolean) => (

--- a/site/src/components/pages/home/WhyBlockProtocol1Section.tsx
+++ b/site/src/components/pages/home/WhyBlockProtocol1Section.tsx
@@ -118,7 +118,7 @@ const CONTENT = [
           textAlign: "center",
         }}
       >
-        We could pull in data from a checklist block our favorite to-do app...
+        We could pull in data from a checklist block on our favorite to-do app...
       </Typography>
     ),
   },

--- a/site/src/components/pages/home/WhyBlockProtocol1Section.tsx
+++ b/site/src/components/pages/home/WhyBlockProtocol1Section.tsx
@@ -118,7 +118,8 @@ const CONTENT = [
           textAlign: "center",
         }}
       >
-        We could pull in data from a checklist block on our favorite to-do app...
+        We could pull in data from a checklist block on our favorite to-do
+        app...
       </Typography>
     ),
   },

--- a/site/src/components/pages/home/WhyBlockProtocol2Section.tsx
+++ b/site/src/components/pages/home/WhyBlockProtocol2Section.tsx
@@ -166,7 +166,7 @@ export const WhyBlockProtocol2Section = () => {
           Keep data in sync, get real-time updates, and integrate with any
           service that uses the protocol.
           <br />
-          No extra configuration required
+          No extra configuration required.
         </Typography>
       </Container>
 

--- a/site/src/components/pages/home/WhyBlockProtocol2Section.tsx
+++ b/site/src/components/pages/home/WhyBlockProtocol2Section.tsx
@@ -193,8 +193,8 @@ export const WhyBlockProtocol2Section = () => {
               and delete data in a predictable way.
               <br />
               <br />
-              This standardization makes it possible to easily move both blocks and
-              data between applications that adhere to the protocol.
+              This standardization makes it possible to easily move both blocks
+              and data between applications that adhere to the protocol.
             </Typography>
             <Link href="/spec">
               <Button variant="secondary">Read the Spec</Button>

--- a/site/src/components/pages/home/WhyBlockProtocol2Section.tsx
+++ b/site/src/components/pages/home/WhyBlockProtocol2Section.tsx
@@ -193,7 +193,7 @@ export const WhyBlockProtocol2Section = () => {
               and delete data in a predictable way.
               <br />
               <br />
-              This standisation makes it possible to easily move both blocks and
+              This standardization makes it possible to easily move both blocks and
               data between applications that adhere to the protocol.
             </Typography>
             <Link href="/spec">


### PR DESCRIPTION
@EllieHoward78 kindly opened a number of PRs (#77, #78, #79, #80 and #81) fixing some typos in our site. These have been merged into an `eh/typo-fixes` branch, and this PR proposes to squash and merge that in into `main`.