### PR TITLE
Fix page width overflow because of background animation

### DIFF
--- a/site/src/components/pages/home/Header/index.tsx
+++ b/site/src/components/pages/home/Header/index.tsx
@@ -202,6 +202,7 @@ export const Header = () => {
       <Box
         sx={{
           position: "absolute",
+          overflow: "hidden",
           top: 0,
           left: 0,
           right: 0,


### PR DESCRIPTION
**Before**

<img width="524" alt="Screenshot 2022-01-28 at 18 05 42" src="https://user-images.githubusercontent.com/608862/151599472-00893dd9-b5f5-4105-8c04-448d77a87114.png">

**After**

<img width="527" alt="Screenshot 2022-01-31 at 16 14 00" src="https://user-images.githubusercontent.com/608862/151830500-e1ad291e-71ba-4be4-a579-c74a8b6ed04b.png">

---

[Slack thread](https://hashintel.slack.com/archives/C02LG39FJAU/p1643305403659149) _(internal link)_

This change was originally implemented as part of https://github.com/blockprotocol/blockprotocol/pull/141, but I extracted it into a separate PR for fast tracking.