### PR TITLE
[SPEC] Update section headers

### DIFF
--- a/registry/@hash/code.json
+++ b/registry/@hash/code.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/dev.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2021-12-24T16:30:00.000Z"
+  "timestamp": "2021-12-25T16:30:00.000Z"
 }

--- a/registry/@hash/divider.json
+++ b/registry/@hash/divider.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/dev.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2021-12-24T16:30:00.000Z"
+  "timestamp": "2021-12-25T16:30:00.000Z"
 }

--- a/registry/@hash/embed.json
+++ b/registry/@hash/embed.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/dev.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2021-12-24T16:30:00.000Z"
+  "timestamp": "2021-12-25T16:30:00.000Z"
 }

--- a/registry/@hash/header.json
+++ b/registry/@hash/header.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/dev.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2021-12-24T16:30:00.000Z"
+  "timestamp": "2021-12-25T16:30:00.000Z"
 }

--- a/registry/@hash/image.json
+++ b/registry/@hash/image.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/dev.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2021-12-24T16:30:00.000Z"
+  "timestamp": "2021-12-25T16:30:00.000Z"
 }

--- a/registry/@hash/paragraph.json
+++ b/registry/@hash/paragraph.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/dev.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2021-12-24T16:30:00.000Z"
+  "timestamp": "2021-12-25T16:30:00.000Z"
 }

--- a/registry/@hash/person.json
+++ b/registry/@hash/person.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/dev.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2021-12-24T16:30:00.000Z"
+  "timestamp": "2021-12-25T16:30:00.000Z"
 }

--- a/registry/@hash/table.json
+++ b/registry/@hash/table.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/dev.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2021-12-24T16:30:00.000Z"
+  "timestamp": "2021-12-25T16:30:00.000Z"
 }

--- a/registry/@hash/video.json
+++ b/registry/@hash/video.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/dev.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2021-12-24T16:30:00.000Z"
+  "timestamp": "2021-12-25T16:30:00.000Z"
 }

--- a/site/src/_pages/spec/1_block-types.mdx
+++ b/site/src/_pages/spec/1_block-types.mdx
@@ -46,7 +46,7 @@ A block package SHOULD contain:
     - `variants` – an array of objects, each with a `name`, `description`, `icon`, and `properties`, which represents different variants of the block that the user can create. As a simple example, a ‘header’ block might have variants called ‘Heading 1’ and ‘Heading 2’, which start with `{ level: 1 }` and `{ level: 2 }` as properties, respectively.
     - `image` – a preview image of the block for users to see it in action before using it. This would ideally have a 3:2 width:height ratio and be a minimum of 900x1170px.
 
-## Requesting, creating, and updating data
+## Data transfer
 
 ### Data provided to blocks
 
@@ -81,7 +81,7 @@ They can be requested using the functions listed below._
 Each entity provided under `linkedEntities` or `linkedAggregations` will also have an `entityId` and `entityTypeId` to be used as arguments when updating those entities.
 See [linking entities](#linking-entities) for a discussion of how links are managed.
 
-### Functions provided to blocks
+### Entity functions
 
 Subject to the permissions granted to them by the embedding application, blocks can expect functions with the names and signatures listed below to be made available to them, i.e. to be passed in along with the properties defined in their schema, or to be otherwise made available in their scope depending on their [implementation](#linking-entities):
 
@@ -193,7 +193,7 @@ retrieve a subset of entities of a given type
 
 The functions defined above return entity data, but block authors should note that in many [implementations](https://blockprotocol.org/spec/embedding-application-implementation) the embedding application will re-render a block with new entity data whenever it is updated (whether by the block or some other actor), e.g. the block will automatically get sent new data via props when any entity it has previously received via props is updated.
 
-### Functions for working with entity types
+### Entity type functions
 
 Where supported and permitted by the embedding application, blocks may be provided with the following functions to work with entity types, i.e. data models.
 
@@ -437,7 +437,7 @@ When requesting entity data via a block protocol function, blocks MAY include a 
 For example, a depth of 2 on a Person would resolve their linked Employer, and their Employer’s linked Location, but no further.
 A depth of 0 would resolve no links to other entities.
 
-### Putting it all together – the data gets sent to blocks
+### Field summary
 
 A block can expect the following fields to be made available to it, whether passed in as props or via another method appropriate to their rendering strategy:
 
@@ -469,7 +469,7 @@ deleteLinks
 getLinks
 ```
 
-### Working with third-party data stores
+### Third-party data stores
 
 Where blocks interact with third-party data stores, i.e. they send data for storage _outside_ the embedding application, they SHOULD where possible keep the entity data in the embedding application in sync, for example by:
 

--- a/site/src/_pages/spec/2_embedding-applications.mdx
+++ b/site/src/_pages/spec/2_embedding-applications.mdx
@@ -1,4 +1,4 @@
-# Embedding application implementation
+# Embedding applications
 
 An embedding application is any app that renders blocks conforming to this protocol, by:
 
@@ -43,7 +43,7 @@ This sandbox application would in turn render the block, and provide it with the
 When the block calls a function (e.g. updateEntity), the sandboxing application sends messages with the request and payload to the parent application.
 Users should then be prompted to permit or deny the sort of action the block is attempting to take, and their preferences saved.
 
-## Making the rendered web page machine-readable
+## Machine-readable pages
 
 Where an embedding application supplies a block with data corresponding to structured entities, and the web page and that entity data are for public consumption, the embedding application SHOULD [include machine-readable structured data on the page](https://developers.google.com/search/docs/guides/intro-structured-data).
 

--- a/site/src/_pages/spec/3_implementation-approaches.mdx
+++ b/site/src/_pages/spec/3_implementation-approaches.mdx
@@ -1,4 +1,4 @@
-# Implementation and rendering context
+# Implementation approaches
 
 <InfoCard>
 
@@ -7,10 +7,10 @@ It is included in this preliminary document to aid the reader in understanding t
 
 </InfoCard>
 
-## Ensuring compliance with requirements
+## Validating compliance
 
 When publishing the block protocol, we will provide tooling to help validate block type compliance with the block protocol.
-We may wish to dictate that blocks meet certain standards before they are made available via the catalog to be hosted on [blockprotocol.org](https://blockprotocol.org).
+We may wish to dictate that blocks meet certain standards before they are made available via the [Block Hub](https://blockprotocol.org/hub).
 
 ## Rendering contexts
 


### PR DESCRIPTION
Some section headers were a little wordy, which was fine for their original doc context, but not when used in a navigation sidebar.

This PR shortens them.

## New tree
![Screenshot 2022-01-12 at 09 28 47](https://user-images.githubusercontent.com/37743469/149112850-e97e08cb-439a-4e28-b429-14c5c68929c0.png)
![Screenshot 2022-01-12 at 09 29 21](https://user-images.githubusercontent.com/37743469/149112878-8f06d06a-1d1c-43de-b59d-5f613b424246.png)

## Old tree
![Screenshot 2022-01-12 at 09 29 34](https://user-images.githubusercontent.com/37743469/149113101-25a7f3d5-e04d-47bc-82b9-8d102cf718b8.png)
![Screenshot 2022-01-12 at 09 29 44](https://user-images.githubusercontent.com/37743469/149113139-cd801fcf-c58f-4fc0-b6eb-09aefbe4e66f.png)

