### PR TITLE
[FE] Remove max-width requirement from block

### DIFF
--- a/site/src/components/pages/hub/BlockDataContainer.tsx
+++ b/site/src/components/pages/hub/BlockDataContainer.tsx
@@ -152,7 +152,7 @@ export const BlockDataContainer: VoidFunctionComponent<
             }),
           }}
         >
-          <Box sx={{ height: 420, backgroundColor: "white" }}>
+          <Box sx={{ height: 450, backgroundColor: "white" }}>
             <Tabs
               TabIndicatorProps={{
                 style: { display: "none" },
@@ -190,7 +190,6 @@ export const BlockDataContainer: VoidFunctionComponent<
                 sx={{
                   height: "max-content",
                   minHeight: "100%",
-                  maxWidth: !isMobile ? "300px" : undefined,
                   mx: "auto",
                 }}
               >

--- a/site/src/components/pages/hub/BlockDataTabPanels.tsx
+++ b/site/src/components/pages/hub/BlockDataTabPanels.tsx
@@ -16,7 +16,7 @@ type BlockDataTabPanelProps = {
 export const BlockDataTabPanels: VoidFunctionComponent<
   BlockDataTabPanelProps
 > = ({ blockDataTab, schema, text, setText, modalOpen }) => {
-  const modalHeight = modalOpen ? "60vh" : 420;
+  const modalHeight = modalOpen ? "60vh" : 450;
 
   return (
     <>


### PR DESCRIPTION
This PR removes the max-width requirement from the `BlockDataContainer`, allowing blocks to take upto 90% of the available space instead. Additionally, the container height is increased to prevent overflow on blocks like the embed block.