### PR TITLE
Update block metadata + build script for new source repo

### DIFF
--- a/hub/@hash/code.json
+++ b/hub/@hash/code.json
@@ -1,6 +1,6 @@
 {
   "workspace": "@hashintel/block-code",
-  "repository": "https://github.com/hashintel/dev.git",
+  "repository": "https://github.com/hashintel/hash.git",
   "branch": "main",
   "distDir": "dist",
   "timestamp": "2021-12-25T16:30:00.000Z"

--- a/hub/@hash/divider.json
+++ b/hub/@hash/divider.json
@@ -1,6 +1,6 @@
 {
   "workspace": "@hashintel/block-divider",
-  "repository": "https://github.com/hashintel/dev.git",
+  "repository": "https://github.com/hashintel/hash.git",
   "branch": "main",
   "distDir": "dist",
   "timestamp": "2021-12-25T16:30:00.000Z"

--- a/hub/@hash/embed.json
+++ b/hub/@hash/embed.json
@@ -1,6 +1,6 @@
 {
   "workspace": "@hashintel/block-embed",
-  "repository": "https://github.com/hashintel/dev.git",
+  "repository": "https://github.com/hashintel/hash.git",
   "branch": "main",
   "distDir": "dist",
   "timestamp": "2021-12-25T16:30:00.000Z"

--- a/hub/@hash/header.json
+++ b/hub/@hash/header.json
@@ -1,6 +1,6 @@
 {
   "workspace": "@hashintel/block-header",
-  "repository": "https://github.com/hashintel/dev.git",
+  "repository": "https://github.com/hashintel/hash.git",
   "branch": "main",
   "distDir": "dist",
   "timestamp": "2021-12-25T16:30:00.000Z"

--- a/hub/@hash/image.json
+++ b/hub/@hash/image.json
@@ -1,6 +1,6 @@
 {
   "workspace": "@hashintel/block-image",
-  "repository": "https://github.com/hashintel/dev.git",
+  "repository": "https://github.com/hashintel/hash.git",
   "branch": "main",
   "distDir": "dist",
   "timestamp": "2021-12-25T16:30:00.000Z"

--- a/hub/@hash/paragraph.json
+++ b/hub/@hash/paragraph.json
@@ -1,6 +1,6 @@
 {
   "workspace": "@hashintel/block-paragraph",
-  "repository": "https://github.com/hashintel/dev.git",
+  "repository": "https://github.com/hashintel/hash.git",
   "branch": "main",
   "distDir": "dist",
   "timestamp": "2021-12-25T16:30:00.000Z"

--- a/hub/@hash/person.json
+++ b/hub/@hash/person.json
@@ -1,6 +1,6 @@
 {
   "workspace": "@hashintel/block-person",
-  "repository": "https://github.com/hashintel/dev.git",
+  "repository": "https://github.com/hashintel/hash.git",
   "branch": "main",
   "distDir": "dist",
   "timestamp": "2021-12-25T16:30:00.000Z"

--- a/hub/@hash/table.json
+++ b/hub/@hash/table.json
@@ -1,6 +1,6 @@
 {
   "workspace": "@hashintel/block-table",
-  "repository": "https://github.com/hashintel/dev.git",
+  "repository": "https://github.com/hashintel/hash.git",
   "branch": "main",
   "distDir": "dist",
   "timestamp": "2021-12-25T16:30:00.000Z"

--- a/hub/@hash/video.json
+++ b/hub/@hash/video.json
@@ -1,6 +1,6 @@
 {
   "workspace": "@hashintel/block-video",
-  "repository": "https://github.com/hashintel/dev.git",
+  "repository": "https://github.com/hashintel/hash.git",
   "branch": "main",
   "distDir": "dist",
   "timestamp": "2021-12-25T16:30:00.000Z"

--- a/site/scripts/build-blocks.sh
+++ b/site/scripts/build-blocks.sh
@@ -112,7 +112,6 @@ function build_block {
 
     log info "downloading ${zip_url}"
 
-    zip_url="${zip_url:0:8}@${zip_url:8}"
 
     res=$(curl -sL -w '%{http_code}' -o "${repo_path}.zip" "$zip_url")
 

--- a/site/scripts/build-blocks.sh
+++ b/site/scripts/build-blocks.sh
@@ -53,18 +53,6 @@ else
     log error "missing commandline tool 'rsync'"
     exit 2
   fi
-
-  if [[ -f "${REPO_ROOT}/site/.env.local" ]]; then
-    source "${REPO_ROOT}/site/.env.local"
-  else
-    log error "missing environment settings \${REPO_ROOT}/site/.env.local"
-    exit 3
-  fi
-fi
-
-if [[ -z "$GH_ACCESS_TOKEN" ]]; then
-  log error "missing environment variable GH_ACCESS_TOKEN"
-  exit 4
 fi
 
 # prep
@@ -124,9 +112,7 @@ function build_block {
 
     log info "downloading ${zip_url}"
 
-    # insert http basic auth credentials (https://<user:password>@domain.com)
-    # cannot use curl's -u options because that would also require a password
-    zip_url="${zip_url:0:8}${GH_ACCESS_TOKEN}@${zip_url:8}"
+    zip_url="${zip_url:0:8}@${zip_url:8}"
 
     res=$(curl -sL -w '%{http_code}' -o "${repo_path}.zip" "$zip_url")
 
@@ -143,7 +129,7 @@ function build_block {
   log debug "pushd into ${repo_path}/${inner_dir}"
   pushd "${repo_path}/${inner_dir}"
 
-  log info "installing, building and publishing"
+  log info "installing and building"
   if [[ "$workspace" == "null" ]]; then
     # devDependencies are required
     NODE_ENV=development yarn install


### PR DESCRIPTION
We recently moved source code for our initial blocks from a private repository to [`hash`](https://github.com/hashintel/hash).

As a consequence this PR:
- updates the block config files to point to the new repo
- removes authentication handling from the block build script - auth is no longer required as the source is available publicly.