### PR TITLE
Add aggregation handling to mock-block-dock

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -163,6 +163,8 @@ module.exports = {
         ],
       },
     ],
+    "no-redeclare": "off",
+    "@typescript-eslint/no-redeclare": ["error"],
   },
   settings: {
     "import/resolver": {

--- a/hub/@hash/table.json
+++ b/hub/@hash/table.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "4af1b13a93e104577433ea718b3acef6c674647b",
+  "commit": "81eef9dc847b355b8122e1ff256e0bb9155fe66a",
 
   "workspace": "@hashintel/block-table",
   "distDir": "dist"

--- a/hub/@hash/table.json
+++ b/hub/@hash/table.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "ec9e50601629207f1fde76a817b02aa8733762fe",
+  "commit": "4af1b13a93e104577433ea718b3acef6c674647b",
 
   "workspace": "@hashintel/block-table",
   "distDir": "dist"

--- a/packages/blockprotocol/core.d.ts
+++ b/packages/blockprotocol/core.d.ts
@@ -298,8 +298,15 @@ export type BlockProtocolUpdateLinkAction = {
   data: BlockProtocolLink;
   sourceAccountId?: string | null;
   sourceEntityId?: string | null;
-  linkId: string;
-};
+} & (
+  | { linkId: string }
+  | {
+      // temporary identifiers for LinkedAggregations - to be replaced with a single id
+      sourceAccountId?: string | null;
+      sourceEntityId: string;
+      path: string;
+    }
+);
 
 export type BlockProtocolUpdateLinksFunction = {
   (actions: BlockProtocolUpdateLinkAction[]): Promise<BlockProtocolLink[]>;
@@ -343,10 +350,10 @@ export type BlockProtocolAggregateEntityTypesPayload = {
   // @todo mention in spec or remove
   // include entities that are used by, but don't belong to, the specified account
   includeOtherTypesInUse?: boolean | null;
-  operation?: Omit<
+  operation?: DistributedOmit<
     BlockProtocolAggregateOperationInput,
     "entityTypeId" | "entityTypeVersionId"
-  >;
+  > | null;
 };
 
 export type BlockProtocolAggregateEntityTypesFunction = {

--- a/packages/mock-block-dock/package.json
+++ b/packages/mock-block-dock/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "blockprotocol": "0.0.6",
+    "lodash": "^4.17.21",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/mock-block-dock/src/MockBlockDock.tsx
+++ b/packages/mock-block-dock/src/MockBlockDock.tsx
@@ -31,8 +31,10 @@ export const MockBlockDock: VoidFunctionComponent<MockBlockDockProps> = ({
       ...(blockSchema ?? {}),
     };
 
+    const accountId = children.props.accountId ?? "accountId";
+
     const initialBlockEntity: BlockProtocolEntity = {
-      accountId: "account1",
+      accountId,
       entityId: "block1",
     };
 
@@ -48,9 +50,19 @@ export const MockBlockDock: VoidFunctionComponent<MockBlockDockProps> = ({
 
     const nextMockData: MockData = { ...initialMockData };
 
-    nextMockData.entities = [...initialMockData.entities, initialBlockEntity];
+    // give the entities/types the same accountId as the root entity
+    nextMockData.entities = [
+      ...initialMockData.entities.map((entity) => ({
+        ...entity,
+        accountId,
+      })),
+      initialBlockEntity,
+    ];
     nextMockData.entityTypes = [
-      ...initialMockData.entityTypes,
+      ...initialMockData.entityTypes.map((entityType) => ({
+        ...entityType,
+        accountId,
+      })),
       blockEntityType,
     ];
 
@@ -91,7 +103,7 @@ export const MockBlockDock: VoidFunctionComponent<MockBlockDockProps> = ({
     prevChildPropsString.current = JSON.stringify(children.props);
   }, [accountId, entityId, entityTypeId, children.props, updateEntities]);
 
-  const { linkGroups, linkedEntities } = useLinkFields({
+  const { linkedAggregations, linkedEntities, linkGroups } = useLinkFields({
     entities,
     links,
     startingEntity: latestBlockEntity,
@@ -112,9 +124,10 @@ export const MockBlockDock: VoidFunctionComponent<MockBlockDockProps> = ({
   const propsToInject = {
     ...latestBlockEntity,
     ...functions,
-    entityTypes: [latestBlockEntityType],
-    linkGroups,
+    entityTypes,
+    linkedAggregations,
     linkedEntities,
+    linkGroups,
   };
 
   return cloneElement(Children.only(children), propsToInject);

--- a/packages/mock-block-dock/src/data/entities.ts
+++ b/packages/mock-block-dock/src/data/entities.ts
@@ -14,19 +14,13 @@ const createPerson = (entityId: number): BlockProtocolEntity => {
   const name = personNames[entityId];
   return {
     entityId: `person-${entityId.toString()}`,
-    timestamps: {
-      createdAt: now,
-      updatedAt: now,
-    },
-    properties: {
-      age: Math.ceil(Math.random() * 100),
-      email: {
-        address: `${name}@example.com`,
-        primary: true,
-      },
-      name,
-      username: name.toLowerCase(),
-    },
+    entityTypeId: "Person",
+    createdAt: now,
+    updatedAt: now,
+    age: Math.ceil(Math.random() * 100),
+    email: `${name}@example.com`,
+    name,
+    username: name.toLowerCase(),
   };
 };
 
@@ -34,15 +28,12 @@ const createCompany = (entityId: number): BlockProtocolEntity => {
   const now = new Date();
   const name = companyNames[entityId];
   return {
-    entityId: entityId.toString(),
-    timestamps: {
-      createdAt: now,
-      updatedAt: now,
-    },
-    properties: {
-      employees: Math.ceil(Math.random() * 10_000),
-      name,
-    },
+    entityId: `company-${entityId.toString()}`,
+    entityTypeId: "Company",
+    createdAt: now,
+    updatedAt: now,
+    employees: Math.ceil(Math.random() * 10_000),
+    name,
   };
 };
 

--- a/packages/mock-block-dock/src/data/entityTypes.ts
+++ b/packages/mock-block-dock/src/data/entityTypes.ts
@@ -1,3 +1,53 @@
 import { BlockProtocolEntityType } from "blockprotocol";
 
-export const entityTypes: BlockProtocolEntityType[] = [];
+export const entityTypes: BlockProtocolEntityType[] = [
+  {
+    $id: "https://example.com/types/Company",
+    title: "Company",
+    entityTypeId: "Company",
+    type: "object",
+    $schema: "https://json-schema.org/draft/2019-09/schema",
+    description: "A company or organisation.",
+    properties: {
+      employees: {
+        type: "number",
+        description: "The number of employees in the company.",
+      },
+      name: {
+        type: "string",
+        description: "A display name for the company.",
+      },
+    },
+    required: ["name", "employees"],
+  },
+  {
+    $id: "https://example.com/types/Person",
+    title: "Person",
+    entityTypeId: "Person",
+    type: "object",
+    $schema: "https://json-schema.org/draft/2019-09/schema",
+    description: "A human person.",
+    properties: {
+      age: {
+        type: "number",
+        description: "The age of the person, in years.",
+      },
+      email: {
+        type: "string",
+        description: "An email address.",
+        format: "email",
+      },
+      name: {
+        type: "string",
+        description: "The person's name.",
+      },
+      username: {
+        description: "The person's username in this application",
+        type: "string",
+        minLength: 4,
+        maxLength: 24,
+      },
+    },
+    required: ["age", "email", "name", "username"],
+  },
+];

--- a/packages/mock-block-dock/src/useMockDatastore.ts
+++ b/packages/mock-block-dock/src/useMockDatastore.ts
@@ -1,4 +1,6 @@
 import {
+  BlockProtocolAggregateEntitiesFunction,
+  BlockProtocolAggregateEntityTypesFunction,
   BlockProtocolCreateEntitiesFunction,
   BlockProtocolCreateLinksFunction,
   BlockProtocolDeleteEntitiesFunction,
@@ -15,7 +17,7 @@ import {
 } from "blockprotocol";
 import { useCallback, useEffect, useState } from "react";
 import { v4 as uuid } from "uuid";
-import { matchIdentifiers } from "./util";
+import { filterAndSortEntitiesOrTypes, matchIdentifiers } from "./util";
 
 export type MockData = {
   entities: BlockProtocolEntity[];
@@ -27,25 +29,20 @@ type MockDataStore = MockData & {
   functions: Omit<
     // @todo implement missing functions
     BlockProtocolFunctions,
-    | "aggregateEntities"
-    | "aggregateEntityTypes"
     | "getEntityTypes"
     | "createEntityTypes"
     | "updateEntityTypes"
     | "deleteEntityTypes"
-    | "uploadFile"
   >;
 };
 
-type UseMockDataStore = (initialData?: MockData) => MockDataStore;
-
-export const useMockDatastore: UseMockDataStore = (
-  initialData = {
+export const useMockDatastore = (
+  initialData: MockData = {
     entities: [],
     links: [],
     entityTypes: [],
   },
-) => {
+): MockDataStore => {
   const [entities, setEntities] = useState<MockDataStore["entities"]>(
     initialData.entities,
   );
@@ -57,6 +54,19 @@ export const useMockDatastore: UseMockDataStore = (
   useEffect(() => {
     setEntities(initialData.entities);
   }, [initialData.entities]);
+
+  const aggregateEntityTypes: BlockProtocolAggregateEntityTypesFunction =
+    useCallback(
+      async (payload) => {
+        return filterAndSortEntitiesOrTypes(entityTypes, payload);
+      },
+      [entityTypes],
+    );
+
+  const aggregateEntities: BlockProtocolAggregateEntitiesFunction = useCallback(
+    async (payload) => filterAndSortEntitiesOrTypes(entities, payload),
+    [entities],
+  );
 
   const createEntities: BlockProtocolCreateEntitiesFunction = useCallback(
     async (actions) => {
@@ -177,11 +187,19 @@ export const useMockDatastore: UseMockDataStore = (
       const updatedLinks: BlockProtocolLink[] = [];
       setLinks((currentLinks) =>
         currentLinks.map((link) => {
-          const actionToApply = actions.find(
-            (action) => link.linkId === action.linkId,
-          );
+          const actionToApply = actions.find((action) => {
+            if ("linkId" in action) {
+              return link.linkId === action.linkId;
+            }
+            const { sourceEntityId, sourceAccountId, path } = action;
+            return (
+              sourceEntityId === link.sourceEntityId &&
+              path === link.path &&
+              (!sourceAccountId || sourceAccountId === link.sourceAccountId)
+            );
+          });
           if (actionToApply) {
-            const newLink = { ...link, ...actionToApply } as BlockProtocolLink;
+            const newLink = { ...link, operation: actionToApply.data };
             updatedLinks.push(newLink);
             return newLink;
           }
@@ -277,6 +295,8 @@ export const useMockDatastore: UseMockDataStore = (
     entities,
     entityTypes,
     functions: {
+      aggregateEntities,
+      aggregateEntityTypes,
       getEntities,
       createEntities,
       deleteEntities,

--- a/site/package.json
+++ b/site/package.json
@@ -5,8 +5,6 @@
   "license": "MIT",
   "scripts": {
     "build": "yarn exe scripts/build.ts",
-    "build-block": "./scripts/build-blocks.sh",
-    "build-blocks": "find ../hub -type f | xargs ./scripts/build-blocks.sh",
     "clean": "rimraf ./.next/",
     "dev": "yarn exe scripts/dev.ts",
     "dev:db": "docker-compose -f docker-compose.dev.yml --env-file .env.local up",

--- a/site/package.json
+++ b/site/package.json
@@ -48,7 +48,7 @@
     "html-to-text": "^8.1.0",
     "immer": "^9.0.12",
     "jsonschema": "^1.4.0",
-    "lodash": "4.17.21",
+    "lodash": "^4.17.21",
     "md5": "^2.3.0",
     "mime-types": "^2.1.34",
     "mock-block-dock": "0.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6608,7 +6608,7 @@ lodash.uniq@4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.21, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
+lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
This expands `mock-block-dock`'s functionality to include `linkedAggregations`, `aggregateEntities` and `aggregateEntityTypes`. The table block and similar depend on these functions.

It also updates `updateLinks` function to handle how we're currently updated linked aggregations, which are identified by fields other than `linkId` - we intend to change this so that
 (a) linked aggregations are in fact identified by a `linkId`, and 
 (b) have separate CRUD operations for linked aggregations vs links to single entities, to save the kind of branching seen here.
— so this will change again soon once we've worked through that.

Other changes:
- add mock entity types
- update `no-redeclare` linting rule to the TS version to allow function overloads
- remove obsolete scripts in `package.json`
- updates the table block hash to bring in the fixes from https://github.com/hashintel/hash/pull/373

## Demo

https://user-images.githubusercontent.com/37743469/156813483-c7acc64c-96a3-45f5-8a27-74f3911ce3db.mp4

