### PR TITLE
[blockprotocol] Add a few missing fields to types

### DIFF
--- a/packages/block-template/package.json
+++ b/packages/block-template/package.json
@@ -29,7 +29,7 @@
     "schema": "typescript-json-schema tsconfig.json AppProps --required true --out dist/block-schema.json"
   },
   "dependencies": {
-    "blockprotocol": "0.0.4"
+    "blockprotocol": "0.0.5"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.0",

--- a/packages/blockprotocol/core.d.ts
+++ b/packages/blockprotocol/core.d.ts
@@ -153,12 +153,12 @@ export type BlockProtocolFileMediaType = "image" | "video";
 
 export type BlockProtocolUploadFileFunction = {
   (action: {
-    accountId?: string;
+    accountId?: string | null;
     file?: File | null;
     url?: string | null;
     mediaType: BlockProtocolFileMediaType;
   }): Promise<{
-    accountId?: string;
+    accountId?: string | null;
     entityId: string;
     url: string;
     mediaType: BlockProtocolFileMediaType;
@@ -168,7 +168,6 @@ export type BlockProtocolUploadFileFunction = {
 // ----------------------------- LINKS -------------------------------- //
 
 type SingleTargetLinkFields = {
-  destinationAccountId?: string | null;
   destinationEntityId: string;
   destinationEntityTypeId?: string | null;
   destinationEntityVersionId?: string | null;
@@ -184,6 +183,7 @@ export type BlockProtocolLink = {
   sourceEntityId: string;
   sourceEntityTypeId?: string | null;
   sourceEntityVersionId?: string | null;
+  destinationAccountId?: string | null;
   index?: number | null;
   path: string;
 } & (SingleTargetLinkFields | AggregationTargetLinkFields);
@@ -224,6 +224,8 @@ export type BlockProtocolCreateLinksFunction = {
 
 export type BlockProtocolUpdateLinkAction = {
   data: BlockProtocolLink;
+  sourceAccountId?: string | null;
+  sourceEntityId?: string | null;
   linkId: string;
 };
 
@@ -232,6 +234,8 @@ export type BlockProtocolUpdateLinksFunction = {
 };
 
 export type BlockProtocolDeleteLinksAction = {
+  sourceAccountId?: string | null;
+  sourceEntityId?: string | null;
   linkId: string;
 };
 
@@ -328,24 +332,24 @@ export type BlockProtocolFunction =
   | BlockProtocolUploadFileFunction;
 
 export type BlockProtocolFunctions = {
-  aggregateEntities: BlockProtocolAggregateEntitiesFunction;
-  createEntities: BlockProtocolCreateEntitiesFunction;
-  getEntities: BlockProtocolGetEntitiesFunction;
-  deleteEntities: BlockProtocolDeleteEntitiesFunction;
-  updateEntities: BlockProtocolUpdateEntitiesFunction;
+  aggregateEntities: BlockProtocolAggregateEntitiesFunction | undefined;
+  createEntities: BlockProtocolCreateEntitiesFunction | undefined;
+  getEntities: BlockProtocolGetEntitiesFunction | undefined;
+  deleteEntities: BlockProtocolDeleteEntitiesFunction | undefined;
+  updateEntities: BlockProtocolUpdateEntitiesFunction | undefined;
 
-  aggregateEntityTypes: BlockProtocolAggregateEntityTypesFunction;
-  createEntityTypes: BlockProtocolCreateEntityTypesFunction;
-  getEntityTypes: BlockProtocolGetEntityTypesFunction;
-  updateEntityTypes: BlockProtocolUpdateEntityTypesFunction;
-  deleteEntityTypes: BlockProtocolDeleteEntityTypesFunction;
+  aggregateEntityTypes: BlockProtocolAggregateEntityTypesFunction | undefined;
+  createEntityTypes: BlockProtocolCreateEntityTypesFunction | undefined;
+  getEntityTypes: BlockProtocolGetEntityTypesFunction | undefined;
+  updateEntityTypes: BlockProtocolUpdateEntityTypesFunction | undefined;
+  deleteEntityTypes: BlockProtocolDeleteEntityTypesFunction | undefined;
 
-  getLinks: BlockProtocolGetLinksFunction;
-  createLinks: BlockProtocolCreateLinksFunction;
-  deleteLinks: BlockProtocolDeleteLinksFunction;
-  updateLinks: BlockProtocolUpdateLinksFunction;
+  getLinks: BlockProtocolGetLinksFunction | undefined;
+  createLinks: BlockProtocolCreateLinksFunction | undefined;
+  deleteLinks: BlockProtocolDeleteLinksFunction | undefined;
+  updateLinks: BlockProtocolUpdateLinksFunction | undefined;
 
-  uploadFile: BlockProtocolUploadFileFunction;
+  uploadFile: BlockProtocolUploadFileFunction | undefined;
 };
 
 export type JSONValue =
@@ -366,7 +370,7 @@ export interface JSONArray extends Array<JSONValue> {}
  */
 export type BlockProtocolProps = {
   accountId?: string;
-  entityId?: string;
+  entityId: string;
   entityTypeId?: string;
   entityTypes?: BlockProtocolEntityType[];
   linkedAggregations?: BlockProtocolLinkedAggregation[];

--- a/packages/blockprotocol/package.json
+++ b/packages/blockprotocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockprotocol",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "TypeScript typings for https://blockprotocol.org developers",
   "keywords": [
     "blockprotocol",

--- a/site/package.json
+++ b/site/package.json
@@ -27,7 +27,7 @@
     "@twind/next": "1.0.8",
     "ajv": "^8.9.0",
     "axios": "^0.24.0",
-    "blockprotocol": "0.0.4",
+    "blockprotocol": "0.0.5",
     "clsx": "^1.1.1",
     "connect-mongo": "^4.6.0",
     "cookie-signature": "^1.1.0",

--- a/site/src/_pages/spec/1_block-types.mdx
+++ b/site/src/_pages/spec/1_block-types.mdx
@@ -393,12 +393,12 @@ In order to create a reference to a separate entity or entities as the desired v
     - `operation` – an aggregation operation which the embedding application should resolve the link to, following the structure of the `operation` object [described above](#aggregate-entities-operation).
 - MAY contain
 
+  - `destinationEntityAccountId?`: \[_string_]\[_optional_]: the `accountId` of the destination entity or account to aggregate entities from.
   - `sourceEntityVersionId?` \[_string_]\[_optional_]: optionally specify that this link is only from a specific version.
   - `sourceAccountId?`: \[_string_]\[_optional_]:: the `accountId` of the source entity.
   - `sourceEntityTypeId?`: \[_string_]\[_optional_]:: the `entityTypeId` of the source entity.
 
 - if `destinationEntityId` is defined, MAY contain:
-  - `destinationEntityAccountId?`: \[_string_]\[_optional_]: the `accountId` of the destination entity.
   - `destinationEntityVersionId:` \[_string_]\[_optional_]: to pin the link to a specific version of the destination entity.
   - `destinationEntityTypeId?`: \[_string_]\[_optional_]: the `entityTypeId` of the destination entity.
   - `index` \[_integer_]: the position of this link in a list (for where ordering of links is important).
@@ -502,6 +502,8 @@ deletes one or more links.
 
 **accepts:** a single _array_ of _objects_ (`DeleteLinksAction`), each with the following shape:
 
+- `sourceAccountId?` \[_string_]\[_optional_]: the `accountId` of the source entity.
+- `sourceEntityId` \[_string_]\[_optional_]: the `entityId` of the source entity.
 - `linkId` \[_string_]: the entity type to delete.
 
 ```block-function


### PR DESCRIPTION
Clean up a few things in the types:
- On links, move `destinationAccountId` from being for single link targets only to also being an optional field when defining a linked aggregation.
- Add optional `sourceAccountId` and `sourceEntityId` when identifying links (`linkId` might not be sufficient/unique)
- Make functions all optional (embedding apps may not provide them)