### PR TITLE
[SPEC] Update internal links to match new headers

### DIFF
--- a/site/src/_pages/docs/1_developing-blocks.mdx
+++ b/site/src/_pages/docs/1_developing-blocks.mdx
@@ -40,7 +40,7 @@ Embedding applications may also pass an `updateEntities` function, an `entityId`
 to your block - these are the ids identifying your block data in the app. Call `updateEntities` with any new data
 you want the app to set for your block - it should match the data types you have defined in `AppProps`.
 
-For more about editing data from blocks, [read the specification](https://blockprotocol.org/spec/block-types#requesting-creating-and-updating-data).
+For more about editing data from blocks, [read the specification](https://blockprotocol.org/spec/block-types#data-transfer).
 
 ### Build
 

--- a/site/src/_pages/docs/3_embedding-blocks.mdx
+++ b/site/src/_pages/docs/3_embedding-blocks.mdx
@@ -1,7 +1,7 @@
 ## Overview
 
 This guide covers a few key points to consider when writing or updating an application to use blocks,
-and is a companion to the [embedding application section of the block protocol specification](https://blockprotocol.org/spec/embedding-application-implementation).
+and is a companion to the [embedding application section of the block protocol specification](https://blockprotocol.org/spec/embedding-applications).
 
 ## Discovering blocks
 

--- a/site/src/_pages/spec/0_index.mdx
+++ b/site/src/_pages/spec/0_index.mdx
@@ -63,13 +63,13 @@ In the context of the protocol, schemas are used both to describe the data a blo
 Field types may be scalar (integer, string etc.), complex objects, collections (lists/arrays), or refer to another schema.
 
 **Block type:** a definition and implementation – i.e. code – for a discrete component on a web page, which provides functionality for structured data (rendering it, editing it).
-A block type specifies the data it accepts via a schema in accordance with [the spec](https://blockprotocol.org/spec/embedding-application-implementation).
+A block type specifies the data it accepts via a schema in accordance with [the spec](https://blockprotocol.org/spec/embedding-applications).
 
 **Block:** an instance of a block type inserted into a web page and supplied with data by an embedding application.
 
 **Block package:** a collection of files making a block type available for use by embedding applications, including its source code and accompanying metadata.
 
-**Embedding application:** an application which can take a block type and insert it in a web page, supplying the block with the structured data and dependencies it needs in accordance with the [specification](https://blockprotocol.org/spec/embedding-application-implementation).
+**Embedding application:** an application which can take a block type and insert it in a web page, supplying the block with the structured data and dependencies it needs in accordance with the [specification](https://blockprotocol.org/spec/embedding-applications).
 
 When capitalized, the words ‘MUST’, ‘MUST NOT’, ‘SHOULD’, ‘SHOULD NOT’, and ’MAY’ in this document are to be interpreted as described in IETF [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 

--- a/site/src/_pages/spec/1_block-types.mdx
+++ b/site/src/_pages/spec/1_block-types.mdx
@@ -8,7 +8,7 @@ A block package MUST contain:
 - **source file or files** (e.g. HTML and JavaScript files), which
 
   - SHOULD contain valid HTML
-  - There are [various tools](https://blockprotocol.org/spec/implementation-and-rendering-context) to help in meeting these requirements.
+  - There are [various tools](https://blockprotocol.org/spec/implementation-approaches) to help in meeting these requirements.
 
 A block package SHOULD contain:
 
@@ -51,7 +51,7 @@ A block package SHOULD contain:
 ### Data provided to blocks
 
 Blocks MUST use the data properties specified in their schema, if any.
-They can expect these properties to be made available to them by the embedding application, exactly how depending on [rendering context](https://blockprotocol.org/spec/implementation-and-rendering-context).
+They can expect these properties to be made available to them by the embedding application, exactly how depending on [rendering context](https://blockprotocol.org/spec/implementation-approaches).
 For example, for a React component block they would be passed as ‘props’.
 In a block with an HTML entrypoint, appropriately sandboxed by the embedding application, the properties would be in the global scope (of the sandbox).
 
@@ -191,7 +191,7 @@ retrieve a subset of entities of a given type
     - `desc?` \[_boolean_]\[_optional_]: whether to sort descending.
 - Embedding apps will provide a default aggregation if not provided.
 
-The functions defined above return entity data, but block authors should note that in many [implementations](https://blockprotocol.org/spec/embedding-application-implementation) the embedding application will re-render a block with new entity data whenever it is updated (whether by the block or some other actor), e.g. the block will automatically get sent new data via props when any entity it has previously received via props is updated.
+The functions defined above return entity data, but block authors should note that in many [implementations](https://blockprotocol.org/spec/embedding-applications) the embedding application will re-render a block with new entity data whenever it is updated (whether by the block or some other actor), e.g. the block will automatically get sent new data via props when any entity it has previously received via props is updated.
 
 ### Entity type functions
 

--- a/site/src/_pages/spec/2_embedding-applications.mdx
+++ b/site/src/_pages/spec/2_embedding-applications.mdx
@@ -15,7 +15,7 @@ In order to be portable anywhere, blocks should not need to have any knowledge o
 To render a block which defines a schema for the data it accepts, embedding applications MUST supply it with any data properties marked as required, SHOULD respect any other constraints expressed in the schema, and MAY supply any further properties expressed in the schema.
 
 Embedding applications SHOULD supply blocks with functions to get, aggregate, create, delete and update entities, entity types, and links between entities (subject to any permissions restrictions).
-These functions MUST conform to the naming conventions and function signatures outlined in [the previous section](https://blockprotocol.org/spec/embedding-application-implementation).
+These functions MUST conform to the naming conventions and function signatures outlined in [the previous section](https://blockprotocol.org/spec/embedding-applications).
 Embedding applications SHOULD provide defaults for aggregation operations to handle cases where the block doesn’t specify its own requirements.
 
 To enable blocks to update data of entities, including themselves, embedding applications SHOULD include an `entityId` and `entityTypeId` alongside the data for each entity it supplies the block with (including the `entityId` and `entityTypeId` of the block itself).


### PR DESCRIPTION
in #88 I updated section headers without catching a few internal links that referred to the old headers.

This fixes that.