### PR TITLE
Fix typo in "in progress" spec banner

### DIFF
--- a/site/src/pages/spec/[[...specSlug]].page.tsx
+++ b/site/src/pages/spec/[[...specSlug]].page.tsx
@@ -98,7 +98,7 @@ const GitHubInfoCard = (
         })}
         maxWidth="62ch"
       >
-        This specification is currently in progress. We’ve drafting it in public
+        This specification is currently in progress. We’re drafting it in public
         to gather feedback and improve the final document. If you have any
         suggestions or improvements you would like to add, or questions you
         would like to ask, feel free to submit a PR or open a discussion on{" "}


### PR DESCRIPTION
Fixes a one letter typo in the "in progress" banner at the top of the spec.