### PR TITLE
BP Site styling tweaks

### DIFF
--- a/site/src/components/BlockCard.tsx
+++ b/site/src/components/BlockCard.tsx
@@ -119,7 +119,7 @@ export const BlockCard: VFC<BlockCardProps> = ({ loading, data }) => {
             "& .block-card__name": {
               color: ({ palette }) => palette.purple[600],
             },
-            transform: "scale(1.03)",
+            transform: "scale(1.02)",
             "&::before": {
               opacity: 0,
             },

--- a/site/src/components/Footer.tsx
+++ b/site/src/components/Footer.tsx
@@ -222,16 +222,14 @@ export const Footer: FC<FooterProps> = ({ ...boxProps }) => {
                 color: ({ palette }) => palette.gray[50],
                 fontWeight: 400,
                 display: "flex",
-              }}
-              variant="bpSmallCopy"
-            >
-              Supported by{" "}
-              <Box
-                component="a"
-                href="https://hash.ai"
-                sx={{
-                  marginLeft: 1,
-                  borderBottomColor: "transparent !important",
+                "> a": {
+                  borderBottomWidth: 0,
+                  transition: theme.transitions.create(
+                    ["color", "borderColor"],
+                    {
+                      duration: 150,
+                    },
+                  ),
                   ":hover": {
                     color: ({ palette }) => palette.gray[30],
                   },
@@ -241,19 +239,21 @@ export const Footer: FC<FooterProps> = ({ ...boxProps }) => {
                   ":focus-visible": {
                     outline: ({ palette }) => `1px solid ${palette.gray[50]}`,
                   },
+                },
+              }}
+              variant="bpSmallCopy"
+            >
+              Supported by{" "}
+              <Link
+                href="https://hash.ai"
+                sx={{
+                  position: "relative",
+                  top: -1,
+                  marginLeft: 1,
                 }}
               >
-                <HASHLogoIcon
-                  sx={{
-                    transition: theme.transitions.create(
-                      ["color", "borderColor"],
-                      {
-                        duration: 150,
-                      },
-                    ),
-                  }}
-                />
-              </Box>
+                <HASHLogoIcon />
+              </Link>
             </Typography>
           </Grid>
         </Grid>

--- a/site/src/components/Footer.tsx
+++ b/site/src/components/Footer.tsx
@@ -40,8 +40,9 @@ const FooterNavigationLinks = FOOTER_NAVIGATION_LINKS.map(({ href, name }) => (
   <Typography
     component="p"
     variant="bpSmallCopy"
-    sx={{
-      color: ({ palette }) => palette.gray[40],
+    key={href}
+    sx={(theme) => ({
+      color: theme.palette.gray[40],
       "&:first-of-type": {
         marginTop: {
           xs: 1.5,
@@ -51,12 +52,8 @@ const FooterNavigationLinks = FOOTER_NAVIGATION_LINKS.map(({ href, name }) => (
       "&:not(:first-of-type)": {
         marginTop: 1.5,
       },
-    }}
-    key={href}
-  >
-    <Link
-      href={href}
-      sx={(theme) => ({
+      "> a": {
+        borderBottomWidth: 0,
         transition: theme.transitions.create("color", { duration: 150 }),
         ":hover": {
           color: theme.palette.gray[20],
@@ -67,10 +64,10 @@ const FooterNavigationLinks = FOOTER_NAVIGATION_LINKS.map(({ href, name }) => (
         ":focus-visible": {
           outlineColor: theme.palette.gray[40],
         },
-      })}
-    >
-      {name}
-    </Link>
+      },
+    })}
+  >
+    <Link href={href}>{name}</Link>
   </Typography>
 ));
 

--- a/site/src/components/InfoCard/InfoCard.tsx
+++ b/site/src/components/InfoCard/InfoCard.tsx
@@ -49,6 +49,17 @@ export const InfoCard: VoidFunctionComponent<InfoCardProps> = ({
           color: ({ palette }) => palette[paperVariant][600],
           fontSize: 15,
           lineHeight: 1.5,
+          "& a": ({ palette }) => ({
+            color: palette[paperVariant][600],
+            borderColor: palette[paperVariant][600],
+            ":hover": {
+              color: palette[paperVariant][700],
+              borderColor: palette[paperVariant][700],
+            },
+            ":focus-visible": {
+              outlineColor: palette[paperVariant][600],
+            },
+          }),
         }}
       >
         {isValidElement(child) ? child.props.children : child}
@@ -66,17 +77,6 @@ export const InfoCard: VoidFunctionComponent<InfoCardProps> = ({
           sm: 3,
         },
         ...sx,
-        "& a": ({ palette }) => ({
-          color: palette[paperVariant][600],
-          borderColor: palette[paperVariant][600],
-          ":hover": {
-            color: palette[paperVariant][700],
-            borderColor: palette[paperVariant][700],
-          },
-          ":focus-visible": {
-            outlineColor: palette[paperVariant][600],
-          },
-        }),
       }}
     >
       <Typography

--- a/site/src/components/MdxPageContent.tsx
+++ b/site/src/components/MdxPageContent.tsx
@@ -152,6 +152,13 @@ export const MdxPageContent: VFC<MdxPageContentProps> = ({
               sm: MDX_TEXT_CONTENT_MAX_WIDTH,
             },
           },
+          /** Headers that come after headers shouldn't have a top margin */
+          "& h1 + h2, h1 + h3, h1 + h4, h2 + h3, h2 + h4, h3 + h4": {
+            marginTop: 0,
+          },
+          "& > :first-child": {
+            marginTop: 0,
+          },
         }}
       >
         <MDXRemote {...serializedPage} components={mdxComponents} />

--- a/site/src/components/Navbar.tsx
+++ b/site/src/components/Navbar.tsx
@@ -426,8 +426,9 @@ export const Navbar: VFC<NavbarProps> = ({
             }}
           >
             {user ? null : router.pathname === "/login" ? null : (
-              <Link
+              <LinkButton
                 href="#"
+                variant="secondary"
                 onClick={(event) => {
                   setDisplayMobileNav(false);
                   openLoginModal();
@@ -438,7 +439,7 @@ export const Navbar: VFC<NavbarProps> = ({
                 }}
               >
                 Log in
-              </Link>
+              </LinkButton>
             )}
             <LinkButton
               href="/docs/developing-blocks"

--- a/site/src/components/pages/hub/BlockDataContainer.tsx
+++ b/site/src/components/pages/hub/BlockDataContainer.tsx
@@ -200,7 +200,6 @@ export const BlockDataContainer: VoidFunctionComponent<
               setBlockVariantsTab={setBlockVariantsTab}
               metadata={metadata ?? {}}
             />
-
             <Box
               sx={{
                 overflow: "auto",

--- a/site/src/components/pages/hub/BlockDataTabs.tsx
+++ b/site/src/components/pages/hub/BlockDataTabs.tsx
@@ -49,8 +49,7 @@ export const BlockDataTabs: VoidFunctionComponent<BlockDataTabsProps> = ({
           borderBottom: "0px",
           transition: "0.25s all ease-in-out",
           margin: 0,
-          paddingLeft: "10px",
-          paddingRight: "10px",
+          padding: theme.spacing(1.5, 2),
           ":hover": {
             backgroundColor: modalOpen ? theme.palette.common.white : undefined,
             color: modalOpen ? "black" : undefined,

--- a/site/src/components/pages/hub/BlockTabsModal.tsx
+++ b/site/src/components/pages/hub/BlockTabsModal.tsx
@@ -41,7 +41,7 @@ export const BlockTabsModal: VoidFunctionComponent<BlockTabsModalProps> = ({
           top: "50%",
           left: "50%",
           transform: "translate(-50%, -50%)",
-          width: "90vw",
+          width: "75vw",
           boxShadow: 24,
           borderBottomLeftRadius: 6,
           borderBottomRightRadius: 6,

--- a/site/src/components/pages/hub/BlockTabsModal.tsx
+++ b/site/src/components/pages/hub/BlockTabsModal.tsx
@@ -41,7 +41,7 @@ export const BlockTabsModal: VoidFunctionComponent<BlockTabsModalProps> = ({
           top: "50%",
           left: "50%",
           transform: "translate(-50%, -50%)",
-          width: "50vw",
+          width: "90vw",
           boxShadow: 24,
           borderBottomLeftRadius: 6,
           borderBottomRightRadius: 6,

--- a/site/src/components/pages/hub/BlockVariantsTabs.tsx
+++ b/site/src/components/pages/hub/BlockVariantsTabs.tsx
@@ -52,8 +52,7 @@ export const BlockVariantsTabs: VoidFunctionComponent<
           margin: 0,
           color: ({ palette }) => palette.gray[60],
           transition: "0.25s all ease-in-out",
-          paddingLeft: "10px",
-          paddingRight: "10px",
+          padding: theme.spacing(1.5, 2),
           "&:hover": {
             backgroundColor: theme.palette.gray[10],
             borderTopLeftRadius: 6,

--- a/site/src/pages/dashboard.page.tsx
+++ b/site/src/pages/dashboard.page.tsx
@@ -77,7 +77,7 @@ const Dashboard: AuthWallPageContent = ({ user }) => {
           }}
         >
           <Typography
-            variant="bpTitle"
+            variant="bpHeading2"
             sx={{
               marginBottom: 2,
             }}
@@ -86,14 +86,16 @@ const Dashboard: AuthWallPageContent = ({ user }) => {
           </Typography>
 
           <Typography
+            variant="bpSmallCaps"
             maxWidth={750}
             sx={{
               marginTop: {
                 xs: 3,
                 md: 6,
               },
+              letterSpacing: "0.05em",
               textTransform: "uppercase",
-              color: "#64778C",
+              color: ({ palette }) => palette.gray[60],
               fontWeight: 600,
             }}
           >

--- a/site/src/pages/docs/[[...docsSlug]].page.tsx
+++ b/site/src/pages/docs/[[...docsSlug]].page.tsx
@@ -172,15 +172,24 @@ const DocsPage: NextPage<DocsPageProps> = ({
             maxWidth={750}
             sx={{
               marginBottom: {
-                xs: 2,
-                md: 3,
+                xs: 3,
+                md: 8,
               },
             }}
           >
             {DOCS_PAGE_SUBTITLES[title]}
           </Typography>
         ) : null}
-        <Box py={4} display="flex" alignItems="flex-start">
+        <Box
+          display="flex"
+          alignItems="flex-start"
+          sx={{
+            marginBottom: {
+              xs: 3,
+              md: 8,
+            },
+          }}
+        >
           {md ? (
             <Sidebar
               flexGrow={0}

--- a/site/src/pages/hub.page.tsx
+++ b/site/src/pages/hub.page.tsx
@@ -63,7 +63,13 @@ const HubPage: VFC<PageProps> = ({ catalog }) => {
             <Typography mb={3} variant="bpHeading1">
               Interactive, data-driven blocks to use in your projects
             </Typography>
-            <Typography sx={{ color: ({ palette }) => palette.gray[60] }}>
+            <Typography
+              textAlign="center"
+              sx={{
+                color: ({ palette }) => palette.gray[60],
+                maxWidth: "unset",
+              }}
+            >
               All open-source and free to use
             </Typography>
           </Box>

--- a/site/src/pages/spec/[[...specSlug]].page.tsx
+++ b/site/src/pages/spec/[[...specSlug]].page.tsx
@@ -31,7 +31,7 @@ const GitHubInfoCard = (
     sx={{
       marginBottom: {
         xs: 3,
-        md: 4,
+        md: 5,
       },
       padding: 3,
       display: "flex",
@@ -244,15 +244,15 @@ const SpecPage: NextPage<SpecPageProps> = ({ serializedPage }) => {
           maxWidth={750}
           sx={{
             marginBottom: {
-              xs: 4,
-              md: 4,
+              xs: 6,
+              md: 8,
             },
           }}
         >
           The open-source protocol for creating interactive, data-driven blocks
         </Typography>
         {GitHubInfoCard}
-        <Box mb={4} py={4} display="flex" alignItems="flex-start">
+        <Box mb={4} display="flex" alignItems="flex-start">
           {md ? (
             <Sidebar
               flexGrow={0}

--- a/site/src/theme/components/dataDisplay/MuiTypographyThemeOptions.ts
+++ b/site/src/theme/components/dataDisplay/MuiTypographyThemeOptions.ts
@@ -8,6 +8,7 @@ export const MuiTypographyThemeOptions: Components<Theme>["MuiTypography"] = {
       bpHeading1: "h1",
       bpHeading2: "h2",
       bpHeading3: "h3",
+      bpHeading4: "h4",
       bpSmallCaps: "p",
       bpLargeText: "p",
       bpBodyCopy: "p",

--- a/site/src/util/mdxComponents.tsx
+++ b/site/src/util/mdxComponents.tsx
@@ -94,7 +94,12 @@ const stringifyChildren = (node: ReactNode): string => {
   return "";
 };
 
-const HEADING_MARGIN_TOP = 6;
+const HEADING_MARGIN_TOP = {
+  H1: 8,
+  H2: 8,
+  H3: 6,
+  H4: 6,
+};
 const HEADING_MARGIN_BOTTOM = 2;
 
 export const mdxComponents: Record<string, ReactNode> = {
@@ -109,14 +114,9 @@ export const mdxComponents: Record<string, ReactNode> = {
     return (
       <Heading
         ref={headingRef}
-        mt={HEADING_MARGIN_TOP}
+        mt={HEADING_MARGIN_TOP.H1}
         mb={HEADING_MARGIN_BOTTOM}
         variant="bpHeading1"
-        sx={{
-          "&:first-of-type": {
-            marginTop: 0,
-          },
-        }}
         {...props}
       >
         {props.children}
@@ -135,14 +135,9 @@ export const mdxComponents: Record<string, ReactNode> = {
     return (
       <Heading
         ref={headingRef}
-        mt={HEADING_MARGIN_TOP}
+        mt={HEADING_MARGIN_TOP.H2}
         mb={HEADING_MARGIN_BOTTOM}
         variant="bpHeading2"
-        sx={{
-          "&:first-of-type": {
-            marginTop: 0,
-          },
-        }}
         {...props}
       >
         {props.children}
@@ -161,7 +156,7 @@ export const mdxComponents: Record<string, ReactNode> = {
     return (
       <Heading
         ref={headingRef}
-        mt={HEADING_MARGIN_TOP}
+        mt={HEADING_MARGIN_TOP.H3}
         mb={HEADING_MARGIN_BOTTOM}
         variant="bpHeading3"
         {...props}
@@ -173,7 +168,7 @@ export const mdxComponents: Record<string, ReactNode> = {
   },
   h4: (props: TypographyProps) => (
     <Heading
-      mt={HEADING_MARGIN_TOP}
+      mt={HEADING_MARGIN_TOP.H4}
       mb={HEADING_MARGIN_BOTTOM}
       variant="bpHeading4"
       {...props}


### PR DESCRIPTION
This PR makes the following style fixes:
- [BP hub: fix centering of sub-heading](https://app.asana.com/0/1201472294283826/1201768159094211)
- [Remove underline from Footer navigation links and change hover color](https://app.asana.com/0/0/1201781321575581)
- [Ensure bottom padding on pages is at least equal to top (see attached)](https://app.asana.com/0/0/1201589261424242)
- [fix Footer "HASH" button hover color](https://app.asana.com/0/0/1201781321575583)
- [Centre align text on block hub](https://app.asana.com/0/0/1201781323994489)
- [Adjust hover scale size on block cards](https://app.asana.com/0/0/1201781323994492)
- [Fix login button in mobile menu](https://app.asana.com/0/0/1201822597391098)
- [Change link colour in blue callout blocks to blue](https://app.asana.com/0/0/1201781323994521)
- [Spacing between headings in docs and specification](https://app.asana.com/0/1201472294283826/1201781323994534)
- [Dashboard typography](https://app.asana.com/0/0/1201781323994524)
- [Padding on block focus page tabs](https://app.asana.com/0/0/1201792603369699)
- [[Duplicate] Hub page: long tabs have no padding (but should)](https://app.asana.com/0/0/1201778873029633)

Not addressed in this PR:
- [BP Site block hub styling tweaks](https://app.asana.com/0/1201095311341924/1201880695835354)
- [BP Site homepage styling tweaks](https://app.asana.com/0/1201095311341924/1201880695835351)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201778474952592