### PR TITLE
[SITE] Replace mui's troublesome scroll-lock implementation

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -203,7 +203,7 @@ module.exports = {
           },
           {
             name: "@mui/material",
-            importNames: ["Button", "TextField"],
+            importNames: ["Button", "TextField", "Popover"],
             message:
               "Please use the custom wrapper component in src/component instead.",
           },
@@ -218,6 +218,12 @@ module.exports = {
             importNames: ["default"],
             message:
               "Please use the custom src/components/TextField component instead.",
+          },
+          {
+            name: "@mui/material/Popover",
+            importNames: ["default"],
+            message:
+              "Please use the custom src/components/Popover component instead.",
           },
         ],
       },

--- a/site/src/components/Modal.tsx
+++ b/site/src/components/Modal.tsx
@@ -1,7 +1,9 @@
-import { FunctionComponent, ReactNode } from "react";
-import Box from "@mui/material/Box";
-import MuiModal from "@mui/material/Modal";
 import { SxProps, Theme } from "@mui/material";
+import Box from "@mui/material/Box";
+import MuiModal, { ModalProps as MuiModalProps } from "@mui/material/Modal";
+import React from "react";
+
+import { useScrollLock } from "../util/muiUtils";
 
 const style: SxProps<Theme> = {
   position: "absolute",
@@ -19,23 +21,23 @@ const style: SxProps<Theme> = {
   p: { xs: 2, md: 4 },
 };
 
-type ModalProps = {
-  open: boolean;
-  onClose: () => void;
-  children: ReactNode;
-};
+type ModalProps = Pick<MuiModalProps, "open" | "onClose" | "disableScrollLock">;
 
-export const Modal: FunctionComponent<ModalProps> = ({
+export const Modal: React.FC<ModalProps> = ({
   open,
   children,
+  disableScrollLock = false,
   onClose,
 }) => {
+  useScrollLock(!disableScrollLock && open);
+
   return (
     <MuiModal
       open={open}
       onClose={onClose}
       aria-labelledby="modal-modal-title"
       aria-describedby="modal-modal-description"
+      disableScrollLock
     >
       <Box sx={style}>{children}</Box>
     </MuiModal>

--- a/site/src/components/Modal/LoginModal.tsx
+++ b/site/src/components/Modal/LoginModal.tsx
@@ -9,6 +9,7 @@ import {
   VerificationCodeScreen,
 } from "../Screens/VerificationCodeScreen";
 import { apiClient } from "../../lib/apiClient";
+import { useScrollLock } from "../../util/muiUtils";
 
 type LoginModalProps = {
   onClose: () => void;
@@ -18,6 +19,7 @@ type LoginModalPage = "Email" | "VerificationCode";
 
 export const LoginModal: VFC<LoginModalProps> = ({
   onClose,
+  disableScrollLock = false,
   ...modalProps
 }) => {
   const { user, setUser } = useContext(UserContext);
@@ -31,6 +33,8 @@ export const LoginModal: VFC<LoginModalProps> = ({
     setCurrentPage("Email");
     setVerificationCodeInfo(undefined);
   };
+
+  useScrollLock(!disableScrollLock && modalProps.open);
 
   useEffect(() => {
     if (modalProps.open && user) {
@@ -76,6 +80,7 @@ export const LoginModal: VFC<LoginModalProps> = ({
         },
       }}
       onClose={handleClose}
+      disableScrollLock
       {...modalProps}
     >
       <Fade in={modalProps.open}>

--- a/site/src/components/Navbar/AccountDropdown.tsx
+++ b/site/src/components/Navbar/AccountDropdown.tsx
@@ -1,16 +1,11 @@
 import { VFC, useState, useContext, useRef } from "react";
-import {
-  Box,
-  Typography,
-  ListItemButton,
-  Divider,
-  Popover,
-} from "@mui/material";
+import { Box, Typography, ListItemButton, Divider } from "@mui/material";
 import { Link } from "../Link";
 import { Button } from "../Button";
 import UserContext from "../../context/UserContext";
 import { apiClient } from "../../lib/apiClient";
 import { UserAvatar } from "../UserAvatar";
+import { Popover } from "../Popover";
 
 export const AccountDropdown: VFC = () => {
   const { user, setUser } = useContext(UserContext);

--- a/site/src/components/Popover.tsx
+++ b/site/src/components/Popover.tsx
@@ -1,0 +1,15 @@
+/* eslint-disable-next-line -- allow import of original popover to extend it */
+import { Popover as MuiPopover, PopoverProps } from "@mui/material";
+import React from "react";
+import { useScrollLock } from "../util/muiUtils";
+
+/**
+ * Custom Popover re-implementing MUI's troublesome scroll-lock mechanism.
+ */
+export const Popover: React.FC<PopoverProps> = ({
+  disableScrollLock = false,
+  ...props
+}) => {
+  useScrollLock(!disableScrollLock && props.open);
+  return <MuiPopover disableScrollLock {...props} />;
+};

--- a/site/src/util/muiUtils.tsx
+++ b/site/src/util/muiUtils.tsx
@@ -13,7 +13,7 @@ export const parseIntFromPixelString = (pixelString: string): number => {
  * This version applies different yet equally effective styles to the document element.
  *
  * Used to replace the functionality behind `disableScollLock` property of MUI's
- * components modal, drawer, menu, popover, modal.
+ * components modal, drawer, menu, popover, dialog.
  */
 export const useScrollLock = (active: boolean) =>
   useLayoutEffect(() => {

--- a/site/src/util/muiUtils.tsx
+++ b/site/src/util/muiUtils.tsx
@@ -1,3 +1,5 @@
+import { useLayoutEffect } from "react";
+
 export const parseIntFromPixelString = (pixelString: string): number => {
   if (!pixelString.endsWith("px")) {
     throw new Error(`The pixel string "${pixelString}" doesn't end with "px"`);
@@ -5,3 +7,20 @@ export const parseIntFromPixelString = (pixelString: string): number => {
 
   return parseInt(pixelString.slice(0, -2), 10);
 };
+
+/**
+ * MUI's implementation applies a padding to the body which may break the layout.
+ * This version applies different yet equally effective styles to the document element.
+ *
+ * Used to replace the functionality behind `disableScollLock` property of MUI's
+ * components modal, drawer, menu, popover, modal.
+ */
+export const useScrollLock = (active: boolean) =>
+  useLayoutEffect(() => {
+    document.documentElement.style.cssText = active
+      ? "position: fixed; overflow-y: scroll; width: 100%"
+      : "";
+    return () => {
+      document.documentElement.style.cssText = "";
+    };
+  }, [active]);


### PR DESCRIPTION
This PR replaces MUI's scroll-lock mechanism which adds a padding to the body to replace the scrollbar which however breaks the layout our case. The solution is to apply different yet equally effective styles to the html element.

How to reproduce: Fire up the site, log in, then press the account button in the top-right corner. The popover should pop over and the menu should no longer shift to the left due to prior body-padding applied by MUI.