### PR TITLE
[FE] Rebuild blocks on blockprotocol.org

### DIFF
--- a/hub/@hash/code.json
+++ b/hub/@hash/code.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/hash.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2022-01-17T12:25:04.907Z"
+  "timestamp": "2022-01-27T15:18:38.967Z"
 }

--- a/hub/@hash/divider.json
+++ b/hub/@hash/divider.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/hash.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2022-01-17T12:25:04.907Z"
+  "timestamp": "2022-01-27T15:18:38.967Z"
 }

--- a/hub/@hash/embed.json
+++ b/hub/@hash/embed.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/hash.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2022-01-17T12:25:04.907Z"
+  "timestamp": "2022-01-27T15:18:38.967Z"
 }

--- a/hub/@hash/image.json
+++ b/hub/@hash/image.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/hash.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2022-01-17T12:25:04.907Z"
+  "timestamp": "2022-01-27T15:18:38.967Z"
 }

--- a/hub/@hash/paragraph.json
+++ b/hub/@hash/paragraph.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/hash.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2022-01-17T12:25:04.907Z"
+  "timestamp": "2022-01-27T15:18:38.967Z"
 }

--- a/hub/@hash/person.json
+++ b/hub/@hash/person.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/hash.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2022-01-17T12:25:04.907Z"
+  "timestamp": "2022-01-27T15:18:38.967Z"
 }

--- a/hub/@hash/table.json
+++ b/hub/@hash/table.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/hash.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2022-01-17T12:25:04.907Z"
+  "timestamp": "2022-01-27T15:18:38.967Z"
 }

--- a/hub/@hash/video.json
+++ b/hub/@hash/video.json
@@ -3,5 +3,5 @@
   "repository": "https://github.com/hashintel/hash.git",
   "branch": "main",
   "distDir": "dist",
-  "timestamp": "2022-01-17T12:25:04.907Z"
+  "timestamp": "2022-01-27T15:18:38.967Z"
 }

--- a/site/src/components/pages/hub/BlockDataContainer.tsx
+++ b/site/src/components/pages/hub/BlockDataContainer.tsx
@@ -43,7 +43,6 @@ export const BlockDataContainer: VoidFunctionComponent<
   const [blockState, setBlockState] = useState<Record<string, unknown>>({
     accountId: "test-account-id",
     entityId: "test-entity-id",
-    initialWidth: 600,
   });
 
   const updateEntities: BlockProtocolUpdateEntitiesFunction = useCallback(

--- a/site/src/components/pages/hub/BlockDataContainer.tsx
+++ b/site/src/components/pages/hub/BlockDataContainer.tsx
@@ -43,6 +43,7 @@ export const BlockDataContainer: VoidFunctionComponent<
   const [blockState, setBlockState] = useState<Record<string, unknown>>({
     accountId: "test-account-id",
     entityId: "test-entity-id",
+    initialWidth: 300,
   });
 
   const updateEntities: BlockProtocolUpdateEntitiesFunction = useCallback(

--- a/site/src/components/pages/hub/BlockDataContainer.tsx
+++ b/site/src/components/pages/hub/BlockDataContainer.tsx
@@ -43,7 +43,7 @@ export const BlockDataContainer: VoidFunctionComponent<
   const [blockState, setBlockState] = useState<Record<string, unknown>>({
     accountId: "test-account-id",
     entityId: "test-entity-id",
-    initialWidth: 300,
+    initialWidth: 600,
   });
 
   const updateEntities: BlockProtocolUpdateEntitiesFunction = useCallback(


### PR DESCRIPTION
This PR is a follow-up to the previous PRs in the hash repo which add examples to various blocks: https://github.com/hashintel/hash/pull/239, https://github.com/hashintel/hash/pull/233 and https://github.com/hashintel/hash/pull/227. The timestamps inside of the block json files have been updated to cause a rebuild of the blocks and render the example.

`initialWidth` is also updated in a place to increase the width the HASH embed starts with.