### PR TITLE
[do not merge] Check if upgrading to Next 12 in HASH breaks blocks

### DIFF
--- a/hub/@hash/code.json
+++ b/hub/@hash/code.json
@@ -1,7 +1,7 @@
 {
   "workspace": "@hashintel/block-code",
   "repository": "https://github.com/hashintel/hash.git",
-  "branch": "main",
+  "branch": "ak/next-12",
   "distDir": "dist",
   "timestamp": "2022-01-27T15:18:38.967Z"
 }

--- a/hub/@hash/divider.json
+++ b/hub/@hash/divider.json
@@ -1,7 +1,7 @@
 {
   "workspace": "@hashintel/block-divider",
   "repository": "https://github.com/hashintel/hash.git",
-  "branch": "main",
+  "branch": "ak/next-12",
   "distDir": "dist",
   "timestamp": "2022-01-27T15:18:38.967Z"
 }

--- a/hub/@hash/embed.json
+++ b/hub/@hash/embed.json
@@ -1,7 +1,7 @@
 {
   "workspace": "@hashintel/block-embed",
   "repository": "https://github.com/hashintel/hash.git",
-  "branch": "main",
+  "branch": "ak/next-12",
   "distDir": "dist",
   "timestamp": "2022-01-27T15:18:38.967Z"
 }

--- a/hub/@hash/header.json
+++ b/hub/@hash/header.json
@@ -1,7 +1,7 @@
 {
   "workspace": "@hashintel/block-header",
   "repository": "https://github.com/hashintel/hash.git",
-  "branch": "main",
+  "branch": "ak/next-12",
   "distDir": "dist",
   "timestamp": "2022-01-25T16:00:20.578Z"
 }

--- a/hub/@hash/image.json
+++ b/hub/@hash/image.json
@@ -1,7 +1,7 @@
 {
   "workspace": "@hashintel/block-image",
   "repository": "https://github.com/hashintel/hash.git",
-  "branch": "main",
+  "branch": "ak/next-12",
   "distDir": "dist",
   "timestamp": "2022-01-27T15:18:38.967Z"
 }

--- a/hub/@hash/paragraph.json
+++ b/hub/@hash/paragraph.json
@@ -1,7 +1,7 @@
 {
   "workspace": "@hashintel/block-paragraph",
   "repository": "https://github.com/hashintel/hash.git",
-  "branch": "main",
+  "branch": "ak/next-12",
   "distDir": "dist",
   "timestamp": "2022-01-27T15:18:38.967Z"
 }

--- a/hub/@hash/person.json
+++ b/hub/@hash/person.json
@@ -1,7 +1,7 @@
 {
   "workspace": "@hashintel/block-person",
   "repository": "https://github.com/hashintel/hash.git",
-  "branch": "main",
+  "branch": "ak/next-12",
   "distDir": "dist",
   "timestamp": "2022-01-27T15:18:38.967Z"
 }

--- a/hub/@hash/table.json
+++ b/hub/@hash/table.json
@@ -1,7 +1,7 @@
 {
   "workspace": "@hashintel/block-table",
   "repository": "https://github.com/hashintel/hash.git",
-  "branch": "main",
+  "branch": "ak/next-12",
   "distDir": "dist",
   "timestamp": "2022-01-27T15:18:38.967Z"
 }

--- a/hub/@hash/video.json
+++ b/hub/@hash/video.json
@@ -1,7 +1,7 @@
 {
   "workspace": "@hashintel/block-video",
   "repository": "https://github.com/hashintel/hash.git",
-  "branch": "main",
+  "branch": "ak/next-12",
   "distDir": "dist",
   "timestamp": "2022-01-27T15:18:38.967Z"
 }


### PR DESCRIPTION
Reason: https://github.com/hashintel/hash/pull/320 (webpack4 → webpack5 in Next)
👀 https://blockprotocol-2guzghk1k-hashintel.vercel.app/hub

I will close this PR when https://github.com/hashintel/hash/pull/320 is merged.