### PR TITLE
Add redirect from `/discord`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for taking the time to contribute! 🎉 HASH has established a set of [community guidelines](https://hash.ai/legal/community) to enable as many people as possible to contribute to and benefit from the Block Protocol. Please follow these when interacting with this repo.
 
-We have a community [Discord server](https://discord.gg/PefPteFe5j) where you can ask questions about contributing to the Block Protocol, and get support on its use. If you'd like to make a significant change or re-architecture, please first discuss the change there (or create an [issue](https://github.com/blockprotocol/blockprotocol/issues)) to get feedback before spending too much time.
+We have a community [Discord server](https://blockprotocol.org/discord) where you can ask questions about contributing to the Block Protocol, and get support on its use. If you'd like to make a significant change or re-architecture, please first discuss the change there (or create an [issue](https://github.com/blockprotocol/blockprotocol/issues)) to get feedback before spending too much time.
 
 ## Block Protocol monorepo
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Distributed under the MIT License. See `LICENSE.md` for more information.
 
 Find us on Twitter at [@blockprotocol](https://twitter.com/blockprotocol) or email [support@blockprotocol.org](mailto:support@blockprotocol.org)
 
-You can also join our [community Discord server](https://discord.gg/PefPteFe5j) for quick help and support.
+You can also join our [community Discord server](https://blockprotocol.org/discord) for quick help and support.
 
 Project Link: [https://github.com/blockprotocol/blockprotocol](https://github.com/blockprotocol/blockprotocol)
 

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -15,6 +15,11 @@ module.exports = withFonts(
     async redirects() {
       return [
         {
+          source: "/discord",
+          destination: "https://discord.gg/PefPteFe5j",
+          permanent: true,
+        },
+        {
           source: "/partners",
           destination: "/contact",
           permanent: true,

--- a/site/src/components/Footer.tsx
+++ b/site/src/components/Footer.tsx
@@ -81,7 +81,7 @@ const SOCIALS: { name: string; icon: ReactNode; href: string }[] = [
   {
     name: "Discord",
     icon: <Icon className="fab fa-discord" />,
-    href: "https://discord.gg/PefPteFe5j",
+    href: "/discord",
   },
   {
     name: "GitHub",

--- a/site/src/components/Link.tsx
+++ b/site/src/components/Link.tsx
@@ -69,7 +69,8 @@ export const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
 
     const isExternal =
       typeof href === "string" &&
-      !/^(mailto:|#|\/|https:\/\/blockprotocol\.org)/.test(href);
+      (href === "/discord" ||
+        !/^(mailto:|#|\/|https:\/\/blockprotocol\.org)/.test(href));
 
     if (isExternal) {
       other.rel = "noopener";

--- a/site/src/pages/contact.page.tsx
+++ b/site/src/pages/contact.page.tsx
@@ -59,10 +59,7 @@ const Partners: NextPage = () => {
             >
               You can also{" "}
               <Link href="mailto:help@blockprotocol.org">email us</Link> or{" "}
-              <Link href="https://discord.gg/PefPteFe5j">
-                chat to us on Discord
-              </Link>
-              .
+              <Link href="/discord">chat to us on Discord</Link>.
             </Typography>
           </Box>
           <form


### PR DESCRIPTION
This PR unifies links to Discord our server by creating a new `/discord` redirect endpoint. It is now used both in internal pages and markdowns. Markdown links are absolute, so we need to merge this PR for them to start working.

<img width="625" alt="Screenshot 2022-01-12 at 16 02 36" src="https://user-images.githubusercontent.com/608862/149176277-11f530e1-f606-4f57-b05f-f72fca7ea76a.png">

I was thinking of putting the link to an env variable, but then decided to hardcode it right in `next.config.js`. That’s one less abstraction to think about if a link changes. I don’t think it will happen too often if at all TBH.

[Asana task](https://app.asana.com/0/1201414765539664/1201562956971361/f) (internal link)