### PR TITLE
Add shortname index on user collection

### DIFF
--- a/site/scripts/create-db-indexes.ts
+++ b/site/scripts/create-db-indexes.ts
@@ -31,7 +31,7 @@ const script = async () => {
   await catchAndLog(async () => {
     await db
       .collection<UserDocument>(User.COLLECTION_NAME)
-      .createIndex({ shortname: 1 });
+      .createIndex({ shortname: 1 }, { unique: true, sparse: true });
   });
 
   await catchAndLog(async () => {

--- a/site/scripts/create-db-indexes.ts
+++ b/site/scripts/create-db-indexes.ts
@@ -30,6 +30,12 @@ const script = async () => {
 
   await catchAndLog(async () => {
     await db
+      .collection<UserDocument>(User.COLLECTION_NAME)
+      .createIndex({ shortname: 1 });
+  });
+
+  await catchAndLog(async () => {
+    await db
       .collection(EntityType.COLLECTION_NAME)
       .createIndex({ entityTypeId: 1 }, { unique: true });
   });


### PR DESCRIPTION
I noticed that user pages were sometimes loading slowly. This is because we didn't have an index on `shortname` in the user collection.

I've already created this in the database directly - this PR adds the index creation to our script so that we can (a) easily see it's present, and (b) have it recreated if for some reason it's ever removed.