### PR TITLE
Replace `postinstall` with `prepare` in `mock-block-dock`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "dev": "yarn workspace @blockprotocol/site dev",
     "dev:seed-db": "yarn workspace @blockprotocol/site dev:seed-db",
     "dev:db": "yarn workspace @blockprotocol/site dev:db",
-    "postinstall": "patch-package",
-    "prepare": "husky install"
+    "prepare": "husky install && patch-package && yarn workspace mock-block-dock run prepare"
   },
   "lint-staged": {
     "**/*": [

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dev": "yarn workspace @blockprotocol/site dev",
     "dev:seed-db": "yarn workspace @blockprotocol/site dev:seed-db",
     "dev:db": "yarn workspace @blockprotocol/site dev:db",
-    "prepare": "husky install && patch-package && yarn workspace mock-block-dock run prepare"
+    "prepare": "patch-package && husky install && yarn workspace mock-block-dock run prepare"
   },
   "lint-staged": {
     "**/*": [

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dev": "yarn workspace @blockprotocol/site dev",
     "dev:seed-db": "yarn workspace @blockprotocol/site dev:seed-db",
     "dev:db": "yarn workspace @blockprotocol/site dev:db",
-    "prepare": "patch-package && husky install && yarn workspace mock-block-dock run prepare"
+    "prepare": "patch-package && husky install && yarn workspace mock-block-dock run prepare && yarn workspace @blockprotocol/site run prepare"
   },
   "lint-staged": {
     "**/*": [

--- a/packages/block-template/README.md
+++ b/packages/block-template/README.md
@@ -4,7 +4,7 @@
 
 See https://blockprotocol.org/docs/developing-blocks
 
-**TL;DR:** Run `npx create-block-app \[your-block-name\]`
+**TL;DR:** Run `npx create-block-app [your-block-name]`
 
 ## Step two: write and build a component
 

--- a/packages/block-template/package.json
+++ b/packages/block-template/package.json
@@ -46,7 +46,7 @@
     "core-js": "^2.6.12",
     "cross-env": "^7.0.3",
     "html-webpack-plugin": "^4.5.2",
-    "mock-block-dock": "0.0.5",
+    "mock-block-dock": "0.0.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "regenerator-runtime": "^0.13.9",

--- a/packages/block-template/package.json
+++ b/packages/block-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "block-template",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Block template",
   "keywords": [
     "blockprotocol",
@@ -46,7 +46,7 @@
     "core-js": "^2.6.12",
     "cross-env": "^7.0.3",
     "html-webpack-plugin": "^4.5.2",
-    "mock-block-dock": "0.0.4",
+    "mock-block-dock": "0.0.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "regenerator-runtime": "^0.13.9",

--- a/packages/mock-block-dock/package.json
+++ b/packages/mock-block-dock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-block-dock",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A mock embedding application for Block Protocol blocks",
   "keywords": [
     "blockprotocol",
@@ -31,8 +31,8 @@
     "build:esm": "tsc --p tsconfig.build.json",
     "clean": "rimraf ./dist/",
     "dev": "concurrently -n webpack,webpack-dev-server -c green,cyan \"yarn build:dev -- --watch --verbose\" \"yarn run-dev-server\"",
-    "postinstall": "yarn build",
     "lint:tsc": "tsc --noEmit",
+    "prepare": "yarn build",
     "run-dev-server": "cross-env NODE_ENV=development webpack-dev-server -d --port 9090 --open --config dev/webpack.config.js"
   },
   "dependencies": {

--- a/packages/mock-block-dock/package.json
+++ b/packages/mock-block-dock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mock-block-dock",
-  "version": "0.0.5",
+  "version": "0.0.4",
   "description": "A mock embedding application for Block Protocol blocks",
   "keywords": [
     "blockprotocol",

--- a/site/package.json
+++ b/site/package.json
@@ -13,8 +13,8 @@
     "dev:seed-db": "node --max-old-space-size=2048 node_modules/.bin/ts-node --files --project tsconfig.json scripts/seed-db",
     "generate-blocks-data": "node --max-old-space-size=2048 node_modules/.bin/ts-node --files --project tsconfig.json scripts/generate-blocks-data",
     "generate-sitemap": "node --max-old-space-size=2048 node_modules/.bin/ts-node --files --project tsconfig.json scripts/generate-sitemap",
-    "postinstall": "patch-package && yarn generate-sitemap && yarn generate-blocks-data",
     "lint:tsc": "tsc --noEmit",
+    "prepare": "patch-package && yarn generate-sitemap && yarn generate-blocks-data",
     "start": "next start"
   },
   "dependencies": {


### PR DESCRIPTION
This PR should fix #161.

Unlike `postinstall`, `prepare` only runs in development. See https://docs.npmjs.com/cli/v8/using-npm/scripts.

Unfortunately, Yarn [does not automatically run `prepare` in workspaces](https://github.com/yarnpkg/yarn/issues/3911). We cannot use `yarn workspaces run prepare`, but that would require dummy `prepare` scripts in all packages. Alternatively, we can `yarn lerna run prepare`, but it [has not been maintained](https://github.com/lerna/lerna/issues/2703) for some time.

To keep this PR small, I am running `yarn workspace mock-block-dock run prepare` in top-level `package.json` → `prepare`. We can change the approach later, but it should be good enough for now 🙂

Depending on how our repo setup evolves, we might want to replace `prepare` with `prepublishOnly`. For example, if we use Turborepo, `yarn build` can be placed into a DAG before `yarn lint` etc. This will make `yarn install` a bit faster.