### PR TITLE
Allow filtering blocks on more parameters

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -281,8 +281,13 @@ The following routes require a valid API key sent in an `x-api-key` header:
 
 - Request Params
 
-  - `q`: an optional text query to search for blocks with a matching name or author. If not provided, all blocks are returned.
+  - `author`: an optional text query to search for blocks with a matching author.
+  - `license`: an optional text query to search for blocks with a matching license. Note: The license name needs to be matching.
+  - `name`: an optional text query to search for blocks with a matching name.
+  - `q`: an optional text query to search for blocks with a matching name or author.
   - `json`: an optional JSON object that filters blocks by schema validity. Preferably URL encoded.
+
+If all of the optional params above are **not** provided, the result will contain all of the blocks.
 
 - Request Response:
   - `results`: the results of the search: an array of block metadata JSON files

--- a/site/README.md
+++ b/site/README.md
@@ -287,7 +287,7 @@ The following routes require a valid API key sent in an `x-api-key` header:
   - `q`: an optional text query to search for blocks with a matching name or author.
   - `json`: an optional JSON object that filters blocks by schema validity. Preferably URL encoded.
 
-If all of the optional params above are **not** provided, the result will contain all of the blocks.
+If all of the optional params are missing, the result will contain all of the blocks.
 
 - Request Response:
   - `results`: the results of the search: an array of block metadata JSON files


### PR DESCRIPTION
## What this Does

The existing blocks API allows users to get a list of all available blocks, and filter them based on:
1. `q`: Which filters by the query string on a set of blockData keys.
2. `json`: Which filters based on the structure of json passed in by the user.

This PR allows filtering based on 3 more data points:
1. `author`: Filter blocks based on block author.
2. `name`: Filter blocks based on either `displayName` or the package name.
3. `license`: Filter blocks based on the type of license that they use.

## How to test this

- Checkout the branch
- Call the API locally, mix and match parameters to see how they combine.

> Note: The Asana task mentions that "Query parameters should be composable / combinable". This PR assumes that all filters will be ANDed, and hence, the order of query parameters doesn't matter. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201472294283824