### PR TITLE
Fix handling of variants/examples combinations in block hub

### DIFF
--- a/packages/blockprotocol/core.d.ts
+++ b/packages/blockprotocol/core.d.ts
@@ -8,9 +8,11 @@ type DistributedOmit<T, K extends PropertyKey> = T extends T
 
 export type BlockVariant = {
   description?: string | null;
+  /** @deprecated displayName has beeen deprecated - use 'name' instead */
   displayName?: string | null;
   examples?: JSONObject[] | null;
   icon?: string | null;
+  name?: string | null;
   properties?: JSONObject | null;
 };
 

--- a/site/src/components/pages/hub/BlockDataContainer.tsx
+++ b/site/src/components/pages/hub/BlockDataContainer.tsx
@@ -112,7 +112,7 @@ export const BlockDataContainer: VoidFunctionComponent<
         });
       }
     };
-  }, [blockVariantsTab, metadata?.variants, text]);
+  }, [blockVariantsTab, metadata?.examples, metadata?.variants, text]);
 
   /** used to recompute props and errors on dep changes (caching has no benefit here) */
   const [props, errors] = useMemo<[object | undefined, string[]]>(() => {

--- a/site/src/components/pages/hub/BlockDataContainer.tsx
+++ b/site/src/components/pages/hub/BlockDataContainer.tsx
@@ -57,8 +57,8 @@ export const BlockDataContainer: VoidFunctionComponent<
     if (prevPackage.current !== metadata?.packagePath) {
       const example = {
         ...metadata?.examples?.[0],
-        ...metadata?.variants?.[0].examples?.[0],
-        ...metadata?.variants?.[0].properties,
+        ...metadata?.variants?.[0]?.examples?.[0],
+        ...metadata?.variants?.[0]?.properties,
       };
 
       // reset data source input when switching blocks
@@ -88,6 +88,7 @@ export const BlockDataContainer: VoidFunctionComponent<
 
         const nextText = {
           ...parsedText,
+          ...metadata?.examples?.[0],
           ...blockVariant.examples?.[0],
           ...blockVariant.properties,
         };

--- a/site/src/components/pages/hub/BlockVariantsTabs.tsx
+++ b/site/src/components/pages/hub/BlockVariantsTabs.tsx
@@ -21,8 +21,6 @@ export const BlockVariantsTabs: VoidFunctionComponent<
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
-  console.log(metadata.variants);
-
   return isMobile ? (
     <Select
       sx={{ width: "100%", mb: 2 }}

--- a/site/src/components/pages/hub/BlockVariantsTabs.tsx
+++ b/site/src/components/pages/hub/BlockVariantsTabs.tsx
@@ -21,6 +21,8 @@ export const BlockVariantsTabs: VoidFunctionComponent<
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
+  console.log(metadata.variants);
+
   return isMobile ? (
     <Select
       sx={{ width: "100%", mb: 2 }}
@@ -29,8 +31,11 @@ export const BlockVariantsTabs: VoidFunctionComponent<
     >
       {metadata.variants ? (
         metadata.variants.map((variant, variantIndex) => (
-          <MenuItem key={variant.displayName} value={variantIndex}>
-            {variant.displayName}
+          <MenuItem
+            key={variant.name ?? variant.displayName}
+            value={variantIndex}
+          >
+            {variant.name ?? variant.displayName}
           </MenuItem>
         ))
       ) : (
@@ -70,7 +75,10 @@ export const BlockVariantsTabs: VoidFunctionComponent<
     >
       {metadata.variants ? (
         metadata.variants.map((variant) => (
-          <Tab key={variant.displayName} label={variant.displayName} />
+          <Tab
+            key={variant.name ?? variant.displayName}
+            label={variant.name ?? variant.displayName}
+          />
         ))
       ) : (
         <Tab label={metadata.displayName} />


### PR DESCRIPTION
#202 introduced the ability to handle block 'variants' in the block hub.

There were a couple of cases not handled which this PR addresses:
1. Where a block has an empty `variants` array - the index access is now checked
2. When a block has variants, but no example defined for the variant - this now falls back to the root example

We also intend to start using `name` instead of `displayName` for the variant's name. This PR handles blocks that still use the old `displayName` (we can remove it after a while).