### PR TITLE
Better handle block hub JSON files. Fix switching between blocks.

### DIFF
--- a/site/scripts/build-blocks.sh
+++ b/site/scripts/build-blocks.sh
@@ -103,10 +103,10 @@ function build_block {
     mkdir -p "$repo_path"
 
     # add others as needed (gitlab, bitbucket)
-    if [[ "$repo_url" =~ ^https://github\.com/.+\.git$ ]]; then
+    if [[ "$repo_url" =~ ^https://github\.com ]]; then
       zip_url="${repo_url%\.git}/archive/refs/heads/${branch}.zip"
     else
-      log error "cannot handle repository url (yet): $url"
+      log error "cannot handle repository url (yet): $repo_url"
       exit 2
     fi
 

--- a/site/src/components/pages/hub/BlockDataContainer.tsx
+++ b/site/src/components/pages/hub/BlockDataContainer.tsx
@@ -79,7 +79,7 @@ export const BlockDataContainer: VoidFunctionComponent<
       );
 
     return [result, errorMessages];
-  }, [text, schema, metadata.name]);
+  }, [text, schema]);
 
   return (
     <>

--- a/site/src/components/pages/hub/BlockDataContainer.tsx
+++ b/site/src/components/pages/hub/BlockDataContainer.tsx
@@ -58,8 +58,8 @@ export const BlockDataContainer: VoidFunctionComponent<
   /** used to recompute props and errors on dep changes (caching has no benefit here) */
   const [props, errors] = useMemo<[object | undefined, string[]]>(() => {
     const result = {
-      accountId: `test-account-${metadata.name}`,
-      entityId: `test-entity-${metadata.name}`,
+      accountId: `test-account-1`,
+      entityId: `test-entity-1`,
       getEmbedBlock,
     };
 

--- a/site/src/lib/blocks.ts
+++ b/site/src/lib/blocks.ts
@@ -11,7 +11,7 @@ export type ExpandedBlockMetadata = BlockMetadata & {
 export type BuildConfig = {
   workspace?: string | null;
   repository: string;
-  branch?: string | null;
+  branch: string;
   distDir: string;
   timestamp?: string | null;
 };

--- a/site/src/lib/blocks.ts
+++ b/site/src/lib/blocks.ts
@@ -9,11 +9,11 @@ export type ExpandedBlockMetadata = BlockMetadata & {
 };
 
 export type BuildConfig = {
-  workspace: string;
+  workspace?: string | null;
   repository: string;
-  branch: string;
+  branch?: string | null;
   distDir: string;
-  timestamp: string;
+  timestamp?: string | null;
 };
 
 const getBlockMediaUrl = (
@@ -58,9 +58,9 @@ export const readBlocksFromDisk = (): ExpandedBlockMetadata[] => {
       author: metadata.packagePath.split("/")[0].replace(/^@/, ""),
       icon: getBlockMediaUrl(metadata.icon, metadata.packagePath),
       image: getBlockMediaUrl(metadata.image, metadata.packagePath),
-      lastUpdated: buildConfig.find(
-        ({ workspace }) => workspace === metadata.name,
-      )?.timestamp,
+      lastUpdated:
+        buildConfig.find(({ workspace }) => workspace === metadata.name)
+          ?.timestamp ?? null,
     }));
 };
 

--- a/site/src/pages/[shortname]/[blockSlug].page.tsx
+++ b/site/src/pages/[shortname]/[blockSlug].page.tsx
@@ -256,23 +256,23 @@ const BlockPage: NextPage<BlockPageProps> = ({
               </span>
               <Bullet />
               <span>V{blockMetadata.version}</span>
-              {isDesktopSize && <Bullet />}
-              <Box
-                component="span"
-                sx={{ display: { xs: "block", md: "inline-block" } }}
-              >
-                {`Updated ${
-                  blockMetadata.lastUpdated
-                    ? formatDistance(
-                        new Date(blockMetadata.lastUpdated),
-                        new Date(),
-                        {
-                          addSuffix: true,
-                        },
-                      )
-                    : "Recently"
-                }`}
-              </Box>
+              {blockMetadata.lastUpdated ? (
+                <>
+                  {isDesktopSize && <Bullet />}
+                  <Box
+                    component="span"
+                    sx={{ display: { xs: "block", md: "inline-block" } }}
+                  >
+                    {`Updated ${formatDistance(
+                      new Date(blockMetadata.lastUpdated),
+                      new Date(),
+                      {
+                        addSuffix: true,
+                      },
+                    )}`}
+                  </Box>
+                </>
+              ) : null}
             </Typography>
           </Box>
         </Box>


### PR DESCRIPTION
This PR fixes a couple of assumptions we made about the JSON files describing blocks:
1. Better handles a missing `timestamp` 
2. Allows repo URLs that don't end in .git

It also reverts a change made in #171 to change the `entityId` of a block - `MockBlockDock` doesn't handle this properly and more changes are needed there to prevent crashes if the `entityId` of the block entity is changed from outside.