### PR TITLE
Temporarily disable `post-commit` git hook

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,4 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-yarn install

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,7 +1,7 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-## This hook was temporary emptied in https://github.com/blockprotocol/blockprotocol/pull/184
+## This hook was disabled in https://github.com/blockprotocol/blockprotocol/pull/184
 ## @todo: Revert when whe cleanup `prepare` script in `package.json`
 
 # yarn install

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,0 +1,7 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+## This hook was temporary emptied in https://github.com/blockprotocol/blockprotocol/pull/184
+## @todo: Revert when whe cleanup `prepare` script in `package.json`
+
+# yarn install


### PR DESCRIPTION
We run `yarn install` after `git commit`, which is useful when cherry-picking. Our `prepare` script got beefier in #173, which made commits quite slow because of a git hook.

When we introduce a monorepo-management tool like Turborepo, we’ll be able to remove package builds from `prepare` and bring the hook back.