### PR TITLE
Increase `waitOn` timeout in package smoke tests

### DIFF
--- a/scripts/packages/smoke-test-create-block-app.ts
+++ b/scripts/packages/smoke-test-create-block-app.ts
@@ -117,7 +117,7 @@ const script = async () => {
       },
     });
 
-    await waitOn({ resources: ["http://localhost:9090"], timeout: 10000 });
+    await waitOn({ resources: ["http://localhost:9090"], timeout: 20000 });
 
     await killProcessTree(devProcess.pid!, "SIGINT");
 


### PR DESCRIPTION
Potentially fixes flaky smoke tests ([example](https://github.com/blockprotocol/blockprotocol/runs/5319952974?check_suite_focus=true))

[Slack thread](https://hashintel.slack.com/archives/C02LG39FJAU/p1645717210124629) & [Asana task](https://app.asana.com/0/1200211978612931/1201883594890019/f) (internal)