### PR TITLE
Fix workspace setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "private": true,
   "description": "blockprotocol monorepo",
   "workspaces": [
-    "./packages/*",
-    "./site"
+    "packages/*",
+    "site"
   ],
   "scripts": {
     "fix": "npm-run-all --continue-on-error \"fix:*\"",


### PR DESCRIPTION
Turns out that `yarn` does not treat `./path/to/workspace` and `path/to/workspace` equally. Related upstream work:

- https://github.com/yarnpkg/yarn/issues/4791
  (same issue as we have)
- https://github.com/yarnpkg/yarn/pull/4654
  (introduces `yarn workspace ... remove`, but probably lacks some check)
  
[Asana Task](https://app.asana.com/0/1201668052739245/1201707629991350/f) _(internal link)_

## Before

```sh
yarn workspace blockprotocol remove @types/react
# error No lockfile in this directory. Run `yarn install` to generate one.
```

```sh
yarn workspace blockprotocol add @types/react
# success Saved 4 new dependencies.

ls packages/blockprotocol/yarn.lock
# file exists (but it should not)
```


## After

```sh
yarn workspace blockprotocol remove @types/react
# no error; packages/blockprotocol/package.json has one less line
```

```sh
yarn workspace blockprotocol add @types/react
# success Saved 1 new dependency.

ls packages/blockprotocol/yarn.lock
# ls: No such file or directory
```
