### PR TITLE
Made sample data consistent

### DIFF
--- a/site/src/_pages/docs/3_embedding-blocks.mdx
+++ b/site/src/_pages/docs/3_embedding-blocks.mdx
@@ -86,13 +86,13 @@ For example, a row in your `users` table:
 
 | id  | name | companyId |
 | --- | ---- | --------- |
-| 41  | Bob  | 456       |
+| 42  | Bob  | 456       |
 
 ...might become the following entity:
 
 ```json
 {
-  "entityId": "41",
+  "entityId": "42",
   "entityTypeId": "User",
   "name": "Bob"
 }


### PR DESCRIPTION
The sample data in the `data-protocol` section used user row with ` entityId` of `41` but the related links example used a `sourceEntityId` of `42` which might be confusing since we're trying to show the way to create related links. This change makes the example data consistent by changing the user row to `42`.
Fixes #176