### PR TITLE
Fix block page when switching blocks or data source

### DIFF
--- a/packages/block-template/package.json
+++ b/packages/block-template/package.json
@@ -46,7 +46,7 @@
     "core-js": "^2.6.12",
     "cross-env": "^7.0.3",
     "html-webpack-plugin": "^4.5.2",
-    "mock-block-dock": "0.0.3",
+    "mock-block-dock": "0.0.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "regenerator-runtime": "^0.13.9",

--- a/packages/mock-block-dock/package.json
+++ b/packages/mock-block-dock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-block-dock",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A mock embedding application for Block Protocol blocks",
   "keywords": [
     "blockprotocol",

--- a/packages/mock-block-dock/src/MockBlockDock.tsx
+++ b/packages/mock-block-dock/src/MockBlockDock.tsx
@@ -63,9 +63,7 @@ export const MockBlockDock: VoidFunctionComponent<MockBlockDockProps> = ({
   const { accountId, entityId, entityTypeId } = latestBlockEntity;
   const { updateEntities } = functions;
 
-  const prevChildPropsString = useRef<ReactElement["props"]>(
-    JSON.stringify(children.props),
-  );
+  const prevChildPropsString = useRef<string>(JSON.stringify(children.props));
   useEffect(() => {
     if (JSON.stringify(children.props) !== prevChildPropsString.current) {
       updateEntities?.([

--- a/packages/mock-block-dock/src/MockBlockDock.tsx
+++ b/packages/mock-block-dock/src/MockBlockDock.tsx
@@ -2,7 +2,9 @@ import {
   Children,
   cloneElement,
   ReactElement,
+  useEffect,
   useMemo,
+  useRef,
   VoidFunctionComponent,
 } from "react";
 import { BlockProtocolEntity, BlockProtocolEntityType } from "blockprotocol";
@@ -51,14 +53,32 @@ export const MockBlockDock: VoidFunctionComponent<MockBlockDockProps> = ({
 
   const latestBlockEntity = useMemo(
     () =>
-      entities.find(
-        (entity) => entity.entityId === initialBlockEntity.entityId,
-      ),
-    [entities, initialBlockEntity.entityId],
+      entities.find((entity) => entity.entityId === children.props.entityId),
+    [entities, children.props.entityId],
   );
   if (!latestBlockEntity) {
     throw new Error("Cannot find block entity. Did it delete itself?");
   }
+
+  const { accountId, entityId, entityTypeId } = latestBlockEntity;
+  const { updateEntities } = functions;
+
+  const prevChildPropsString = useRef<ReactElement["props"]>(
+    JSON.stringify(children.props),
+  );
+  useEffect(() => {
+    if (JSON.stringify(children.props) !== prevChildPropsString.current) {
+      updateEntities?.([
+        {
+          accountId,
+          entityId,
+          entityTypeId,
+          ...children.props,
+        },
+      ]);
+    }
+    prevChildPropsString.current = JSON.stringify(children.props);
+  }, [accountId, entityId, entityTypeId, children.props, updateEntities]);
 
   const { linkGroups, linkedEntities } = useLinkFields({
     entities,

--- a/site/package.json
+++ b/site/package.json
@@ -47,7 +47,7 @@
     "jsonschema": "^1.4.0",
     "lodash": "4.17.21",
     "md5": "^2.3.0",
-    "mock-block-dock": "0.0.3",
+    "mock-block-dock": "0.0.4",
     "mongodb": "^4.2.2",
     "next": "11.1.3",
     "next-connect": "^0.11.0",

--- a/site/src/components/pages/hub/BlockDataContainer.tsx
+++ b/site/src/components/pages/hub/BlockDataContainer.tsx
@@ -62,14 +62,6 @@ export const BlockDataContainer: VoidFunctionComponent<
       getEmbedBlock,
     };
 
-    const blockFunctions: Record<string, (params: any) => unknown> = {
-      getEmbedBlock,
-    };
-
-    for (const functionName of Object.keys(blockFunctions)) {
-      result[functionName] = blockFunctions[functionName];
-    }
-
     try {
       Object.assign(result, JSON.parse(text));
     } catch (err) {

--- a/site/src/components/pages/hub/BlockDataContainer.tsx
+++ b/site/src/components/pages/hub/BlockDataContainer.tsx
@@ -1,6 +1,12 @@
 import { Box, Tabs, Tab, useTheme, useMediaQuery } from "@mui/material";
 import { Validator } from "jsonschema";
-import { useMemo, useState, VoidFunctionComponent } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  VoidFunctionComponent,
+} from "react";
 import { MockBlockDock } from "mock-block-dock";
 
 import { ExpandedBlockMetadata as BlockMetadata } from "../../../lib/blocks";
@@ -26,32 +32,46 @@ export const BlockDataContainer: VoidFunctionComponent<
   const [blockTab, setBlockTab] = useState(0);
   const [blockModalOpen, setBlockModalOpen] = useState(false);
 
-  const metadataExample = metadata.examples?.length
-    ? JSON.stringify(metadata.examples[0], null, 2)
-    : "{}";
+  const example = metadata.examples?.[0];
 
-  const [text, setText] = useState(metadataExample);
+  const [text, setText] = useState(
+    example ? JSON.stringify(example, undefined, 2) : "",
+  );
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
   const [activeMobileTab, setActiveMobileTab] = useState(0);
 
+  const prevPackage = useRef<string>(metadata.packagePath);
+  useEffect(() => {
+    if (prevPackage.current !== metadata.packagePath) {
+      // reset data source input when switching blocks
+      if (example) {
+        setText(JSON.stringify(example, undefined, 2));
+      } else {
+        setText("");
+      }
+    }
+    prevPackage.current = metadata.packagePath;
+  }, [example, metadata.packagePath, text]);
+
   /** used to recompute props and errors on dep changes (caching has no benefit here) */
   const [props, errors] = useMemo<[object | undefined, string[]]>(() => {
-    let result;
+    const result = {
+      accountId: "test-account-id",
+      entityId: "test-entity-id",
+      getEmbedBlock,
+    };
 
     const blockFunctions: Record<string, (params: any) => unknown> = {
       getEmbedBlock,
     };
 
-    try {
-      result = JSON.parse(text);
-      result.accountId = "test-account-id";
-      result.entityId = "test-entity-id";
-      result.getEmbedBlock = getEmbedBlock;
+    for (const functionName of Object.keys(blockFunctions)) {
+      result[functionName] = blockFunctions[functionName];
+    }
 
-      for (const functionName of Object.keys(blockFunctions)) {
-        result[functionName] = blockFunctions[functionName];
-      }
+    try {
+      Object.assign(result, JSON.parse(text));
     } catch (err) {
       return [result, [(err as Error).message]];
     }


### PR DESCRIPTION
There were a couple of bugs on the individual block pages which this PR fixes:
1. `MockBlockDock` was not set up for the block it's wrapping to receive new props after the first render - this meant that edits in the 'data source' input were not reflected in the block (you had to use the block's own editing functionality)
2. `BlockDataContainer` (the thing holding the blocks on their page) did not react to users navigating between blocks, e.g. via the carousel.

This PR fixes both of those things by tracking the previous value for (1) the wrapped block's props, and (2) the block being viewed, respectively.