### PR TITLE
Upgrade `check-dependency-version-consistency` to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@typescript-eslint/parser": "5.11.0",
     "algoliasearch": "4.12.1",
     "chalk": "4.1.2",
-    "check-dependency-version-consistency": "1.6.0",
+    "check-dependency-version-consistency": "2.0.0",
     "concurrently": "^7.0.0",
     "dotenv-flow": "3.2.0",
     "envalid": "7.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3911,15 +3911,15 @@ charenc@0.0.2:
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
   integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
 
-check-dependency-version-consistency@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/check-dependency-version-consistency/-/check-dependency-version-consistency-1.6.0.tgz#213a3c53d5976c46b63383c725b1fa0cb0b471fc"
-  integrity sha512-7SlDVyoSnIf5BnPzIYxxLLTqK3nfXETBdXSHu72RK3utxYvFanKGa3YRmiHeh9h3l32JrYrzpcLcLHs7WJ29hA==
+check-dependency-version-consistency@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/check-dependency-version-consistency/-/check-dependency-version-consistency-2.0.0.tgz#06eaa6faee2d0fc50eef8c0666b6ab0ec3b0bb12"
+  integrity sha512-FT3f13Nxvez9qXcvH5UJyrHZKGwQh+nTCWD5DhI/W/qvhU4zyX2IPS5XLgnGwpb/PQqCU3JLDSrkO0kRbJp47A==
   dependencies:
     chalk "^4.1.2"
     commander "^8.1.0"
     edit-json-file "^1.7.0"
-    globby "^12.0.2"
+    globby "^13.1.1"
     semver "^7.3.5"
     table "^6.7.1"
     type-fest "^2.1.0"
@@ -5158,7 +5158,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.0.3, fast-glob@^3.2.7, fast-glob@^3.2.9:
+fast-glob@^3.0.3, fast-glob@^3.2.11, fast-glob@^3.2.7, fast-glob@^3.2.9:
   version "3.2.11"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
   integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
@@ -5524,6 +5524,17 @@ globby@^12.0.2:
     dir-glob "^3.0.1"
     fast-glob "^3.2.7"
     ignore "^5.1.9"
+    merge2 "^1.4.1"
+    slash "^4.0.0"
+
+globby@^13.1.1:
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-13.1.1.tgz#7c44a93869b0b7612e38f22ed532bfe37b25ea6f"
+  integrity sha512-XMzoDZbGZ37tufiv7g0N4F/zp3zkwdFtVbV3EHsVl1KQr4RPLfNoT068/97RPshz2J5xYNEjLKKBKaGHifBd3Q==
+  dependencies:
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.11"
+    ignore "^5.2.0"
     merge2 "^1.4.1"
     slash "^4.0.0"
 


### PR DESCRIPTION
Author of `check-dependency-version-consistency` [implemented](https://github.com/bmish/check-dependency-version-consistency/pull/343) my [feature request](https://github.com/bmish/check-dependency-version-consistency/issues/332) 🎉

We are now protected against wrong version numbers for our own packages, a mistake I have made before. Here is the `yarn lint` output if I change `blockprotocol` version to `0.4.2` in `block-template` → `package.json`:

<img width="599" alt="Screenshot 2022-02-15 at 14 44 13" src="https://user-images.githubusercontent.com/608862/154089454-ef931769-3ad0-4a05-b4fb-dc51b4dbac8a.png">

Same PR in the HASH repo: https://github.com/hashintel/hash/pull/318
