### PR TITLE
[API] Filter blocks by JSON schema validity

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -201,10 +201,7 @@ The following routes require a valid API key sent in an `x-api-key` header:
 - Request Params
 
   - `q`: an optional text query to search for blocks with a matching name or author. If not provided, all blocks are returned.
-
-- Request Body:
-
-  - `json`: an optional JSON object that filters blocks by schema validity.
+  - `json`: an optional JSON object that filters blocks by schema validity. Preferably URL encoded.
 
 - Request Response:
   - `results`: the results of the search: an array of block metadata JSON files

--- a/site/README.md
+++ b/site/README.md
@@ -202,5 +202,9 @@ The following routes require a valid API key sent in an `x-api-key` header:
 
   - `q`: an optional text query to search for blocks with a matching name or author. If not provided, all blocks are returned.
 
+- Request Body:
+
+  - `json`: an optional JSON object that filters blocks by schema validity.
+
 - Request Response:
   - `results`: the results of the search: an array of block metadata JSON files

--- a/site/package.json
+++ b/site/package.json
@@ -25,6 +25,7 @@
     "@emotion/styled": "^11.6.0",
     "@mui/material": "^5.2.1",
     "@twind/next": "1.0.8",
+    "ajv": "^8.9.0",
     "axios": "^0.24.0",
     "blockprotocol": "^0.0.1",
     "clsx": "^1.1.1",

