### PR TITLE
[tool] build all blocks everytime

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/blockprotocol/blockprotocol.git",
   "license": "MIT",
   "scripts": {
-    "build": "./scripts/build-blocks.sh && yarn generate-sitemap && next build",
+    "build": "yarn build-blocks && yarn generate-sitemap && next build",
     "build-block": "./scripts/build-blocks.sh",
     "build-blocks": "find ../registry -type f | xargs ./scripts/build-blocks.sh",
     "clean": "rimraf ./.next/",


### PR DESCRIPTION
Vercel persists nextjs' cache between builds. That's why I used it to persist block builds, too.
However, vercel provides fresh cache instances for each branch and seems to clear the target branch's
cache when merging. This PR removes all caching functionality and changes the build command so that all blocks get build everytime.