### PR TITLE
Use `fs-extra` consistenlty

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -206,6 +206,11 @@ module.exports = {
         "no-restricted-imports": [
           "error",
           {
+            name: "fs",
+            message:
+              "Please use 'fs-extra' for promise-based API, extra methods and consistency.",
+          },
+          {
             name: "@mui/material",
             importNames: ["Link"],
             message:

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -202,6 +202,10 @@ module.exports = {
     },
     {
       files: ["site/**"],
+      parserOptions: {
+        tsconfigRootDir: `${__dirname}/site`,
+        project: "tsconfig.json",
+      },
       rules: {
         "no-restricted-imports": [
           "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,14 @@
+const sharedNoRestrictedImportsConfig = {
+  paths: [],
+  patterns: [
+    {
+      group: ["fs", "fs/*"],
+      message:
+        "Please use 'fs-extra' for promise-based API, extra methods and consistency.",
+    },
+  ],
+};
+
 module.exports = {
   // this is the highest config lower ones will automatically extend
   root: true,
@@ -40,6 +51,7 @@ module.exports = {
     "react/prop-types": "off",
     // because we are using typescript this is redundant
     "jsx-a11y/anchor-is-valid": "off",
+    "no-restricted-imports": ["error", sharedNoRestrictedImportsConfig],
     "react/function-component-definition": [
       "error",
       {
@@ -210,7 +222,9 @@ module.exports = {
         "no-restricted-imports": [
           "error",
           {
+            ...sharedNoRestrictedImportsConfig,
             paths: [
+              ...sharedNoRestrictedImportsConfig.paths,
               {
                 name: "@mui/material",
                 importNames: ["Link"],
@@ -256,13 +270,6 @@ module.exports = {
                 importNames: ["default"],
                 message:
                   "Please use the custom src/components/Popover component instead.",
-              },
-            ],
-            patterns: [
-              {
-                group: ["fs", "fs/*"],
-                message:
-                  "Please use 'fs-extra' for promise-based API, extra methods and consistency.",
               },
             ],
           },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -206,55 +206,61 @@ module.exports = {
         "no-restricted-imports": [
           "error",
           {
-            name: "fs",
-            message:
-              "Please use 'fs-extra' for promise-based API, extra methods and consistency.",
-          },
-          {
-            name: "@mui/material",
-            importNames: ["Link"],
-            message:
-              "Please use the custom src/components/Link component instead to ensure Next.js and MUI compatibility.",
-          },
-          {
-            name: "@mui/material/Link",
-            message:
-              "Please use the custom src/components/Link component instead to ensure Next.js and MUI compatibility.",
-          },
-          {
-            name: "next",
-            importNames: ["Link"],
-            message:
-              "Please use the custom src/components/Link component instead to ensure Next.js and MUI compatibility.",
-          },
-          {
-            name: "next/link",
-            message:
-              "Please use the custom src/components/Link component instead to ensure Next.js and MUI compatibility.",
-          },
-          {
-            name: "@mui/material",
-            importNames: ["Button", "TextField", "Popover"],
-            message:
-              "Please use the custom wrapper component in src/component instead.",
-          },
-          {
-            name: "@mui/material/Button",
-            importNames: ["default"],
-            message:
-              "Please use the custom src/components/Button component instead.",
-          },
-          {
-            name: "@mui/material/TextField",
-            importNames: ["default"],
-            message:
-              "Please use the custom src/components/TextField component instead.",
-          },
-          {
-            name: "@mui/material/Popover",
-            importNames: ["default"],
-            message:
-              "Please use the custom src/components/Popover component instead.",
+            paths: [
+              {
+                name: "@mui/material",
+                importNames: ["Link"],
+                message:
+                  "Please use the custom src/components/Link component instead to ensure Next.js and MUI compatibility.",
+              },
+              {
+                name: "@mui/material/Link",
+                message:
+                  "Please use the custom src/components/Link component instead to ensure Next.js and MUI compatibility.",
+              },
+              {
+                name: "next",
+                importNames: ["Link"],
+                message:
+                  "Please use the custom src/components/Link component instead to ensure Next.js and MUI compatibility.",
+              },
+              {
+                name: "next/link",
+                message:
+                  "Please use the custom src/components/Link component instead to ensure Next.js and MUI compatibility.",
+              },
+              {
+                name: "@mui/material",
+                importNames: ["Button", "TextField", "Popover"],
+                message:
+                  "Please use the custom wrapper component in src/component instead.",
+              },
+              {
+                name: "@mui/material/Button",
+                importNames: ["default"],
+                message:
+                  "Please use the custom src/components/Button component instead.",
+              },
+              {
+                name: "@mui/material/TextField",
+                importNames: ["default"],
+                message:
+                  "Please use the custom src/components/TextField component instead.",
+              },
+              {
+                name: "@mui/material/Popover",
+                importNames: ["default"],
+                message:
+                  "Please use the custom src/components/Popover component instead.",
+              },
+            ],
+            patterns: [
+              {
+                group: ["fs", "fs/*"],
+                message:
+                  "Please use 'fs-extra' for promise-based API, extra methods and consistency.",
+              },
+            ],
           },
         ],
       },

--- a/scripts/sync-algolia-index.ts
+++ b/scripts/sync-algolia-index.ts
@@ -1,4 +1,4 @@
-import fs from "fs";
+import fs from "fs-extra";
 import path from "path";
 import matter from "gray-matter";
 import algoliasearch from "algoliasearch";

--- a/site/.eslintrc.js
+++ b/site/.eslintrc.js
@@ -1,9 +1,0 @@
-/* eslint-env node */
-
-module.exports = {
-  root: false,
-  parserOptions: {
-    tsconfigRootDir: __dirname,
-    project: "tsconfig.json",
-  },
-};

--- a/site/package.json
+++ b/site/package.json
@@ -41,6 +41,7 @@
     "dotenv": "^10.0.0",
     "express-session": "^1.17.2",
     "express-validator": "^6.14.0",
+    "fs-extra": "^10.0.0",
     "glob": "^7.2.0",
     "gray-matter": "^4.0.3",
     "gsap": "^3.8.0",

--- a/site/scripts/generate-blocks-data.ts
+++ b/site/scripts/generate-blocks-data.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { writeFileSync } from "fs";
+import fs from "fs-extra";
 import path from "path";
 import { readBlocksFromDisk } from "../src/lib/blocks";
 
@@ -8,12 +8,10 @@ const script = async () => {
 
   const blocksInfo = readBlocksFromDisk();
 
-  writeFileSync(
-    path.join(process.cwd(), `blocks-data.json`),
-    JSON.stringify(blocksInfo, null, "\t"),
-  );
+  const blocksDataFilePath = path.join(process.cwd(), `blocks-data.json`);
+  await fs.writeJson(blocksDataFilePath, blocksInfo, { spaces: "\t" });
 
-  console.log("✅ Blocks data generated");
+  console.log(`✅ Blocks data generated: ${blocksDataFilePath}`);
 };
 
 export default script();

--- a/site/scripts/generate-sitemap.ts
+++ b/site/scripts/generate-sitemap.ts
@@ -1,4 +1,4 @@
-import { writeFileSync } from "fs";
+import fs from "fs-extra";
 import path from "path";
 import chalk from "chalk";
 import { generateSiteMap } from "../src/lib/sitemap";
@@ -8,12 +8,10 @@ const script = async () => {
 
   const sitemap = generateSiteMap();
 
-  writeFileSync(
-    path.join(process.cwd(), `site-map.json`),
-    JSON.stringify(sitemap, null, "\t"),
-  );
+  const siteMapFilePath = path.join(process.cwd(), `site-map.json`);
+  await fs.writeJson(siteMapFilePath, sitemap, { spaces: "\t" });
 
-  console.log("✅ Site map generated");
+  console.log(`✅ Site map generated: ${siteMapFilePath}`);
 };
 
 export default script();

--- a/site/src/lib/blocks.ts
+++ b/site/src/lib/blocks.ts
@@ -37,7 +37,7 @@ const getBlockMediaUrl = (
  */
 export const readBlocksFromDisk = (): ExpandedBlockMetadata[] => {
   /* eslint-disable global-require -- dependencies are required at runtime to avoid bundling them w/ nextjs */
-  const fs = require("fs");
+  const fs = require("fs-extra");
   const glob = require("glob");
   /* eslint-enable global-require */
 
@@ -71,7 +71,7 @@ export const readBlockDataFromDisk = ({
   source,
 }: ExpandedBlockMetadata) => {
   /* eslint-disable global-require -- dependencies are required at runtime to avoid bundling them w/ nextjs */
-  const fs = require("fs");
+  const fs = require("fs-extra");
   // @todo update to also return the metadata information
   // @see https://github.com/blockprotocol/blockprotocol/pull/66#discussion_r784070161
   return {

--- a/site/src/util/mdxUtils.tsx
+++ b/site/src/util/mdxUtils.tsx
@@ -1,7 +1,7 @@
 import { serialize } from "next-mdx-remote/serialize";
 import path from "path";
 import matter from "gray-matter";
-import { readFileSync, readdirSync } from "fs";
+import fs from "fs-extra";
 import unified from "unified";
 // @ts-expect-error -- Need to figure out how to get or declare the necessary types
 import remarkMdx from "remark-mdx";
@@ -72,7 +72,7 @@ const parseNameFromFileName = (fileName: string) => {
 export const getAllPageHrefs = (params: { folderName: string }): string[] => {
   const { folderName } = params;
 
-  const fileNames = readdirSync(
+  const fileNames = fs.readdirSync(
     path.join(process.cwd(), `src/_pages/${folderName}`),
   );
 
@@ -90,7 +90,7 @@ export const getSerializedPage = async (params: {
 }): Promise<MDXRemoteSerializeResult<Record<string, unknown>>> => {
   const { pathToDirectory, fileNameWithoutIndex } = params;
 
-  const fileNames = readdirSync(
+  const fileNames = await fs.readdir(
     path.join(process.cwd(), `src/_pages/${pathToDirectory}`),
   );
 
@@ -98,7 +98,7 @@ export const getSerializedPage = async (params: {
     fullFileName.endsWith(`${fileNameWithoutIndex}.mdx`),
   );
 
-  const source = readFileSync(
+  const source = await fs.readFile(
     path.join(process.cwd(), `src/_pages/${pathToDirectory}/${fileName}`),
   );
 
@@ -130,7 +130,7 @@ export const getPage = (params: {
 }): SiteMapPage => {
   const { pathToDirectory, fileName } = params;
 
-  const source = readFileSync(
+  const source = fs.readFileSync(
     path.join(process.cwd(), `src/_pages/${pathToDirectory}/${fileName}`),
   );
 
@@ -194,7 +194,7 @@ export const getAllPages = (params: {
 }): SiteMapPage[] => {
   const { pathToDirectory } = params;
 
-  const fileNames = readdirSync(
+  const fileNames = fs.readdirSync(
     path.join(process.cwd(), `src/_pages/${pathToDirectory}`),
   );
 


### PR DESCRIPTION
With `fs-extra` added in https://github.com/blockprotocol/blockprotocol/pull/210, it’d be nice to use this package consistently. This PR replaces `import ... from "fs"` with `import ... from "fs-extra"` and adds a linting rule that reminds us to not use plain `fs`.

We still have two occurrences of `require("fs")` in `create-block-app` and `block-template`. Those cases are not covered by `no-restricted-imports` in ESLint 8. This is good, because we don’t want to introduce `fs-extra` as a dependency of published packages (at least for now). If we decide to restrict certain paths in `require` in the future, we can install `eslint-plugin-node` and configure [`node/no-restricted-require`](https://github.com/mysticatea/eslint-plugin-node/blob/master/docs/rules/no-restricted-require.md).