### PR TITLE
[FE] Fix typo in Algolia Action and update index name

### DIFF
--- a/.github/workflows/algolia-upload-index.yml
+++ b/.github/workflows/algolia-upload-index.yml
@@ -2,7 +2,7 @@ name: Algolia Upload Index
 
 env:
   ALGOLIA_PROJECT: ${{ secrets.ALGOLIA_PROJECT }}
-  AGOLIA_WRITE_KEY: ${{ secrets.AGOLIA_WRITE_KEY }}
+  ALGOLIA_WRITE_KEY: ${{ secrets.ALGOLIA_WRITE_KEY }}
 
 on:
   push:

--- a/scripts/sync-algolia-index.ts
+++ b/scripts/sync-algolia-index.ts
@@ -119,7 +119,7 @@ const syncAlgoliaIndex = async () => {
     process.env.AGOLIA_WRITE_KEY ?? "",
   );
 
-  const index = client.initIndex("blockprotocol_testing");
+  const index = client.initIndex("blockprotocol");
 
   let oldIndexObjects: Array<{ objectID: string }> = [];
 

--- a/site/src/components/pages/docs/Search/index.tsx
+++ b/site/src/components/pages/docs/Search/index.tsx
@@ -21,7 +21,7 @@ import SearchItem, {
 import { Link } from "../../../Link";
 
 const client = algoliasearch("POOWZ64DSV", "96dc0442fd27b903440955dc03e5e60e");
-const index = client.initIndex("blockprotocol_testing");
+const index = client.initIndex("blockprotocol");
 
 interface SearchProps {
   variant: SearchVariants;


### PR DESCRIPTION
## What this does

1. This PR fixes the typo in the GitHub Action yaml file, which means the correct secret will get passed down to the script.
2. The index name inside the action and in the app are updated to `blockprotocol`, so both of them use the actual index.