--- a/site/src/_pages/docs/3_embedding-blocks.mdx
+++ b/site/src/_pages/docs/3_embedding-blocks.mdx
@@ -16,15 +16,21 @@ You can also [generate an API key](https://blockprotocol.org/settings/api-keys) 
 
 To authenticate with the API, pass your API key in an `x-api-key` header.
 
-### Coming soon
+It is also possible to search blocks by data structure: allowing you to provide a data object, and be told which blocks can display or edit it.
 
-We will soon introduce a feature to search blocks by data structure: allowing you to provide a data object, and be told which blocks can display or edit it.
+For example, if you provide `{ "name": "Bob", "email": "bob@test.com" }` in the `json` query parameter, the API will suggest the
+[person block](https://blockprotocol.org/@hash/person). It's preferable to URL encode the json object.
 
-For example, if you provide `{ "name": "Bob", email: "bob@test.com" }`, the API will suggest the
-[person block](https://blockprotocol.org/@hash/person).
+`https://blockprotocol.org/api/blocks?json={"name":"Bob","email":"bob@test.com"}`
+
+URL encoded:
+
+`https://blockprotocol.org/api/blocks?json=%7B%20%22name%22%3A%20%22Bob%22,%20%22email%22%3A%20%22bob%40test.com%22%20%7D`
 
 Once your app implements the block protocol, your users can search and use blocks to work with a
 wide variety of data structures, without further effort on your part.
+
+Both the `q` and `json` query parameters work together.
 
 ## Building the block's properties
 

--- a/site/src/_pages/docs/3_embedding-blocks.mdx
+++ b/site/src/_pages/docs/3_embedding-blocks.mdx
@@ -30,7 +30,7 @@ URL encoded:
 Once your app implements the block protocol, your users can search and use blocks to work with a
 wide variety of data structures, without further effort on your part.
 
-Both the `q` and `json` query parameters work together.
+Both the `q` and `json` query parameters work together. You may provide either, both, or none.
 
 ## Building the block's properties
 

--- a/site/src/pages/api/blocks.api.ts
+++ b/site/src/pages/api/blocks.api.ts
@@ -1,8 +1,5 @@
 import Ajv from "ajv";
-import {
-  query as queryValidator,
-  body as bodyValidator,
-} from "express-validator";
+import { query as queryValidator } from "express-validator";
 import { cloneDeep } from "lodash";
 import blocksData from "../../../blocks-data.json";
 import {
@@ -13,9 +10,6 @@ import { createApiKeyRequiredHandler } from "../../lib/handler/apiKeyRequiredHan
 
 export type ApiSearchRequestQuery = {
   q: string;
-};
-
-export type ApiSearchBody = {
   json: string;
 };
 
@@ -23,12 +17,13 @@ export type ApiSearchResponse = {
   results: BlockMetadata[];
 };
 
-export default createApiKeyRequiredHandler<ApiSearchBody, ApiSearchResponse>()
-  .use(bodyValidator("json").isJSON())
+export default createApiKeyRequiredHandler<null, ApiSearchResponse>()
   .use(queryValidator("q").isString().toLowerCase())
+  .use(queryValidator("json").isJSON())
   .get(async (req, res) => {
-    const { q: query } = req.query as ApiSearchRequestQuery;
-    const { json } = req.body as ApiSearchBody;
+    const { q: query, json: jsonText } = req.query as ApiSearchRequestQuery;
+
+    const json = JSON.parse(jsonText);
 
     let data: BlockMetadata[] = blocksData;
 

--- a/site/src/pages/api/blocks.api.ts
+++ b/site/src/pages/api/blocks.api.ts
@@ -9,8 +9,8 @@ import {
 import { createApiKeyRequiredHandler } from "../../lib/handler/apiKeyRequiredHandler";
 
 export type ApiSearchRequestQuery = {
-  q: string;
-  json: string;
+  q?: string;
+  json?: string;
 };
 
 export type ApiSearchResponse = {
@@ -22,8 +22,6 @@ export default createApiKeyRequiredHandler<null, ApiSearchResponse>()
   .use(queryValidator("json").isJSON())
   .get(async (req, res) => {
     const { q: query, json: jsonText } = req.query as ApiSearchRequestQuery;
-
-    const json = JSON.parse(jsonText);
 
     let data: BlockMetadata[] = blocksData;
 
@@ -41,7 +39,9 @@ export default createApiKeyRequiredHandler<null, ApiSearchResponse>()
 
     // beware, this is a slow operation
     // @todo optimize for quicker passes.
-    if (json) {
+    if (jsonText) {
+      const json = JSON.parse(jsonText);
+
       // If any property is not a part of the schema, remove it from the validated json
       const ajv = new Ajv({ removeAdditional: "all" });
 
@@ -56,14 +56,14 @@ export default createApiKeyRequiredHandler<null, ApiSearchResponse>()
           const valid = validate(withoutAdditional);
 
           // removeAdditional lets us count how many keys are a part of the schema
-          const keyCountWithouTAdditional =
+          const keyCountWithoutAdditional =
             Object.keys(withoutAdditional).length;
 
           const keyCountDifference =
-            Object.keys(json).length - keyCountWithouTAdditional;
+            Object.keys(json).length - keyCountWithoutAdditional;
 
           // Only show valid schemas with at least 1 matching field
-          return valid && keyCountWithouTAdditional >= 1
+          return valid && keyCountWithoutAdditional >= 1
             ? [[block, keyCountDifference]]
             : [];
         }) as [BlockMetadata, number][]

--- a/site/src/pages/api/blocks.api.ts
+++ b/site/src/pages/api/blocks.api.ts
@@ -1,20 +1,34 @@
-import { query as queryValidator } from "express-validator";
+import Ajv from "ajv";
+import {
+  query as queryValidator,
+  body as bodyValidator,
+} from "express-validator";
+import { cloneDeep } from "lodash";
 import blocksData from "../../../blocks-data.json";
-import { ExpandedBlockMetadata as BlockMetadata } from "../../lib/blocks";
+import {
+  ExpandedBlockMetadata as BlockMetadata,
+  readBlockDataFromDisk,
+} from "../../lib/blocks";
 import { createApiKeyRequiredHandler } from "../../lib/handler/apiKeyRequiredHandler";
 
 export type ApiSearchRequestQuery = {
   q: string;
 };
 
+export type ApiSearchBody = {
+  json: string;
+};
+
 export type ApiSearchResponse = {
   results: BlockMetadata[];
 };
 
-export default createApiKeyRequiredHandler<null, ApiSearchResponse>()
+export default createApiKeyRequiredHandler<ApiSearchBody, ApiSearchResponse>()
+  .use(bodyValidator("json").isJSON())
   .use(queryValidator("q").isString().toLowerCase())
   .get(async (req, res) => {
     const { q: query } = req.query as ApiSearchRequestQuery;
+    const { json } = req.body as ApiSearchBody;
 
     let data: BlockMetadata[] = blocksData;
 
@@ -28,6 +42,32 @@ export default createApiKeyRequiredHandler<null, ApiSearchResponse>()
             variant.displayName?.toLowerCase().includes(query),
           ),
       );
+    }
+
+    // beware, this is a slow operation
+    // @todo optimize for quicker passes.
+    if (json) {
+      const ajv = new Ajv({ removeAdditional: "all" });
+
+      data = (
+        data.flatMap((block) => {
+          const schema = readBlockDataFromDisk(block).schema;
+          const validate = ajv.compile(schema);
+          // withoutAdditional is transformed in validate.
+          // eslint-disable-next-line prefer-const
+          let withoutAdditional = cloneDeep(json);
+          const valid = validate(withoutAdditional);
+          // removeAdditional lets us count how many keys are parsed vs how many are not through
+          // the transformed json payload
+          const keyCountDifference =
+            Object.keys(json).length - Object.keys(withoutAdditional).length;
+          // if the json isn't valid, don't add it to the list, otherwise prepare blocks for sorting
+          return valid ? [[block, keyCountDifference]] : [];
+        }) as [BlockMetadata, number][]
+      )
+        // sort by how many keys are present in the validated output after removeAdditional.
+        .sort(([_, a], [__, b]) => a - b)
+        .map(([block, _]) => block);
     }
 
     // @todo paginate response

--- a/yarn.lock
+++ b/yarn.lock
@@ -2671,17 +2671,7 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.4, ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.1:
-  version "8.8.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.8.2.tgz#01b4fef2007a28bf75f0b7fc009f62679de4abbb"
-  integrity sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-    uri-js "^4.2.2"
-
-ajv@^8.9.0:
+ajv@^8.0.1, ajv@^8.9.0:
   version "8.9.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.9.0.tgz#738019146638824dea25edcf299dcba1b0e7eb18"
   integrity sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2681,6 +2681,16 @@ ajv@^8.0.1:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
+ajv@^8.9.0:
+  version "8.9.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.9.0.tgz#738019146638824dea25edcf299dcba1b0e7eb18"
+  integrity sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 anser@1.4.9:
   version "1.4.9"
   resolved "https://registry.yarnpkg.com/anser/-/anser-1.4.9.tgz#1f85423a5dcf8da4631a341665ff675b96845760"


### PR DESCRIPTION
This PR adds a query parameter for filtering blocks by a JSON payload on the query parameter on the `/api/blocks` endpoint.

The added query parameter is `json` and can be used as follows

`https://blockprotocol.org/api/blocks?json={"name":"Bob","email":"bob@test.com"}`
or URL encoded:
`https://blockprotocol.org/api/blocks?json=%7B%20%22name%22%3A%20%22Bob%22,%20%22email%22%3A%20%22bob%40test.com%22%20%7D`

The implementation requires any JSON object to at least supply one value from any block it returns, otherwise blocks that have only optional fields/no fields would always validate and be returned (such as the Divider block.)
