### PR TITLE
[SITE] Fix API URL reaching client

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -19,7 +19,7 @@ The public-facing [blockprotocol.org](https://blockprotocol.org) website serves 
     - `MONGODB_DB_NAME`: the name of the database (for example `local`)
     - `MONGODB_USERNAME`: the database username
     - `MONGODB_PASSWORD`: the database password
-    - `FRONTEND_URL` (optional): the URL where the frontend is hosted (defaults to `http://localhost:3000`)
+    - `NEXT_PUBLIC_FRONTEND_URL` (optional): the URL where the frontend is hosted (defaults to `http://localhost:3000`)
 
     Example minimal file at `site/.env.local` (with **zero** security) to make local development work when following the instructions below:
 

--- a/site/src/lib/config.ts
+++ b/site/src/lib/config.ts
@@ -1,5 +1,5 @@
-export const FRONTEND_URL = process.env.FRONTEND_URL
-  ? process.env.FRONTEND_URL
+export const FRONTEND_URL = process.env.NEXT_PUBLIC_FRONTEND_URL
+  ? process.env.NEXT_PUBLIC_FRONTEND_URL
   : process.env.NEXT_PUBLIC_VERCEL_URL
   ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
   : "http://localhost:3000";


### PR DESCRIPTION
We have a variable, `FRONTEND_URL`, which determines various things including:
- cookie domain
- origin of links sent to users
- endpoint that the API client will call

The variable can be set via user-supplied environment variable, and falls back to the Vercel deployment origin if this isn't present. 

For the third use case, the variable needs to reach the client - this requires prefixing it with `NEXT_PUBLIC_`, which the PR does.