### PR TITLE
Run `yarn lint:dependency-version-consistency` in CI

### DIFF
--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -15,6 +15,18 @@ jobs:
 
       - run: yarn install
 
+      - name: Run yarn lint:dependency-version-consistency
+        if: ${{ success() || failure() }}
+        run: |
+          if ! yarn lint:dependency-version-consistency; then
+            echo ''
+            echo ''
+            echo 'ℹ️ ℹ️ ℹ️'
+            echo 'Try running `yarn fix:dependency-version-consistency` locally to apply autofixes.'
+            echo 'ℹ️ ℹ️ ℹ️'
+            exit 1
+          fi
+
       - name: Run yarn lint:eslint
         if: ${{ success() || failure() }}
         run: |


### PR DESCRIPTION
Follows #165

I thought I added the script to the yaml, but it was in another repo 😅