### PR TITLE
[SITE] Fix cookie domain in production

### DIFF
--- a/site/src/lib/config.ts
+++ b/site/src/lib/config.ts
@@ -1,6 +1,8 @@
-export const FRONTEND_URL = process.env.NEXT_PUBLIC_VERCEL_URL
+export const FRONTEND_URL = process.env.FRONTEND_URL
+  ? process.env.FRONTEND_URL
+  : process.env.NEXT_PUBLIC_VERCEL_URL
   ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
-  : process.env.FRONTEND_URL ?? "http://localhost:3000";
+  : "http://localhost:3000";
 
 export const FRONTEND_DOMAIN = new URL(FRONTEND_URL).hostname;
 


### PR DESCRIPTION
We need to know the frontend URL to (a) email links to users to login, and (b) to derive the domain to set for the cookie.

This was configured to prioritise the `NEXT_PUBLIC_VERCEL_URL`, which is fine for preview deployments, but inappropriate for production as it is not the actual domain users are visiting (https://blockprotocol.org), but a different Vercel URL.

This means that users visiting https://blockprotocol.org will have the incorrect domain set on the cookie issued to them on login, and subsequent requests will not be authenticated.

This PR fixes that by prioritising the `FRONTEND_URL` variable (which has been set in Vercel for production to https://blockprotocol.org).