### PR TITLE
Smoke-test npm packages

### DIFF
--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -116,6 +116,9 @@ jobs:
   packages:
     name: NPM Packages
     runs-on: ubuntu-20.04
+    env:
+      BLOCK_NAME: test-block
+      BLOCK_DIR_PATH: ~/test-block
 
     steps:
       - uses: actions/checkout@v2
@@ -148,3 +151,10 @@ jobs:
         run: |
           docker logs verdaccio
           docker stop verdaccio
+
+      - name: "Upload block"
+        uses: actions/upload-artifact@v2
+        if: ${{ success() || failure() }}
+        with:
+          name: blocks/${{ BLOCK_NAME }}
+          path: ${{ env.BLOCK_DIR_PATH }}

--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -152,7 +152,7 @@ jobs:
           docker logs verdaccio
           docker stop verdaccio
 
-      - name: "Upload generated block folder as artifact for inspection"
+      - name: Upload block folder as artifact
         uses: actions/upload-artifact@v2
         if: ${{ success() || failure() }}
         with:

--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -156,5 +156,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: ${{ success() || failure() }}
         with:
-          name: blocks/${{ env.BLOCK_NAME }}
-          path: ${{ env.BLOCK_DIR_PATH }}
+          name: ${{ env.BLOCK_NAME }}
+          path: |
+            ${{ env.BLOCK_DIR_PATH }}
+            !${{ env.BLOCK_DIR_PATH }}/node_modules/**

--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -112,3 +112,39 @@ jobs:
             echo 'ℹ️ ℹ️ ℹ️'
             exit 1;
           fi
+
+  packages:
+    name: NPM Packages
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: yarn
+
+      - run: yarn install
+
+      - name: Run local registry
+        run: |
+          docker pull verdaccio/verdaccio
+          docker run -it --detach --rm --name verdaccio -p 4873:4873  verdaccio/verdaccio
+          yarn wait-on --timeout 30000 http://localhost:4873
+
+      - name: Publish NPM packages to local registry
+        run: |
+          yarn exe scripts/packages/mock-publish-to-local-registry.ts
+
+      - name: Smoke-test create-block-app
+        run: |
+          yarn exe scripts/packages/smoke-test-create-block-app.ts
+        env:
+          NPM_CONFIG_REGISTRY: http://localhost:4873
+
+      - name: Show local registry logs and stop it
+        if: ${{ success() || failure() }}
+        run: |
+          docker logs verdaccio
+          docker stop verdaccio

--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -137,12 +137,10 @@ jobs:
           yarn wait-on --timeout 30000 http://localhost:4873
 
       - name: Publish NPM packages to local registry
-        run: |
-          yarn exe scripts/packages/publish-to-local-registry.ts
+        run: yarn exe scripts/packages/publish-to-local-registry.ts
 
       - name: Smoke-test create-block-app
-        run: |
-          yarn exe scripts/packages/smoke-test-create-block-app.ts
+        run: yarn exe scripts/packages/smoke-test-create-block-app.ts
         env:
           NPM_CONFIG_REGISTRY: http://localhost:4873
 

--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -156,5 +156,5 @@ jobs:
         uses: actions/upload-artifact@v2
         if: ${{ success() || failure() }}
         with:
-          name: blocks/${{ BLOCK_NAME }}
+          name: blocks/${{ env.BLOCK_NAME }}
           path: ${{ env.BLOCK_DIR_PATH }}

--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -138,7 +138,7 @@ jobs:
 
       - name: Publish NPM packages to local registry
         run: |
-          yarn exe scripts/packages/mock-publish-to-local-registry.ts
+          yarn exe scripts/packages/publish-to-local-registry.ts
 
       - name: Smoke-test create-block-app
         run: |

--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -152,7 +152,7 @@ jobs:
           docker logs verdaccio
           docker stop verdaccio
 
-      - name: "Upload block"
+      - name: "Upload generated block folder as artifact for inspection"
         uses: actions/upload-artifact@v2
         if: ${{ success() || failure() }}
         with:

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -2,6 +2,6 @@
 . "$(dirname "$0")/_/husky.sh"
 
 ## This hook was disabled in https://github.com/blockprotocol/blockprotocol/pull/184
-## @todo: Revert when whe cleanup `prepare` script in `package.json`
+## @todo: Revert when we cleanup `prepare` script in `package.json`
 
 # yarn install

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "sleep-promise": "^9.1.0",
     "suppress-exit-code": "1.0.0",
     "tmp-promise": "^3.0.3",
+    "tree-kill": "^1.2.2",
     "ts-node": "^10.4.0",
     "uuid": "^8.3.2",
     "wait-on": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "tmp-promise": "^3.0.3",
     "tree-kill": "^1.2.2",
     "ts-node": "^10.4.0",
+    "untildify": "4.0.0",
     "uuid": "^8.3.2",
     "wait-on": "^6.0.0",
     "yarn-deduplicate": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@swc/core": "^1.2.135",
     "@swc/helpers": "^0.3.2",
+    "@types/wait-on": "^5.3.1",
     "@typescript-eslint/eslint-plugin": "4.29.0",
     "@typescript-eslint/parser": "4.29.0",
     "algoliasearch": "^4.12.0",
@@ -50,6 +51,7 @@
     "eslint-plugin-no-restricted-imports": "0.0.0",
     "eslint-plugin-react": "^7.25.1",
     "eslint-plugin-react-hooks": "4.2.0",
+    "execa": "^5.1.1",
     "gray-matter": "^4.0.3",
     "husky": "^7.0.4",
     "lint-staged": "^12.1.2",
@@ -60,9 +62,12 @@
     "prettier-plugin-packagejson": "2.2.13",
     "prettier-plugin-sh": "0.7.1",
     "regenerator-runtime": "^0.13.9",
+    "sleep-promise": "^9.1.0",
     "suppress-exit-code": "1.0.0",
+    "tmp-promise": "^3.0.3",
     "ts-node": "^10.4.0",
     "uuid": "^8.3.2",
+    "wait-on": "^6.0.0",
     "yarn-deduplicate": "^3.1.0"
   }
 }

--- a/packages/block-template/package.json
+++ b/packages/block-template/package.json
@@ -25,7 +25,7 @@
     "clean": "rimraf ./dist/",
     "dev": "concurrently -n webpack,webpack-dev-server -c green,cyan \"yarn build:dev -- --watch --verbose\" \"yarn run-dev-server\"",
     "lint:tsc": "tsc --noEmit",
-    "run-dev-server": "cross-env NODE_ENV=development webpack-dev-server -d --port 9090 --config webpack-dev-server.config.js --open",
+    "run-dev-server": "cross-env NODE_ENV=development webpack-dev-server -d --port 9090 --config webpack-dev-server.config.js",
     "schema": "typescript-json-schema tsconfig.json AppProps --required true --out dist/block-schema.json"
   },
   "dependencies": {

--- a/packages/block-template/webpack-dev-server.config.js
+++ b/packages/block-template/webpack-dev-server.config.js
@@ -20,7 +20,6 @@ module.exports = {
   devServer: {
     hot: true,
     contentBase: __dirname,
-    open: process.env.BROWSER !== "none",
     headers: {
       "Access-Control-Allow-Origin": "*",
       "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",
@@ -32,6 +31,7 @@ module.exports = {
         "sentry-trace",
       ],
     },
+    open: process.env.BROWSER !== "none",
   },
   resolve: {
     extensions: [

--- a/packages/block-template/webpack-dev-server.config.js
+++ b/packages/block-template/webpack-dev-server.config.js
@@ -20,6 +20,7 @@ module.exports = {
   devServer: {
     hot: true,
     contentBase: __dirname,
+    open: process.env.BROWSER !== "none",
     headers: {
       "Access-Control-Allow-Origin": "*",
       "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",

--- a/packages/create-block-app/create-block-app.js
+++ b/packages/create-block-app/create-block-app.js
@@ -7,6 +7,7 @@ const child_process = require("child_process");
 const fs = require("fs");
 const pacote = require("pacote");
 const path = require("path");
+const untildify = require("untildify");
 
 const exec = promisify(child_process.exec);
 
@@ -23,7 +24,7 @@ const templatePackageName = "block-template";
   // @todo: replace with `process.argv[3] ?? blockName` after upgrading ESLint
   const blockPath = process.argv[3] ? process.argv[3] : blockName;
 
-  const resolvedBlockPath = path.resolve(blockPath);
+  const resolvedBlockPath = path.resolve(untildify(blockPath));
 
   try {
     fs.statSync(resolvedBlockPath);

--- a/packages/create-block-app/create-block-app.js
+++ b/packages/create-block-app/create-block-app.js
@@ -72,6 +72,11 @@ const templatePackageName = "block-template";
 
   fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, undefined, 2));
 
+  console.log(`Testing testing (remove before merging)`);
+  console.log(`Testing testing (remove before merging)`);
+  console.log(`Testing testing (remove before merging)`);
+  console.log(`Testing testing (remove before merging)`);
+
   console.log(
     `Your ${blockName} block is ready to code in ${resolvedBlockPath}`,
   );

--- a/packages/create-block-app/create-block-app.js
+++ b/packages/create-block-app/create-block-app.js
@@ -37,7 +37,9 @@ const templatePackageName = "block-template";
 
   console.log("Downloading template...");
 
-  await pacote.extract(templatePackageName, resolvedBlockPath);
+  await pacote.extract(templatePackageName, resolvedBlockPath, {
+    registry: process.env.NPM_CONFIG_REGISTRY,
+  });
 
   console.log("Updating files...");
   try {

--- a/packages/create-block-app/create-block-app.js
+++ b/packages/create-block-app/create-block-app.js
@@ -7,7 +7,6 @@ const child_process = require("child_process");
 const fs = require("fs");
 const pacote = require("pacote");
 const path = require("path");
-const os = require("os");
 const untildify = require("untildify");
 
 const exec = promisify(child_process.exec);
@@ -26,17 +25,6 @@ const templatePackageName = "block-template";
   const blockPath = process.argv[3] ? process.argv[3] : blockName;
 
   const resolvedBlockPath = path.resolve(untildify(blockPath));
-
-  console.log("blockPath", JSON.stringify(blockPath));
-  console.log("untildify(blockPath)", JSON.stringify(untildify(blockPath)));
-  console.log("resolvedBlockPath", JSON.stringify(resolvedBlockPath));
-
-  console.log("~~~~~");
-  console.log("homedir");
-  console.log(os.homedir());
-  console.log("process.env keys");
-  console.log(Object.keys(process.env).join("\n"));
-  console.log("~~~~~");
 
   try {
     fs.statSync(resolvedBlockPath);
@@ -83,11 +71,6 @@ const templatePackageName = "block-template";
   }
 
   fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, undefined, 2));
-
-  console.log(`Testing testing (remove before merging)`);
-  console.log(`Testing testing (remove before merging)`);
-  console.log(`Testing testing (remove before merging)`);
-  console.log(`Testing testing (remove before merging)`);
 
   console.log(
     `Your ${blockName} block is ready to code in ${resolvedBlockPath}`,

--- a/packages/create-block-app/create-block-app.js
+++ b/packages/create-block-app/create-block-app.js
@@ -7,6 +7,7 @@ const child_process = require("child_process");
 const fs = require("fs");
 const pacote = require("pacote");
 const path = require("path");
+const os = require("os");
 const untildify = require("untildify");
 
 const exec = promisify(child_process.exec);
@@ -25,6 +26,17 @@ const templatePackageName = "block-template";
   const blockPath = process.argv[3] ? process.argv[3] : blockName;
 
   const resolvedBlockPath = path.resolve(untildify(blockPath));
+
+  console.log("blockPath", JSON.stringify(blockPath));
+  console.log("untildify(blockPath)", JSON.stringify(untildify(blockPath)));
+  console.log("resolvedBlockPath", JSON.stringify(resolvedBlockPath));
+
+  console.log("~~~~~");
+  console.log("homedir");
+  console.log(os.homedir());
+  console.log("process.env keys");
+  console.log(Object.keys(process.env).join("\n"));
+  console.log("~~~~~");
 
   try {
     fs.statSync(resolvedBlockPath);

--- a/packages/create-block-app/package.json
+++ b/packages/create-block-app/package.json
@@ -24,7 +24,8 @@
     "lint:tsc": "echo \"Skipping: TypeScript not configured\""
   },
   "dependencies": {
-    "pacote": "12.0.2"
+    "pacote": "12.0.2",
+    "untildify": "4.0.0"
   },
   "devDependencies": {
     "@types/pacote": "11.1.3"

--- a/packages/mock-block-dock/dev/webpack.config.js
+++ b/packages/mock-block-dock/dev/webpack.config.js
@@ -39,6 +39,7 @@ module.exports = {
         "sentry-trace",
       ],
     },
+    open: process.env.BROWSER !== "none",
   },
   resolve: {
     extensions: [

--- a/packages/mock-block-dock/package.json
+++ b/packages/mock-block-dock/package.json
@@ -33,7 +33,7 @@
     "dev": "concurrently -n webpack,webpack-dev-server -c green,cyan \"yarn build:dev -- --watch --verbose\" \"yarn run-dev-server\"",
     "lint:tsc": "tsc --noEmit",
     "prepare": "yarn build",
-    "run-dev-server": "cross-env NODE_ENV=development webpack-dev-server -d --port 9090 --open --config dev/webpack.config.js"
+    "run-dev-server": "cross-env NODE_ENV=development webpack-dev-server -d --port 9090 --config dev/webpack.config.js"
   },
   "dependencies": {
     "blockprotocol": "0.0.6",

--- a/scripts/packages/mock-publish-to-local-registry.ts
+++ b/scripts/packages/mock-publish-to-local-registry.ts
@@ -1,0 +1,55 @@
+import execa from "execa";
+import sleep from "sleep-promise";
+import path from "path";
+
+// These variables are hardcoded on purpose. We don’t want to accidentally push to a real registry.
+const npmRegistry = "http://localhost:4873";
+const npmUserAndPassword = "verdaccio";
+const npmEmail = "verdaccio@example.com";
+
+const packageNames = ["blockprotocol", "block-template", "create-block-app"];
+
+const defaultExecaOptions = {
+  env: {
+    NODE_ENV: "development",
+    NPM_CONFIG_REGISTRY: npmRegistry,
+    PATH: process.env.PATH,
+  },
+  extendEnv: false,
+  stdio: "inherit",
+} as const;
+
+const script = async () => {
+  // Login
+  const addUserProcess = execa("npm", ["adduser"], {
+    ...defaultExecaOptions,
+    stdio: undefined,
+    stdout: "inherit",
+  });
+
+  // Execa does not support multiple prompts, so using sleep to enter credentials
+  // https://github.com/sindresorhus/execa/issues/418
+  await sleep(500);
+  addUserProcess.stdin?.write(`${npmUserAndPassword}\n`);
+  await sleep(500);
+  addUserProcess.stdin?.write(`${npmUserAndPassword}\n`);
+  await sleep(500);
+  addUserProcess.stdin?.write(`${npmEmail}\n`);
+  await addUserProcess;
+
+  for (const packageName of packageNames) {
+    const packageDirPath = path.resolve(`packages/${packageName}`);
+    await execa("npm", ["unpublish", "--force"], {
+      ...defaultExecaOptions,
+      cwd: packageDirPath,
+      reject: false,
+    });
+
+    await execa("npm", ["publish", "--force"], {
+      ...defaultExecaOptions,
+      cwd: packageDirPath,
+    });
+  }
+};
+
+void script();

--- a/scripts/packages/publish-to-local-registry.ts
+++ b/scripts/packages/publish-to-local-registry.ts
@@ -17,11 +17,9 @@ const packageNames = [
 
 const defaultExecaOptions = {
   env: {
-    HOME: process.env.HOME,
     NODE_ENV: "development",
     NPM_CONFIG_REGISTRY: npmRegistry,
     PATH: process.env.PATH,
-    USERPROFILE: process.env.USERPROFILE,
   },
   extendEnv: false,
   stdio: "inherit",

--- a/scripts/packages/publish-to-local-registry.ts
+++ b/scripts/packages/publish-to-local-registry.ts
@@ -17,9 +17,11 @@ const packageNames = [
 
 const defaultExecaOptions = {
   env: {
+    HOME: process.env.HOME,
     NODE_ENV: "development",
     NPM_CONFIG_REGISTRY: npmRegistry,
     PATH: process.env.PATH,
+    USERPROFILE: process.env.USERPROFILE,
   },
   extendEnv: false,
   stdio: "inherit",

--- a/scripts/packages/publish-to-local-registry.ts
+++ b/scripts/packages/publish-to-local-registry.ts
@@ -29,9 +29,12 @@ const defaultExecaOptions = {
 } as const;
 
 const script = async () => {
+  console.log("~~~~~");
   console.log("homedir");
   console.log(os.homedir());
-  console.log("homedir");
+  console.log("process.env keys");
+  console.log(Object.keys(process.env).join("\n"));
+  console.log("~~~~~");
 
   logStepStart("Login into local registry");
 

--- a/scripts/packages/publish-to-local-registry.ts
+++ b/scripts/packages/publish-to-local-registry.ts
@@ -1,10 +1,9 @@
 import execa from "execa";
 import sleep from "sleep-promise";
 import path from "path";
-import os from "os";
 import { logStepEnd, logStepStart } from "../shared/logging";
 
-// These variables are hardcoded on purpose. We don’t want to accidentally push to a real registry.
+// These variables are hardcoded on purpose. We don’t want to publish to a real registry by mistake.
 const npmRegistry = "http://localhost:4873";
 const npmUserAndPassword = "verdaccio";
 const npmEmail = "verdaccio@example.com";
@@ -29,13 +28,6 @@ const defaultExecaOptions = {
 } as const;
 
 const script = async () => {
-  console.log("~~~~~");
-  console.log("homedir");
-  console.log(os.homedir());
-  console.log("process.env keys");
-  console.log(Object.keys(process.env).join("\n"));
-  console.log("~~~~~");
-
   logStepStart("Login into local registry");
 
   const addUserProcess = execa("npm", ["adduser"], {

--- a/scripts/packages/publish-to-local-registry.ts
+++ b/scripts/packages/publish-to-local-registry.ts
@@ -1,6 +1,7 @@
 import execa from "execa";
 import sleep from "sleep-promise";
 import path from "path";
+import os from "os";
 import { logStepEnd, logStepStart } from "../shared/logging";
 
 // These variables are hardcoded on purpose. We don’t want to accidentally push to a real registry.
@@ -28,6 +29,10 @@ const defaultExecaOptions = {
 } as const;
 
 const script = async () => {
+  console.log("homedir");
+  console.log(os.homedir());
+  console.log("homedir");
+
   logStepStart("Login into local registry");
 
   const addUserProcess = execa("npm", ["adduser"], {

--- a/scripts/packages/publish-to-local-registry.ts
+++ b/scripts/packages/publish-to-local-registry.ts
@@ -28,6 +28,12 @@ const defaultExecaOptions = {
 const script = async () => {
   logStepStart("Login into local registry");
 
+  if (!npmRegistry.includes("localhost")) {
+    throw new Error(
+      "This script runs `npm unpublish` which can harm published packages. Please make sure `npmRegistry` value includes `localhost`.",
+    );
+  }
+
   const addUserProcess = execa("npm", ["adduser"], {
     ...defaultExecaOptions,
     stdio: undefined,

--- a/scripts/packages/smoke-test-create-block-app.ts
+++ b/scripts/packages/smoke-test-create-block-app.ts
@@ -42,7 +42,7 @@ const script = async () => {
 
       devProcess.kill("SIGINT");
 
-      await execa("npm", ["run", "lint:tsc"]);
+      await execa("npm", ["run", "lint:tsc"], execaOptionsInBlockDir);
 
       await execa("npm", ["run", "build"], execaOptionsInBlockDir);
     },

--- a/scripts/packages/smoke-test-create-block-app.ts
+++ b/scripts/packages/smoke-test-create-block-app.ts
@@ -12,7 +12,7 @@ import { logStepStart, logStepEnd } from "../shared/logging";
  * Calling `execa.kill()` does not terminate processes recursively on Ubuntu.
  * Using `killProcessTree` helps avoid hanging processes.
  *
- * Anonymous function is use inside promisify because promisify(treeKill)
+ * Anonymous function is used inside promisify because promisify(treeKill)
  * produces incomplete typings.
  *
  * @see https://github.com/sindresorhus/execa/issues/96
@@ -81,7 +81,7 @@ const script = async () => {
       ...execaOptionsInBlockDir,
       env: {
         ...execaOptionsInBlockDir.env,
-        BROWSER: "none", // Blocks browser tab creation during local runs
+        BROWSER: "none", // Disable browser tab opening
       },
     });
 
@@ -101,7 +101,7 @@ const script = async () => {
 
     logStepEnd();
   } finally {
-    void tmpDir?.cleanup();
+    await tmpDir?.cleanup();
   }
 };
 

--- a/scripts/packages/smoke-test-create-block-app.ts
+++ b/scripts/packages/smoke-test-create-block-app.ts
@@ -1,0 +1,53 @@
+import execa from "execa";
+import path from "path";
+import tmp from "tmp-promise";
+import waitOn from "wait-on";
+
+const blockName = "test-block";
+
+const defaultExecaOptions = {
+  env: {
+    NODE_ENV: "development",
+    NPM_CONFIG_REGISTRY: process.env.NPM_CONFIG_REGISTRY,
+    PATH: process.env.PATH,
+  },
+  extendEnv: false,
+  stdio: "inherit",
+} as const;
+
+const script = async () => {
+  await tmp.withDir(
+    async ({ path: tempDirPath }) => {
+      await execa("npx", ["create-block-app", blockName], {
+        ...defaultExecaOptions,
+        cwd: tempDirPath,
+      });
+
+      const execaOptionsInBlockDir = {
+        ...defaultExecaOptions,
+        cwd: path.resolve(tempDirPath, blockName),
+      };
+
+      await execa("npm", ["install"], execaOptionsInBlockDir);
+
+      const devProcess = execa("npm", ["run", "dev"], {
+        ...execaOptionsInBlockDir,
+        env: {
+          ...execaOptionsInBlockDir.env,
+          BROWSER: "none", // Blocks browser tab creation during local runs
+        },
+      });
+
+      await waitOn({ resources: ["http://localhost:9090"], timeout: 10000 });
+
+      devProcess.kill("SIGINT");
+
+      await execa("npm", ["run", "lint:tsc"]);
+
+      await execa("npm", ["run", "build"], execaOptionsInBlockDir);
+    },
+    { unsafeCleanup: true },
+  );
+};
+
+void script();

--- a/scripts/packages/smoke-test-create-block-app.ts
+++ b/scripts/packages/smoke-test-create-block-app.ts
@@ -1,8 +1,14 @@
 import execa from "execa";
 import path from "path";
-import sleep from "sleep-promise";
+// import sleep from "sleep-promise";
 import tmp from "tmp-promise";
 import waitOn from "wait-on";
+import treeKillWillCallback from "tree-kill";
+import { promisify } from "util";
+
+const treeKill = promisify((pid: number, sig: string, callback: () => void) =>
+  treeKillWillCallback(pid, sig, callback),
+);
 
 const blockName = "test-block";
 
@@ -42,12 +48,13 @@ const script = async () => {
       await waitOn({ resources: ["http://localhost:9090"], timeout: 10000 });
 
       console.log("===== before kill");
-      devProcess.kill("SIGINT");
-      console.log("===== after kill");
-      await Promise.any([devProcess, sleep(10000)]);
-      if (!devProcess.killed) {
-        devProcess.kill("SIGKILL");
-      }
+      await treeKill(devProcess.pid!, "SIGINT");
+      // devProcess.kill("SIGINT");
+      // console.log("===== after kill");
+      // await Promise.any([devProcess, sleep(10000)]);
+      // if (!devProcess.killed) {
+      //   devProcess.kill("SIGKILL");
+      // }
       console.log("===== after kill await");
 
       await execa("npm", ["run", "lint:tsc"], execaOptionsInBlockDir);

--- a/scripts/packages/smoke-test-create-block-app.ts
+++ b/scripts/packages/smoke-test-create-block-app.ts
@@ -40,11 +40,17 @@ const script = async () => {
 
       await waitOn({ resources: ["http://localhost:9090"], timeout: 10000 });
 
+      console.log("===== before kill");
       devProcess.kill("SIGINT");
+      console.log("===== after kill");
+      await devProcess;
+      console.log("===== after kill await");
 
       await execa("npm", ["run", "lint:tsc"], execaOptionsInBlockDir);
+      console.log("===== after tsc");
 
       await execa("npm", ["run", "build"], execaOptionsInBlockDir);
+      console.log("===== after build");
     },
     { unsafeCleanup: true },
   );

--- a/scripts/packages/smoke-test-create-block-app.ts
+++ b/scripts/packages/smoke-test-create-block-app.ts
@@ -25,9 +25,11 @@ const killProcessTree = promisify(
 
 const defaultExecaOptions = {
   env: {
+    HOME: process.env.HOME,
     NODE_ENV: "development",
     NPM_CONFIG_REGISTRY: process.env.NPM_CONFIG_REGISTRY,
     PATH: process.env.PATH,
+    USERPROFILE: process.env.USERPROFILE,
   },
   extendEnv: false,
   stdio: "inherit",

--- a/scripts/packages/smoke-test-create-block-app.ts
+++ b/scripts/packages/smoke-test-create-block-app.ts
@@ -25,11 +25,9 @@ const killProcessTree = promisify(
 
 const defaultExecaOptions = {
   env: {
-    HOME: process.env.HOME,
     NODE_ENV: "development",
     NPM_CONFIG_REGISTRY: process.env.NPM_CONFIG_REGISTRY,
     PATH: process.env.PATH,
-    USERPROFILE: process.env.USERPROFILE,
   },
   extendEnv: false,
   stdio: "inherit",

--- a/scripts/packages/smoke-test-create-block-app.ts
+++ b/scripts/packages/smoke-test-create-block-app.ts
@@ -45,7 +45,7 @@ const script = async () => {
 
   const resolvedBlockDirPath = tmpDir
     ? path.resolve(tmpDir?.path, blockName)
-    : path.resolve(userDefinedBlockDirPath!);
+    : userDefinedBlockDirPath!;
 
   const fileNames =
     (await fs.readdir(resolvedBlockDirPath).catch(() => {})) ?? [];

--- a/scripts/packages/smoke-test-create-block-app.ts
+++ b/scripts/packages/smoke-test-create-block-app.ts
@@ -1,5 +1,6 @@
 import execa from "execa";
 import path from "path";
+import sleep from "sleep-promise";
 import tmp from "tmp-promise";
 import waitOn from "wait-on";
 
@@ -43,7 +44,10 @@ const script = async () => {
       console.log("===== before kill");
       devProcess.kill("SIGINT");
       console.log("===== after kill");
-      await devProcess;
+      await Promise.any([devProcess, sleep(10000)]);
+      if (!devProcess.killed) {
+        devProcess.kill("SIGKILL");
+      }
       console.log("===== after kill await");
 
       await execa("npm", ["run", "lint:tsc"], execaOptionsInBlockDir);

--- a/scripts/shared/logging.ts
+++ b/scripts/shared/logging.ts
@@ -1,12 +1,12 @@
 let currentMarkEndOfPhase: (() => void) | undefined = undefined;
 
 export const logStepStart = (phaseName: string) => {
-  console.log();
+  console.log("");
   console.log("=".repeat(phaseName.length));
   console.log(phaseName);
   console.log("=".repeat(phaseName.length));
   console.log("↓".repeat(phaseName.length));
-  console.log();
+  console.log("");
 
   const startTime = Date.now();
 
@@ -16,12 +16,12 @@ export const logStepStart = (phaseName: string) => {
     const doneMessage = `Done in ${Math.round(
       (endTime - startTime) / 1000,
     )} s.`;
-    console.log();
+    console.log("");
     console.log("↑".repeat(doneMessage.length));
     console.log("=".repeat(doneMessage.length));
     console.log(doneMessage);
     console.log("=".repeat(doneMessage.length));
-    console.log();
+    console.log("");
   };
 };
 

--- a/scripts/shared/logging.ts
+++ b/scripts/shared/logging.ts
@@ -1,0 +1,30 @@
+let currentMarkEndOfPhase: (() => void) | undefined = undefined;
+
+export const logStepStart = (phaseName: string) => {
+  console.log();
+  console.log("=".repeat(phaseName.length));
+  console.log(phaseName);
+  console.log("=".repeat(phaseName.length));
+  console.log("↓".repeat(phaseName.length));
+  console.log();
+
+  const startTime = Date.now();
+
+  currentMarkEndOfPhase = () => {
+    const endTime = Date.now();
+
+    const doneMessage = `Done in ${Math.round(
+      (endTime - startTime) / 1000,
+    )} s.`;
+    console.log();
+    console.log("↑".repeat(doneMessage.length));
+    console.log("=".repeat(doneMessage.length));
+    console.log(doneMessage);
+    console.log("=".repeat(doneMessage.length));
+    console.log();
+  };
+};
+
+export const logStepEnd = () => {
+  currentMarkEndOfPhase?.();
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1929,10 +1929,17 @@
   dependencies:
     "@hapi/hoek" "9.x.x"
 
-"@hapi/hoek@9.x.x":
+"@hapi/hoek@9.x.x", "@hapi/hoek@^9.0.0":
   version "9.2.1"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.1.tgz#9551142a1980503752536b5050fd99f4a7f13b17"
   integrity sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw==
+
+"@hapi/topo@^5.0.0":
+  version "5.1.0"
+  resolved "http://localhost:4873/@hapi%2ftopo/-/topo-5.1.0.tgz#dc448e332c6c6e37a4dc02fd84ba8d44b9afb012"
+  integrity sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
@@ -2231,6 +2238,23 @@
   dependencies:
     domhandler "^4.2.0"
     selderee "^0.6.0"
+
+"@sideway/address@^4.1.3":
+  version "4.1.3"
+  resolved "http://localhost:4873/@sideway%2faddress/-/address-4.1.3.tgz#d93cce5d45c5daec92ad76db492cc2ee3c64ab27"
+  integrity sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.0"
+  resolved "http://localhost:4873/@sideway%2fformula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "http://localhost:4873/@sideway%2fpinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@swc/core-android-arm-eabi@1.2.135":
   version "1.2.135"
@@ -2686,6 +2710,13 @@
   version "8.3.4"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
   integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+
+"@types/wait-on@^5.3.1":
+  version "5.3.1"
+  resolved "http://localhost:4873/@types%2fwait-on/-/wait-on-5.3.1.tgz#bc5520d1d8b90b9caab1bef23315685ded73320d"
+  integrity sha512-2FFOKCF/YydrMUaqg+fkk49qf0e5rDgwt6aQsMzFQzbS419h2gNOXyiwp/o2yYy27bi/C1z+HgfncryjGzlvgQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/webidl-conversions@*":
   version "6.1.1"
@@ -3357,6 +3388,13 @@ axe-core@^4.3.5:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.3.5.tgz#78d6911ba317a8262bfee292aeafcc1e04b49cc5"
   integrity sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==
+
+axios@^0.21.1:
+  version "0.21.4"
+  resolved "http://localhost:4873/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+  dependencies:
+    follow-redirects "^1.14.0"
 
 axios@^0.24.0:
   version "0.24.0"
@@ -5763,7 +5801,7 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.4:
+follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.4:
   version "1.14.7"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
   integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
@@ -7100,6 +7138,17 @@ jest-worker@27.0.0-next.5:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
+
+joi@^17.4.0:
+  version "17.6.0"
+  resolved "http://localhost:4873/joi/-/joi-17.6.0.tgz#0bb54f2f006c09a96e75ce687957bd04290054b2"
+  integrity sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.3"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
 
 js-cookie@^2.2.1:
   version "2.2.1"
@@ -9720,7 +9769,7 @@ rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.2:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -9778,12 +9827,12 @@ rxjs@^6.6.3:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.4.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.4.0.tgz#a12a44d7eebf016f5ff2441b87f28c9a51cebc68"
-  integrity sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==
+rxjs@^7.1.0, rxjs@^7.4.0:
+  version "7.5.2"
+  resolved "http://localhost:4873/rxjs/-/rxjs-7.5.2.tgz#11e4a3a1dfad85dbf7fb6e33cbba17668497490b"
+  integrity sha512-PwDt186XaL3QN5qXj/H9DGyHhP3/RYYgZZwqBv9Tv8rsAaiwFH1IsJJlcgD37J7UW5a6O67qX0KWKS3/pu0m4w==
   dependencies:
-    tslib "~2.1.0"
+    tslib "^2.1.0"
 
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -10080,6 +10129,11 @@ slash@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
   integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
+
+sleep-promise@^9.1.0:
+  version "9.1.0"
+  resolved "http://localhost:4873/sleep-promise/-/sleep-promise-9.1.0.tgz#101ebe65700bcd184709da95d960967b02b79d03"
+  integrity sha512-UHYzVpz9Xn8b+jikYSD6bqvf754xL2uBUzDFwiU6NcdZeifPr6UfgU43xpkPu67VMS88+TI2PSI7Eohgqf2fKA==
 
 slice-ansi@^3.0.0:
   version "3.0.0"
@@ -10832,12 +10886,26 @@ timers-browserify@2.0.12, timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
+tmp-promise@^3.0.3:
+  version "3.0.3"
+  resolved "http://localhost:4873/tmp-promise/-/tmp-promise-3.0.3.tgz#60a1a1cc98c988674fcbfd23b6e3367bdeac4ce7"
+  integrity sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==
+  dependencies:
+    tmp "^0.2.0"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
+
+tmp@^0.2.0:
+  version "0.2.1"
+  resolved "http://localhost:4873/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+  dependencies:
+    rimraf "^3.0.0"
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"
@@ -10989,11 +11057,6 @@ tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
-
-tslib@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -11439,6 +11502,17 @@ w-json@^1.3.10:
   version "1.3.10"
   resolved "https://registry.yarnpkg.com/w-json/-/w-json-1.3.10.tgz#ac448a19ca22376e2753a684b52369c7b1e83313"
   integrity sha512-XadVyw0xE+oZ5FGApXsdswv96rOhStzKqL53uSe5UaTadABGkWIg1+DTx8kiZ/VqTZTBneoL0l65RcPe4W3ecw==
+
+wait-on@^6.0.0:
+  version "6.0.0"
+  resolved "http://localhost:4873/wait-on/-/wait-on-6.0.0.tgz#7e9bf8e3d7fe2daecbb7a570ac8ca41e9311c7e7"
+  integrity sha512-tnUJr9p5r+bEYXPUdRseolmz5XqJTTj98JgOsfBn7Oz2dxfE2g3zw1jE+Mo8lopM3j3et/Mq1yW7kKX6qw7RVw==
+  dependencies:
+    axios "^0.21.1"
+    joi "^17.4.0"
+    lodash "^4.17.21"
+    minimist "^1.2.5"
+    rxjs "^7.1.0"
 
 watchpack-chokidar2@^2.0.1:
   version "2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11319,6 +11319,11 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
+untildify@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
+  integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
+
 upath@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10980,7 +10980,7 @@ tr46@^3.0.0:
 
 tree-kill@^1.2.2:
   version "1.2.2"
-  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  resolved "http://localhost:4873/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
 trim-trailing-lines@^1.0.0:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1936,7 +1936,7 @@
 
 "@hapi/topo@^5.0.0":
   version "5.1.0"
-  resolved "http://localhost:4873/@hapi%2ftopo/-/topo-5.1.0.tgz#dc448e332c6c6e37a4dc02fd84ba8d44b9afb012"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.1.0.tgz#dc448e332c6c6e37a4dc02fd84ba8d44b9afb012"
   integrity sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==
   dependencies:
     "@hapi/hoek" "^9.0.0"
@@ -2241,19 +2241,19 @@
 
 "@sideway/address@^4.1.3":
   version "4.1.3"
-  resolved "http://localhost:4873/@sideway%2faddress/-/address-4.1.3.tgz#d93cce5d45c5daec92ad76db492cc2ee3c64ab27"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.3.tgz#d93cce5d45c5daec92ad76db492cc2ee3c64ab27"
   integrity sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==
   dependencies:
     "@hapi/hoek" "^9.0.0"
 
 "@sideway/formula@^3.0.0":
   version "3.0.0"
-  resolved "http://localhost:4873/@sideway%2fformula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
   integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
 
 "@sideway/pinpoint@^2.0.0":
   version "2.0.0"
-  resolved "http://localhost:4873/@sideway%2fpinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
   integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@swc/core-android-arm-eabi@1.2.135":
@@ -2713,7 +2713,7 @@
 
 "@types/wait-on@^5.3.1":
   version "5.3.1"
-  resolved "http://localhost:4873/@types%2fwait-on/-/wait-on-5.3.1.tgz#bc5520d1d8b90b9caab1bef23315685ded73320d"
+  resolved "https://registry.yarnpkg.com/@types/wait-on/-/wait-on-5.3.1.tgz#bc5520d1d8b90b9caab1bef23315685ded73320d"
   integrity sha512-2FFOKCF/YydrMUaqg+fkk49qf0e5rDgwt6aQsMzFQzbS419h2gNOXyiwp/o2yYy27bi/C1z+HgfncryjGzlvgQ==
   dependencies:
     "@types/node" "*"
@@ -3391,7 +3391,7 @@ axe-core@^4.3.5:
 
 axios@^0.21.1:
   version "0.21.4"
-  resolved "http://localhost:4873/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
@@ -7141,7 +7141,7 @@ jest-worker@27.0.0-next.5:
 
 joi@^17.4.0:
   version "17.6.0"
-  resolved "http://localhost:4873/joi/-/joi-17.6.0.tgz#0bb54f2f006c09a96e75ce687957bd04290054b2"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.6.0.tgz#0bb54f2f006c09a96e75ce687957bd04290054b2"
   integrity sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==
   dependencies:
     "@hapi/hoek" "^9.0.0"
@@ -9829,7 +9829,7 @@ rxjs@^6.6.3:
 
 rxjs@^7.1.0, rxjs@^7.4.0:
   version "7.5.2"
-  resolved "http://localhost:4873/rxjs/-/rxjs-7.5.2.tgz#11e4a3a1dfad85dbf7fb6e33cbba17668497490b"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.2.tgz#11e4a3a1dfad85dbf7fb6e33cbba17668497490b"
   integrity sha512-PwDt186XaL3QN5qXj/H9DGyHhP3/RYYgZZwqBv9Tv8rsAaiwFH1IsJJlcgD37J7UW5a6O67qX0KWKS3/pu0m4w==
   dependencies:
     tslib "^2.1.0"
@@ -10132,7 +10132,7 @@ slash@^4.0.0:
 
 sleep-promise@^9.1.0:
   version "9.1.0"
-  resolved "http://localhost:4873/sleep-promise/-/sleep-promise-9.1.0.tgz#101ebe65700bcd184709da95d960967b02b79d03"
+  resolved "https://registry.yarnpkg.com/sleep-promise/-/sleep-promise-9.1.0.tgz#101ebe65700bcd184709da95d960967b02b79d03"
   integrity sha512-UHYzVpz9Xn8b+jikYSD6bqvf754xL2uBUzDFwiU6NcdZeifPr6UfgU43xpkPu67VMS88+TI2PSI7Eohgqf2fKA==
 
 slice-ansi@^3.0.0:
@@ -10888,7 +10888,7 @@ timers-browserify@2.0.12, timers-browserify@^2.0.4:
 
 tmp-promise@^3.0.3:
   version "3.0.3"
-  resolved "http://localhost:4873/tmp-promise/-/tmp-promise-3.0.3.tgz#60a1a1cc98c988674fcbfd23b6e3367bdeac4ce7"
+  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.3.tgz#60a1a1cc98c988674fcbfd23b6e3367bdeac4ce7"
   integrity sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==
   dependencies:
     tmp "^0.2.0"
@@ -10902,7 +10902,7 @@ tmp@^0.0.33:
 
 tmp@^0.2.0:
   version "0.2.1"
-  resolved "http://localhost:4873/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
   integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
   dependencies:
     rimraf "^3.0.0"
@@ -11505,7 +11505,7 @@ w-json@^1.3.10:
 
 wait-on@^6.0.0:
   version "6.0.0"
-  resolved "http://localhost:4873/wait-on/-/wait-on-6.0.0.tgz#7e9bf8e3d7fe2daecbb7a570ac8ca41e9311c7e7"
+  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-6.0.0.tgz#7e9bf8e3d7fe2daecbb7a570ac8ca41e9311c7e7"
   integrity sha512-tnUJr9p5r+bEYXPUdRseolmz5XqJTTj98JgOsfBn7Oz2dxfE2g3zw1jE+Mo8lopM3j3et/Mq1yW7kKX6qw7RVw==
   dependencies:
     axios "^0.21.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10980,7 +10980,7 @@ tr46@^3.0.0:
 
 tree-kill@^1.2.2:
   version "1.2.2"
-  resolved "http://localhost:4873/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
 trim-trailing-lines@^1.0.0:


### PR DESCRIPTION
This PR helps complete https://github.com/blockprotocol/blockprotocol/pull/168 and also simplifies further work on the npm packages. It introduces a simple smoke test for `npx create-block-app`, which includes `npm install`, `npm run dev`, `npm run lint:tsc` and `npm run build` inside a new block folder.

## In scope

- Two new scripts:

  - `scripts/packages/publish-to-local-registry.ts`
     It publishes `block-template`, `blockprotocol`, `create-block-app` and `mock-block-dock` to `http://localhost:4873`.  Registry address is hardcoded to save us from accidental publishing to the real registry (at least for now).

  - `scripts/packages/smoke-test-create-block-app.ts`
      It pretty much follows the instructions at https://blockprotocol.org/docs/developing-blocks. This script can work against both local and public registry, which means that we can also use it for e2e testing of just-published packages.

- New CI job which runs both scripts and then uploads the block folder as an artifact

- Small tweaks in packages (see diff comments)

I am using [Verdaccio](https://github.com/verdaccio/verdaccio) to spin up the local NPM registry. [CRA uses it too](https://github.com/facebook/create-react-app/search?q=Verdaccio) for a similar kind of smoke tests. I’ve chosen to run Verdaccio in a Docker container as it saves us from some extra setup and folder cleaning. The `docker run` command we have in the Yaml can be launched locally as is.

## Out of scope

- The scripts are not using `yarn create block-app`, `yarn install`, etc. It is unlikely that we’ll hit discrepancies between Yarn and NPM at this stage, so we can add Yarn to smoke-testing a bit later. We can also include different versions of Node, Yarn and NPM for some extra robustness.

- There are no assertions inside `smoke-test-create-block-app`. We can check block name and other metadata, but that’s not a priority right now. Just running lifecycle commands with exit code 0 is probably enough to start with. 

- I haven’t updated `CONTRIBUTING.md` so that I can publish this PR by the end of today. I can write something up in a follow-up PR to get this one in faster.