### PR TITLE
[CHORE] Trigger rebuild of Header block

### DIFF
--- a/hub/@hash/header.json
+++ b/hub/@hash/header.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/hash.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2022-01-17T12:25:04.907Z"
+  "timestamp": "2022-01-25T16:00:20.578Z"
 }


### PR DESCRIPTION
The header block was updated in https://github.com/hashintel/hash/pull/194 in order to add variants, and we now need to update the version on the registry so that users can start using them. Merging this pull request should do that. 