### PR TITLE
Fix `completeSignup` error

### DIFF
--- a/site/src/lib/api/model/user.model.ts
+++ b/site/src/lib/api/model/user.model.ts
@@ -234,6 +234,7 @@ export class User {
     updatedProperties: Partial<UserProperties>,
   ): Promise<User> {
     if (
+      this.shortname &&
       updatedProperties.shortname &&
       updatedProperties.shortname !== this.shortname
     ) {


### PR DESCRIPTION
This PR fixes an error that is thrown when the `completeSignup` Next API endpoint is called.