### PR TITLE
BP site display server errors to user

### DIFF
--- a/site/src/components/Screens/CompleteSignupScreen.tsx
+++ b/site/src/components/Screens/CompleteSignupScreen.tsx
@@ -55,7 +55,7 @@ export const CompleteSignupScreen: VFC<CompleteSignupScreenProps> = ({
       setCompletingSignup(false);
 
       if (error) {
-        setCompleteSignupError(error.parsedErrorMessage);
+        setCompleteSignupError(error.message);
       } else if (data) {
         setUser(data.user);
       }

--- a/site/src/components/Screens/CompleteSignupScreen.tsx
+++ b/site/src/components/Screens/CompleteSignupScreen.tsx
@@ -1,5 +1,5 @@
-import { Box, Icon, Typography } from "@mui/material";
-import { useRef, useState, VFC } from "react";
+import { Box, Collapse, FormHelperText, Icon, Typography } from "@mui/material";
+import { ReactNode, useRef, useState, VFC } from "react";
 import { TextField } from "../TextField";
 import { Button } from "../Button";
 import { useShortnameTextField } from "../hooks/useShortnameTextField";
@@ -28,6 +28,7 @@ export const CompleteSignupScreen: VFC<CompleteSignupScreenProps> = ({
     useState<boolean>(false);
 
   const [completingSignup, setCompletingSignup] = useState<boolean>(false);
+  const [completeSignupError, setCompleteSignupError] = useState<ReactNode>();
 
   const { shortname, setShortname, isShortnameValid, shortnameHelperText } =
     useShortnameTextField({
@@ -54,7 +55,7 @@ export const CompleteSignupScreen: VFC<CompleteSignupScreenProps> = ({
       setCompletingSignup(false);
 
       if (error) {
-        throw error;
+        setCompleteSignupError(error.parsedErrorMessage);
       } else if (data) {
         setUser(data.user);
       }
@@ -146,6 +147,11 @@ export const CompleteSignupScreen: VFC<CompleteSignupScreenProps> = ({
         >
           Continue
         </Button>
+        <Collapse in={!!completeSignupError}>
+          <FormHelperText error sx={{ marginTop: 1, fontSize: 15 }}>
+            {completeSignupError}
+          </FormHelperText>
+        </Collapse>
       </Box>
     </Box>
   );

--- a/site/src/components/Screens/SendLoginCodeScreen.tsx
+++ b/site/src/components/Screens/SendLoginCodeScreen.tsx
@@ -55,7 +55,7 @@ export const SendLoginCodeScreen: VFC<SendLoginCodeScreenProps> = ({
       setSendingLoginCode(false);
 
       if (error) {
-        setApiErrorMessage(error.parsedErrorMessage);
+        setApiErrorMessage(error.message);
       } else if (verificationCodeInfo) {
         onLoginCodeSent({ verificationCodeInfo, email: emailValue });
       }

--- a/site/src/components/Screens/SendLoginCodeScreen.tsx
+++ b/site/src/components/Screens/SendLoginCodeScreen.tsx
@@ -55,11 +55,7 @@ export const SendLoginCodeScreen: VFC<SendLoginCodeScreenProps> = ({
       setSendingLoginCode(false);
 
       if (error) {
-        if (error.response?.data.errors) {
-          setApiErrorMessage(error.response.data.errors.map(({ msg }) => msg));
-        } else {
-          throw error;
-        }
+        setApiErrorMessage(error.parsedErrorMessage);
       } else if (verificationCodeInfo) {
         onLoginCodeSent({ verificationCodeInfo, email: emailValue });
       }

--- a/site/src/components/Screens/SignupScreen.tsx
+++ b/site/src/components/Screens/SignupScreen.tsx
@@ -54,7 +54,7 @@ export const SignupScreen: VFC<SignupScreenProps> = ({
       setSigningUp(false);
 
       if (error) {
-        setApiErrorMessage(error.parsedErrorMessage);
+        setApiErrorMessage(error.message);
       } else if (verificationCodeInfo) {
         onSignup({ verificationCodeInfo, email: emailValue });
       }

--- a/site/src/components/Screens/SignupScreen.tsx
+++ b/site/src/components/Screens/SignupScreen.tsx
@@ -54,11 +54,7 @@ export const SignupScreen: VFC<SignupScreenProps> = ({
       setSigningUp(false);
 
       if (error) {
-        if (error.response?.data.errors) {
-          setApiErrorMessage(error.response.data.errors.map(({ msg }) => msg));
-        } else {
-          throw error;
-        }
+        setApiErrorMessage(error.parsedErrorMessage);
       } else if (verificationCodeInfo) {
         onSignup({ verificationCodeInfo, email: emailValue });
       }

--- a/site/src/components/Screens/VerificationCodeScreen.tsx
+++ b/site/src/components/Screens/VerificationCodeScreen.tsx
@@ -94,13 +94,7 @@ export const VerificationCodeScreen: VFC<VerificationCodeScreenProps> = ({
     setSendingVerificationCode(false);
 
     if (error) {
-      if (error.response?.data.errors) {
-        setApiResendEmailErrorMessage(
-          error.response.data.errors.map(({ msg }) => msg),
-        );
-      } else {
-        throw error;
-      }
+      setApiResendEmailErrorMessage(error.parsedErrorMessage);
     } else if (data) {
       unstable_batchedUpdates(() => {
         setVerificationCode("");
@@ -129,13 +123,7 @@ export const VerificationCodeScreen: VFC<VerificationCodeScreenProps> = ({
         setSubmitting(false);
 
         if (error) {
-          if (error.response?.data.errors) {
-            setApiSubmittedErrorMessage(
-              error.response.data.errors.map(({ msg }) => msg),
-            );
-          } else {
-            throw error;
-          }
+          setApiSubmittedErrorMessage(error.parsedErrorMessage);
         } else if (data) {
           onSubmit(data.user);
         }

--- a/site/src/components/Screens/VerificationCodeScreen.tsx
+++ b/site/src/components/Screens/VerificationCodeScreen.tsx
@@ -94,7 +94,7 @@ export const VerificationCodeScreen: VFC<VerificationCodeScreenProps> = ({
     setSendingVerificationCode(false);
 
     if (error) {
-      setApiResendEmailErrorMessage(error.parsedErrorMessage);
+      setApiResendEmailErrorMessage(error.message);
     } else if (data) {
       unstable_batchedUpdates(() => {
         setVerificationCode("");
@@ -123,7 +123,7 @@ export const VerificationCodeScreen: VFC<VerificationCodeScreenProps> = ({
         setSubmitting(false);
 
         if (error) {
-          setApiSubmittedErrorMessage(error.parsedErrorMessage);
+          setApiSubmittedErrorMessage(error.message);
         } else if (data) {
           onSubmit(data.user);
         }

--- a/site/src/lib/api/model/user.model.ts
+++ b/site/src/lib/api/model/user.model.ts
@@ -233,10 +233,11 @@ export class User {
     db: Db,
     updatedProperties: Partial<UserProperties>,
   ): Promise<User> {
+    // Prevent the user from updating their shortname if...
     if (
-      this.shortname &&
-      updatedProperties.shortname &&
-      updatedProperties.shortname !== this.shortname
+      this.shortname && // ...the user already has a shortname, and...
+      updatedProperties.shortname && // ...the user is trying to update the shortname, and...
+      updatedProperties.shortname !== this.shortname // ...the updated shortname is different from the user's original shortname.
     ) {
       throw new Error("Cannot update shortname");
     }

--- a/site/src/lib/apiClient.ts
+++ b/site/src/lib/apiClient.ts
@@ -44,9 +44,9 @@ const axiosClient = axios.create({
 
 export type ApiClientError = AxiosError<{
   errors?: Partial<ValidationError>[];
-}> & { parsedErrorMessage: string };
+}>;
 
-const parseErrorMessageFromAxiosError = (error: ApiClientError) => {
+const parseErrorMessageFromAxiosError = (error: ApiClientError): string => {
   const firstValidationErrorMessage = error.response?.data.errors?.find(
     ({ msg }) => !!msg,
   )?.msg;
@@ -54,7 +54,7 @@ const parseErrorMessageFromAxiosError = (error: ApiClientError) => {
   return (
     firstValidationErrorMessage ??
     error.response?.statusText ??
-    "An unknown error occurred"
+    "An error occurred"
   );
 };
 
@@ -64,7 +64,7 @@ const handleAxiosError = (
   /** @todo: report unexpected server errors to sentry or equivalent */
   const error = {
     ...axiosError,
-    parsedErrorMessage: parseErrorMessageFromAxiosError(axiosError),
+    message: parseErrorMessageFromAxiosError(axiosError),
   };
   return { error };
 };

--- a/site/src/lib/apiClient.ts
+++ b/site/src/lib/apiClient.ts
@@ -42,17 +42,32 @@ const axiosClient = axios.create({
   withCredentials: true,
 });
 
-const handleAxiosError = (
-  error: AxiosError,
-): { error: AxiosError<{ errors: Partial<ValidationError>[] }> } => {
-  /** @todo: stop special casing unauthorized errors */
-  if (error.response?.status === 401 || error.response?.data.errors) {
-    return { error };
-  }
-  throw error;
+export type ApiClientError = AxiosError<{
+  errors?: Partial<ValidationError>[];
+}> & { parsedErrorMessage: string };
+
+const parseErrorMessageFromAxiosError = (error: ApiClientError) => {
+  const firstValidationErrorMessage = error.response?.data.errors?.find(
+    ({ msg }) => !!msg,
+  )?.msg;
+
+  return (
+    firstValidationErrorMessage ??
+    error.response?.statusText ??
+    "An unknown error occurred"
+  );
 };
 
-export type ApiClientError = AxiosError<{ errors: Partial<ValidationError>[] }>;
+const handleAxiosError = (
+  axiosError: ApiClientError,
+): { error: ApiClientError } => {
+  /** @todo: report unexpected server errors to sentry or equivalent */
+  const error = {
+    ...axiosError,
+    parsedErrorMessage: parseErrorMessageFromAxiosError(axiosError),
+  };
+  return { error };
+};
 
 const get = <ResponseData = any, RequestParams = any>(
   url: string,


### PR DESCRIPTION
This PR changes how Next API errors are handled in the `ApiClient`, and which errors are displayed to the user. Changes include:
- modifying the `handleAxiosError` method to stop throwing some errors. Instead all errors are now returned by the `ApiClient` methods, so that these can be handled by the caller.
- for every axios error a default error message is parsed and attached to the error object, so that this logic can be reused by callers of the api client.
- the `CompleteSignupScreen` has been updated to display errors thrown by the `completeSignup` request. Previously when an error occurred it would be stuck in the loading state indefinitely, preventing the user from retrying to submit the form for instance when a network error is encountered.

Other changes made as part of this PR:
- comments added to the `update` method of the `User` model class to clarify the meaning behind the conditionals checked when preventing a user from updating their `shortname`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201795402978690