### PR TITLE
Fix 404 in spec and 500 in spec & docs

### DIFF
--- a/site/src/_pages/spec/1_block-types.mdx
+++ b/site/src/_pages/spec/1_block-types.mdx
@@ -61,7 +61,7 @@ A block package SHOULD contain:
 
 Blocks MUST use the data properties specified in their schema, if any.
 
-They can expect these properties to be made available to them by the embedding application, exactly how depending on [rendering context](https://blockprotocol.org/spec/implementation-and-rendering-context).
+They can expect these properties to be made available to them by the embedding application, exactly how depending on [rendering context](https://blockprotocol.org/spec/implementation-approaches#rendering-contexts).
 
 The data for the block itself will be at the root level of the data made available to it, i.e. a block which had a `level` property at the root of the properties in its schema would have a `level` property passed to it.
 

--- a/site/src/pages/docs/[[...docsSlug]].page.tsx
+++ b/site/src/pages/docs/[[...docsSlug]].page.tsx
@@ -77,7 +77,7 @@ export const getStaticProps: GetStaticProps<
   //
   //   Error: ENOENT: no such file or directory, open '{...}/_pages/docs/undefined'
   //
-  // Using try / catch prevents this, but we might not need it after upgrading Next.
+  // Using try / catch prevents 500, but we might not need them in Next v12+.
   try {
     const tabPageSerializedContent = await getSerializedPage({
       pathToDirectory: `docs`,

--- a/site/src/pages/docs/[[...docsSlug]].page.tsx
+++ b/site/src/pages/docs/[[...docsSlug]].page.tsx
@@ -72,17 +72,23 @@ export const getStaticProps: GetStaticProps<
 
   const tabPage = documentationPages.find(({ href }) => href === tabHref)!;
 
-  const tabPageSerializedContent = await getSerializedPage({
-    pathToDirectory: `docs`,
-    fileNameWithoutIndex: tabSlug ?? "index",
-  });
+  try {
+    const tabPageSerializedContent = await getSerializedPage({
+      pathToDirectory: `docs`,
+      fileNameWithoutIndex: tabSlug ?? "index",
+    });
 
-  return {
-    props: {
-      tabPage,
-      tabPageSerializedContent,
-    },
-  };
+    return {
+      props: {
+        tabPage,
+        tabPageSerializedContent,
+      },
+    };
+  } catch {
+    return {
+      notFound: true,
+    };
+  }
 };
 
 const DocsPage: NextPage<DocsPageProps> = ({

--- a/site/src/pages/docs/[[...docsSlug]].page.tsx
+++ b/site/src/pages/docs/[[...docsSlug]].page.tsx
@@ -72,6 +72,12 @@ export const getStaticProps: GetStaticProps<
 
   const tabPage = documentationPages.find(({ href }) => href === tabHref)!;
 
+  // As of Jan 2022, { fallback: false } in getStaticPaths does not prevent Vercel
+  // from calling getStaticProps for unknown pages. This causes 500 instead of 404:
+  //
+  //   Error: ENOENT: no such file or directory, open '{...}/_pages/docs/undefined'
+  //
+  // Using try / catch prevents this, but we might not need it after upgrading Next.
   try {
     const tabPageSerializedContent = await getSerializedPage({
       pathToDirectory: `docs`,

--- a/site/src/pages/spec/[[...specSlug]].page.tsx
+++ b/site/src/pages/spec/[[...specSlug]].page.tsx
@@ -173,7 +173,7 @@ export const getStaticProps: GetStaticProps<
   //
   //   Error: ENOENT: no such file or directory, open '{...}/_pages/docs/undefined'
   //
-  // Using try / catch prevents this, but we might not need it after upgrading Next.
+  // Using try / catch prevents 500, but we might not need them in Next v12+.
   try {
     const serializedPage = await getSerializedPage({
       pathToDirectory: "spec",

--- a/site/src/pages/spec/[[...specSlug]].page.tsx
+++ b/site/src/pages/spec/[[...specSlug]].page.tsx
@@ -168,16 +168,22 @@ export const getStaticProps: GetStaticProps<
   const fileNameWithoutIndex =
     specSlug && specSlug.length > 0 ? specSlug[0] : "index";
 
-  const serializedPage = await getSerializedPage({
-    pathToDirectory: "spec",
-    fileNameWithoutIndex,
-  });
+  try {
+    const serializedPage = await getSerializedPage({
+      pathToDirectory: "spec",
+      fileNameWithoutIndex,
+    });
 
-  return {
-    props: {
-      serializedPage,
-    },
-  };
+    return {
+      props: {
+        serializedPage,
+      },
+    };
+  } catch {
+    return {
+      notFound: true,
+    };
+  }
 };
 
 const SpecPage: NextPage<SpecPageProps> = ({ serializedPage }) => {

--- a/site/src/pages/spec/[[...specSlug]].page.tsx
+++ b/site/src/pages/spec/[[...specSlug]].page.tsx
@@ -168,6 +168,12 @@ export const getStaticProps: GetStaticProps<
   const fileNameWithoutIndex =
     specSlug && specSlug.length > 0 ? specSlug[0] : "index";
 
+  // As of Jan 2022, { fallback: false } in getStaticPaths does not prevent Vercel
+  // from calling getStaticProps for unknown pages. This causes 500 instead of 404:
+  //
+  //   Error: ENOENT: no such file or directory, open '{...}/_pages/docs/undefined'
+  //
+  // Using try / catch prevents this, but we might not need it after upgrading Next.
   try {
     const serializedPage = await getSerializedPage({
       pathToDirectory: "spec",


### PR DESCRIPTION
## 404

Reported in: https://github.com/blockprotocol/blockprotocol/discussions/118 (thanks for spotting this @leswaters 👍)

This has been fixed by changing a link in [Block types → Data transfer](https://blockprotocol.org/spec/block-types#data-transfer).

Before:
- https://blockprotocol-7hzzd9xe6-hashintel.vercel.app/spec/block-types#data-transfer

After: 
- https://blockprotocol-apxv16otf-hashintel.vercel.app/spec/block-types#data-transfer

## 500

All non-existing pages under `/docs/*` and `/spec/*` were returning HTTP 500 instead of 404.

Logs (internal link): https://vercel.com/hashintel/blockprotocol/3GwSF5NKh2zaaqjsYyR8QZ9kFR4W/functions

![Screenshot 2022-01-24 at 16 43 11](https://user-images.githubusercontent.com/608862/150826047-9ace964e-6caa-445c-af0f-3ab1c2c439cf.png)

This has been fixed with `try / catch` inside `getStaticProps`. See comments in diff for details.

Before:
- https://blockprotocol-7hzzd9xe6-hashintel.vercel.app/spec/oops
- https://blockprotocol-7hzzd9xe6-hashintel.vercel.app/docs/oops

After:
- https://blockprotocol-apxv16otf-hashintel.vercel.app/spec/oops
- https://blockprotocol-apxv16otf-hashintel.vercel.app/docs/oops