### PR TITLE
BP site fix block page

### DIFF
--- a/site/src/lib/blocks.ts
+++ b/site/src/lib/blocks.ts
@@ -37,7 +37,7 @@ const getBlockMediaUrl = (
  */
 export const readBlocksFromDisk = (): ExpandedBlockMetadata[] => {
   /* eslint-disable global-require -- dependencies are required at runtime to avoid bundling them w/ nextjs */
-  const fs = require("fs-extra");
+  const fs = require("fs");
   const glob = require("glob");
   /* eslint-enable global-require */
 
@@ -71,7 +71,7 @@ export const readBlockDataFromDisk = ({
   source,
 }: ExpandedBlockMetadata) => {
   /* eslint-disable global-require -- dependencies are required at runtime to avoid bundling them w/ nextjs */
-  const fs = require("fs-extra");
+  const fs = require("fs");
   // @todo update to also return the metadata information
   // @see https://github.com/blockprotocol/blockprotocol/pull/66#discussion_r784070161
   return {


### PR DESCRIPTION
This PR fixes a `404` error encountered on each block page in Vercel deployments of the BP site. This involved reverting a runtime import of `fs-extra` back to using `fs` instead.