### PR TITLE
Hotfix scrolling and performance issues on profile page

### DIFF
--- a/site/src/components/pages/user/UserPageComponent.tsx
+++ b/site/src/components/pages/user/UserPageComponent.tsx
@@ -41,8 +41,9 @@ export const UserPageComponent: VoidFunctionComponent<UserPageProps> = ({
 
   useEffect(() => {
     const { profileTabs } = router.query;
+    const profileTabSlug = Array.isArray(profileTabs) ? profileTabs[0] : "";
 
-    const matchingTab = TABS.find((tab) => tab.slug === profileTabs?.[0]);
+    const matchingTab = TABS.find((tab) => profileTabSlug === tab.slug);
 
     if (!matchingTab) {
       void router.replace(`/@${user.shortname}`);


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/1200211978612931/1201907149831297/f) (internal)

This PR provides a quick hotfix for the user profile page (`blockprotocol.org/@user`). It removes an ‘infinite `useEffect` loop’ which triggers endless calls to `getServerSideProps`. This resets scroll position via endless `router.push` calls.

Although this PR fixes the above problems, we still need a better fix (I am working on it). Current implementation does not support browser navigation (back & forward) and does not allow us to open tabs in a new window too (by using ctrl+click). I will submit a proper fix a bit later as it requires some refactoring. This PR can help in the meantime.