### PR TITLE
fix(tool): build all blocks everytime regardless of which ones actual…

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/blockprotocol/blockprotocol.git",
   "license": "MIT",
   "scripts": {
-    "build": "./scripts/build-blocks.sh && yarn generate-sitemap && next build",
+    "build": "yarn build-blocks && yarn generate-sitemap && next build",
     "build-block": "./scripts/build-blocks.sh",
     "build-blocks": "find ../registry -type f | xargs ./scripts/build-blocks.sh",
     "clean": "rimraf ./.next/",

--- a/site/scripts/build-blocks.sh
+++ b/site/scripts/build-blocks.sh
@@ -38,7 +38,6 @@ function abs() {
 # ----
 DIR=$(abs "${BASH_SOURCE[0]%/*}")
 REPO_ROOT="$DIR/../.."
-CACHE_DIR="${REPO_ROOT}/site/.next/cache"
 
 # deps
 # ----
@@ -81,12 +80,6 @@ onexit() {
 }
 
 trap onexit EXIT HUP INT QUIT PIPE TERM
-
-# use nextjs build cache to store previous builds (vercel does preserve it)
-# @see https://vercel.com/docs/concepts/deployments/build-step#caching
-log info "restore previous builds from the cache"
-mkdir -p "${CACHE_DIR}/blocks"
-cp -a "${CACHE_DIR}/blocks" "${REPO_ROOT}/site/public"
 
 # main
 # ----
@@ -190,9 +183,6 @@ else
     build_block "$build_config"
   done
 fi
-
-log info "pushing updated builds to the cache"
-rsync -a --delete "${REPO_ROOT}/site/public/blocks/" "${CACHE_DIR}/blocks"
 
 log info "finished w/o errors"
 exit 0


### PR DESCRIPTION
Vercel persists nextjs' cache between builds. That's why I used it to persist block builds, too.
However, vercel provides fresh cache instances for each branch and seems to clear the target branch's
cache when merging. This PR removes all caching functionality and changes the `build` command so that all blocks get build everytime.