### PR TITLE
Add `envalid` to improve script feedback when env vars are missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "check-dependency-version-consistency": "^1.6.0",
     "concurrently": "^6.5.1",
     "dotenv-flow": "3.2.0",
+    "envalid": "^7.2.2",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-prettier": "8.3.0",

--- a/scripts/sync-algolia-index.ts
+++ b/scripts/sync-algolia-index.ts
@@ -115,6 +115,8 @@ const generateAlgoliaRecords: () => AlgoliaRecord[] = () => {
 };
 
 const script = async () => {
+  console.log("Syncing Algolia index");
+
   const env = envalid.cleanEnv(process.env, {
     ALGOLIA_PROJECT: envalid.str({
       desc: "Algolia app id",
@@ -162,7 +164,7 @@ const script = async () => {
 
   await index.saveObjects(indexObjects);
 
-  console.log("Algolia Indexes Updated.");
+  console.log("Algolia index updated.");
 };
 
 void script();

--- a/scripts/sync-algolia-index.ts
+++ b/scripts/sync-algolia-index.ts
@@ -6,6 +6,8 @@ import * as envalid from "envalid";
 
 import siteMap from "../site/site-map.json";
 
+const monorepoDirPath = path.resolve(__dirname, "..");
+
 type DocsFrontMatter = {
   content: string;
   data: Record<string, string>;
@@ -92,8 +94,16 @@ const generateAlgoliaRecords: () => AlgoliaRecord[] = () => {
     return appendData;
   };
 
-  const specFiles = getFileInfos("../../../site/src/_pages/spec", [], "spec");
-  const docsFiles = getFileInfos("../../../site/src/_pages/docs", [], "docs");
+  const specFiles = getFileInfos(
+    path.resolve(monorepoDirPath, "site/src/_pages/spec"),
+    [],
+    "spec",
+  );
+  const docsFiles = getFileInfos(
+    path.resolve(monorepoDirPath, "site/src/_pages/docs"),
+    [],
+    "docs",
+  );
 
   const specData = specFiles.map((filePath, fileIndex) => {
     const file = fs.readFileSync(filePath.inputPath, "utf8");

--- a/yarn.lock
+++ b/yarn.lock
@@ -5075,6 +5075,13 @@ env-paths@^2.2.0:
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
+envalid@^7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/envalid/-/envalid-7.2.2.tgz#f3219f85e692002dca0f28076740227d30c817e3"
+  integrity sha512-bl/3VF5PhoF26HlDWiE0NRRHUbKT/+UDP/+0JtOFmhUwK3cUPS7JgWYGbE8ArvA61T+SyNquxscLCS6y4Wnpdw==
+  dependencies:
+    tslib "2.3.1"
+
 err-code@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/err-code/-/err-code-2.0.3.tgz#23c2f3b756ffdfc608d30e27c9a941024807e7f9"
@@ -11048,15 +11055,15 @@ tsconfig-paths@^3.11.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
+tslib@2.3.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
 tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
-  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
We were having issues with [Algolia indexing](https://github.com/blockprotocol/blockprotocol/actions/workflows/algolia-upload-index.yml) recently and it was unclear whether it was because of missing or incorrect env vars. This PR introduces [`envalid`](https://www.npmjs.com/package/envalid?activeTab=versions), which improves script feedback. We can add this library to other scripts as needed.

## Before 🤔

<img width="803" alt="Screenshot 2022-02-03 at 19 33 49" src="https://user-images.githubusercontent.com/608862/152415998-79a599b6-b4a4-4d38-9587-2f69e1ff8421.png">

## After 💡

<img width="772" alt="Screenshot 2022-02-03 at 19 33 02" src="https://user-images.githubusercontent.com/608862/152416056-ca6ce253-6eb9-422f-ac2d-78cd0a58f066.png">

## Feature summary

```ts
const env = envalid.cleanEnv({
  EMAIL: envalid.email({ default: "hello@example.com" }),
  EMAIL_TRANSPORT: envalid.str({ choices: ["aws", "none"], default: "aws", devDefault: "none" }),
  PORT: envalid.port({ default: 3000 }),
});
```

```ts
console.log(typeof env.PORT === 3000); // true

// with PORT=-42 → 💥

console.log(env.EMAIL); // always a valid email

console.log(env.EMAIL_TRANSPORT); // "none"
console.log(env.isProduction); // false

// with NODE_ENV=production
console.log(env.EMAIL_TRANSPORT); // "aws"
console.log(env.isProduction); // true

// with EMAIL_TRANSPORT=oops → 💥
```

## Caveats

- By default, `envalid` calls `process.exit` instead of throwing. This makes script output cleaner because it does not contain the call stack. We can’t use `try / catch` though. If we do want to use `try / catch`, we can implement a [custom reporter](https://github.com/af/envalid#error-reporting), which would throw. This may be useful in server-side code, but I doubt about scripts.

- We need to use `import * as envalid from "envalid"`. Writing `import envalid from "envalid"` does not produce a TS error but crashes. This may change if we switch to native ESM modules.

- Specifying `choices` does not narrow the return type (i.e. `env.EMAIL_TRANSPORT` is `string`, not `"aws" | "none"`). This might be fixed via https://github.com/af/envalid/pull/176

---

[Asana task](https://app.asana.com/0/0/1201766858773607/f) _(internal link)_
