### PR TITLE
Hide `/settings/api-keys` for guests, unify auth wall

### DIFF
--- a/site/src/components/Modal/LoginModal.tsx
+++ b/site/src/components/Modal/LoginModal.tsx
@@ -1,8 +1,8 @@
 import { Modal, Paper, ModalProps, Box, Icon, Fade } from "@mui/material";
-import React, { useContext, useEffect, useState, VFC } from "react";
+import React, { useEffect, useState, VFC } from "react";
 import { SerializedUser } from "../../lib/model/user.model";
 import { Button } from "../Button";
-import UserContext from "../../context/UserContext";
+import { useUser } from "../../context/UserContext";
 import { SendLoginCodeScreen } from "../Screens/SendLoginCodeScreen";
 import {
   VerificationCodeInfo,
@@ -22,7 +22,7 @@ export const LoginModal: VFC<LoginModalProps> = ({
   disableScrollLock = false,
   ...modalProps
 }) => {
-  const { user, setUser } = useContext(UserContext);
+  const { user, setUser } = useUser();
   const [currentPage, setCurrentPage] = useState<LoginModalPage>("Email");
 
   const [email, setEmail] = useState<string>();

--- a/site/src/components/Navbar.tsx
+++ b/site/src/components/Navbar.tsx
@@ -19,7 +19,7 @@ import { BlockProtocolLogoIcon } from "./SvgIcon/BlockProtocolLogoIcon";
 import { BoltIcon } from "./SvgIcon/BoltIcon";
 import { HOME_PAGE_HEADER_HEIGHT } from "../pages/index.page";
 import SiteMapContext from "../context/SiteMapContext";
-import UserContext from "../context/UserContext";
+import { useUser } from "../context/UserContext";
 import { AccountDropdown } from "./Navbar/AccountDropdown";
 import { MobileNavItems } from "./Navbar/MobileNavItems";
 import { itemIsPage, NAVBAR_LINK_ICONS } from "./Navbar/util";
@@ -91,7 +91,7 @@ export const Navbar: VFC<NavbarProps> = ({
   const theme = useTheme();
   const router = useRouter();
   const { pages } = useContext(SiteMapContext);
-  const { user } = useContext(UserContext);
+  const { user } = useUser();
 
   const [displayMobileNav, setDisplayMobileNav] = useState<boolean>(false);
   const [idleScrollPosition, setIdleScrollPosition] = useState<boolean>(false);
@@ -343,7 +343,7 @@ export const Navbar: VFC<NavbarProps> = ({
                       </Typography>
                     </Button>
                   )}
-                  {user?.isSignedUp ? null : (
+                  {user !== "loading" && !user?.isSignedUp ? (
                     <Link href="/docs/developing-blocks">
                       <Button
                         size="small"
@@ -355,7 +355,7 @@ export const Navbar: VFC<NavbarProps> = ({
                           : "Quick Start Guide"}
                       </Button>
                     </Link>
-                  )}
+                  ) : null}
                 </>
               ) : (
                 <IconButton
@@ -369,7 +369,7 @@ export const Navbar: VFC<NavbarProps> = ({
                   <Icon className="fas fa-bars" />
                 </IconButton>
               )}
-              {user?.isSignedUp ? <AccountDropdown /> : null}
+              <AccountDropdown />
             </Box>
           </Box>
           <Collapse in={displayBreadcrumbs}>

--- a/site/src/components/Navbar/AccountDropdown.tsx
+++ b/site/src/components/Navbar/AccountDropdown.tsx
@@ -1,14 +1,14 @@
-import { VFC, useState, useContext, useRef } from "react";
+import { VFC, useState, useRef } from "react";
 import { Box, Typography, ListItemButton, Divider } from "@mui/material";
 import { Link } from "../Link";
 import { Button } from "../Button";
-import UserContext from "../../context/UserContext";
+import { useUser } from "../../context/UserContext";
 import { apiClient } from "../../lib/apiClient";
 import { UserAvatar } from "../UserAvatar";
 import { Popover } from "../Popover";
 
 export const AccountDropdown: VFC = () => {
-  const { user, setUser } = useContext(UserContext);
+  const { user, setUser } = useUser();
 
   const buttonRef = useRef<HTMLButtonElement>(null);
 
@@ -28,7 +28,11 @@ export const AccountDropdown: VFC = () => {
     setUser(undefined);
   };
 
-  const { preferredName, shortname } = user || {};
+  if (user === "loading" || !user) {
+    return null;
+  }
+
+  const { preferredName, shortname } = user;
 
   const id = open ? "simple-popover" : undefined;
 
@@ -40,7 +44,7 @@ export const AccountDropdown: VFC = () => {
         onClick={handleClick}
         ref={buttonRef}
       >
-        <UserAvatar />
+        <UserAvatar user={user} />
       </Button>
       <Popover
         id={id}

--- a/site/src/components/Screens/CompleteSignupScreen.tsx
+++ b/site/src/components/Screens/CompleteSignupScreen.tsx
@@ -1,5 +1,5 @@
 import { Box, Icon, Typography } from "@mui/material";
-import { useContext, useRef, useState, VFC } from "react";
+import { useRef, useState, VFC } from "react";
 import { TextField } from "../TextField";
 import { Button } from "../Button";
 import { useShortnameTextField } from "../hooks/useShortnameTextField";
@@ -8,7 +8,7 @@ import {
   ApiCompleteSignupRequestBody,
   ApiCompleteSignupResponse,
 } from "../../pages/api/completeSignup.api";
-import UserContext from "../../context/UserContext";
+import { useUser } from "../../context/UserContext";
 
 type CompleteSignupScreenProps = {
   email: string;
@@ -17,7 +17,7 @@ type CompleteSignupScreenProps = {
 export const CompleteSignupScreen: VFC<CompleteSignupScreenProps> = ({
   email,
 }) => {
-  const { setUser } = useContext(UserContext);
+  const { setUser } = useUser();
 
   const shortnameInputRef = useRef<HTMLInputElement>(null);
   const preferredNameInputRef = useRef<HTMLInputElement>(null);

--- a/site/src/components/UserAvatar.tsx
+++ b/site/src/components/UserAvatar.tsx
@@ -1,10 +1,12 @@
-import { VFC, useContext } from "react";
+import { VFC } from "react";
 import { Box } from "@mui/material";
-import UserContext from "../context/UserContext";
+import { SerializedUser } from "../lib/model/user.model";
 
-export const UserAvatar: VFC = () => {
-  const { user } = useContext(UserContext);
+interface UserAvatarProps {
+  user: SerializedUser;
+}
 
+export const UserAvatar: VFC<UserAvatarProps> = ({ user }) => {
   const { preferredName } = user || {};
 
   return (

--- a/site/src/components/pages/authWall.tsx
+++ b/site/src/components/pages/authWall.tsx
@@ -1,0 +1,42 @@
+import { NextPage } from "next";
+import { useRouter } from "next/router";
+import { VoidFunctionComponent } from "react";
+import { useUser } from "../../context/UserContext";
+import { SerializedUser } from "../../lib/model/user.model";
+
+export interface AuthWallPageContentProps {
+  user: SerializedUser;
+}
+
+export type AuthWallPageContent =
+  VoidFunctionComponent<AuthWallPageContentProps>;
+
+const AuthWallWrapper: VoidFunctionComponent<{
+  Content: AuthWallPageContent;
+}> = ({ Content }) => {
+  const router = useRouter();
+  const { user } = useUser();
+
+  if (user === "loading" || !process.browser) {
+    return null;
+  }
+
+  if (!user) {
+    void router.push("/");
+    return null;
+  }
+
+  return <Content user={user} />;
+};
+
+/**
+ * We don’t know if a user is logged in during server-side-rendering, but we want
+ * some pages to be available behind the auth wall. Once UserContext is populated
+ * with the result of /api/me, we want to redirect guest users from to /.
+ * use `withAuthWall` to enable this behavior.
+ *
+ * You can also get user object from Content props and thus avoid extra checks.
+ */
+export const withAuthWall = (Content: AuthWallPageContent): NextPage => {
+  return () => <AuthWallWrapper Content={Content} />;
+};

--- a/site/src/components/pages/authWall.tsx
+++ b/site/src/components/pages/authWall.tsx
@@ -21,7 +21,7 @@ const AuthWallWrapper: VoidFunctionComponent<{
     return null;
   }
 
-  if (!user) {
+  if (!user?.isSignedUp) {
     void router.push("/");
     return null;
   }

--- a/site/src/context/UserContext.ts
+++ b/site/src/context/UserContext.ts
@@ -1,16 +1,18 @@
-import { createContext, Dispatch, SetStateAction } from "react";
+import { createContext, Dispatch, SetStateAction, useContext } from "react";
 import { SerializedUser } from "../lib/model/user.model";
 
-type UserContextProps = {
-  user?: SerializedUser;
-  setUser: Dispatch<SetStateAction<SerializedUser | undefined>>;
+export type UserState = SerializedUser | "loading" | undefined;
+
+export type UserContextValue = {
+  user: UserState;
+  setUser: Dispatch<SetStateAction<UserState>>;
   refetch: () => void;
 };
 
-const UserContext = createContext<UserContextProps>({
+export const UserContext = createContext<UserContextValue>({
   user: undefined,
   setUser: () => undefined,
   refetch: () => undefined,
 });
 
-export default UserContext;
+export const useUser = () => useContext(UserContext);

--- a/site/src/pages/dashboard.page.tsx
+++ b/site/src/pages/dashboard.page.tsx
@@ -1,15 +1,15 @@
 import { Box, Container, Typography } from "@mui/material";
-import { useContext } from "react";
-import { NextPage } from "next";
 import Head from "next/head";
-import { useRouter } from "next/router";
 
 import {
   DashboardCard,
   DashboardCardProps,
 } from "../components/pages/dashboard/DashboardCard";
-import UserContext from "../context/UserContext";
 import { TopNavigationTabs } from "../components/pages/dashboard/TopNavigationTabs";
+import {
+  AuthWallPageContent,
+  withAuthWall,
+} from "../components/pages/authWall";
 
 const dashboardCardData: DashboardCardProps[] = [
   {
@@ -47,16 +47,7 @@ const dashboardCardData: DashboardCardProps[] = [
   },
 ];
 
-const DashboardPage: NextPage = () => {
-  const router = useRouter();
-
-  const { user } = useContext(UserContext);
-
-  if (process.browser && !user) {
-    void router.push("/");
-    return null;
-  }
-
+const Dashboard: AuthWallPageContent = ({ user }) => {
   const { preferredName: userName } = user ?? {};
 
   return (
@@ -133,4 +124,4 @@ const DashboardPage: NextPage = () => {
   );
 };
 
-export default DashboardPage;
+export default withAuthWall(Dashboard);

--- a/site/src/pages/login.page.tsx
+++ b/site/src/pages/login.page.tsx
@@ -1,13 +1,13 @@
 import { NextPage } from "next";
 import { useRouter } from "next/router";
-import { useEffect, useState, useMemo, useContext } from "react";
+import { useEffect, useState, useMemo } from "react";
 import { Paper, Box, Icon, Fade, Container } from "@mui/material";
 import { apiClient } from "../lib/apiClient";
 import { ApiLoginWithLoginCodeRequestBody } from "./api/loginWithLoginCode.api";
 import { Button } from "../components/Button";
 import { SendLoginCodeScreen } from "../components/Screens/SendLoginCodeScreen";
 import { SerializedUser } from "../lib/model/user.model";
-import UserContext from "../context/UserContext";
+import { useUser } from "../context/UserContext";
 import {
   VerificationCodeInfo,
   VerificationCodeScreen,
@@ -22,7 +22,7 @@ const toStringElseUndefined = (item: string | string[] | undefined) =>
   typeof item === "string" ? item : undefined;
 
 const LoginPage: NextPage = () => {
-  const { user, setUser } = useContext(UserContext);
+  const { user, setUser } = useUser();
   const router = useRouter();
 
   const parsedQuery = useMemo((): LoginPageParsedUrlQuery => {

--- a/site/src/pages/settings/api-keys.page.tsx
+++ b/site/src/pages/settings/api-keys.page.tsx
@@ -1,5 +1,4 @@
 import { Box, Container, Typography } from "@mui/material";
-import { NextPage } from "next";
 import Head from "next/head";
 import { useEffect, useMemo, useState } from "react";
 
@@ -13,8 +12,12 @@ import { apiClient } from "../../lib/apiClient";
 import { DateTimeCell } from "../../components/TableCells";
 import { Button } from "../../components/Button";
 import { TopNavigationTabs } from "../../components/pages/dashboard/TopNavigationTabs";
+import {
+  AuthWallPageContent,
+  withAuthWall,
+} from "../../components/pages/authWall";
 
-const DashboardPage: NextPage = () => {
+const ApiKeys: AuthWallPageContent = () => {
   const [activeApiKeys, setActiveApiKeys] = useState<
     UserFacingApiKeyProperties[]
   >([]);
@@ -201,4 +204,4 @@ const DashboardPage: NextPage = () => {
   );
 };
 
-export default DashboardPage;
+export default withAuthWall(ApiKeys);

--- a/site/src/pages/signup.page.tsx
+++ b/site/src/pages/signup.page.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import { useContext, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { NextPage } from "next";
 import { Box, Container, Paper, Fade, Icon, Typography } from "@mui/material";
 import { Button } from "../components/Button";
@@ -10,7 +10,7 @@ import {
 } from "../components/Screens/VerificationCodeScreen";
 import { SerializedUser } from "../lib/model/user.model";
 import { apiClient } from "../lib/apiClient";
-import UserContext from "../context/UserContext";
+import { useUser } from "../context/UserContext";
 import { ApiVerifyEmailRequestBody } from "./api/verifyEmail.api";
 import { CompleteSignupScreen } from "../components/Screens/CompleteSignupScreen";
 
@@ -45,7 +45,7 @@ const SignupPage: NextPage = () => {
     };
   }, [router]);
 
-  const { user, setUser } = useContext(UserContext);
+  const { user, setUser } = useUser();
   const [currentScreen, setCurrentScreen] = useState<SignupPageScreen>("Email");
 
   const [email, setEmail] = useState<string>();
@@ -75,7 +75,7 @@ const SignupPage: NextPage = () => {
   }, [parsedQuery, router]);
 
   useEffect(() => {
-    if (user) {
+    if (user && user !== "loading") {
       if (user.isSignedUp) {
         void router.push(redirectPath ?? "/");
       } else if (currentScreen !== "CompleteSignup") {


### PR DESCRIPTION
This reuses guest redirects in `/dashboard` in `/settings/api-keys`. To avoid repetition, I’ve introduced `withAuthWall`, which we can use onwards in the new pages.

To further reduce repetition, I have replaced `useContext(UserContext)` with `useUser()`, which is a common pattern in React hooks.

When looking at the original logic in `/dashboard`, I noticed a timing bug which was to do with the speed of `/auth/me`. If we rendered the dashboard before `fetch` was resolved, we ended up with an unwanted redirect for logged in users. This is fixed by adding `UserState = SerializedUser | "loading" | undefined`, which allows us to represent reality more accurately.

[Asana task](https://app.asana.com/0/1201095311341924/1201694916711161/f) _(internal link)_