### PR TITLE
Speed up profile page on Vercel

### DIFF
--- a/.github/workflows/algolia-upload-index.yml
+++ b/.github/workflows/algolia-upload-index.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   triage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/labeler@v3
         with:

--- a/.github/workflows/warm-up-vercel.yml
+++ b/.github/workflows/warm-up-vercel.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Fetch URLs that use AWS Lambda
         run: |
           cat << EOF > curl-format.txt
-            %{url}\n
+            %{url_effective}\n
               Status code: %{http_code}\n
               Time: %{time_total}\n
             \n

--- a/.github/workflows/warm-up-vercel.yml
+++ b/.github/workflows/warm-up-vercel.yml
@@ -1,9 +1,13 @@
+## Vercel uses AWS Lambda. When we call getStaticProps in fallback mode or getServerSideProps,
+## a cold Lambda function may take 5-15 seconds to execute. This pipeline warms up Lambda
+## containers for new deployments and keeps them up by fetching affected URLs every 10 minutes.
+
 name: Warm-up Vercel
 
 on:
   deployment_status:
   schedule:
-    - cron: "*/10 * * * *" ## every 10 minutes
+    - cron: "*/10 * * * *"
 
 jobs:
   fetch:

--- a/.github/workflows/warm-up-vercel.yml
+++ b/.github/workflows/warm-up-vercel.yml
@@ -6,7 +6,6 @@ on:
     - cron: "*/10 * * * *" ## every 10 minutes
 
 jobs:
-  ##  && github.event.deployment.environment == 'refs/heads/main'
   warm-up:
     if: |
       !github.event.deployment_status || (github.event.deployment_status.state == 'success')
@@ -14,7 +13,15 @@ jobs:
     steps:
       - name: Visit URLs that use AWS Lambda
         run: |
-          curl "${BASE_URL}/@hash"
-          curl "${BASE_URL}/types/DUMMY_ENTITY_ID"
+          for PATHNAME in "/@hash" "/types/DUMMY_ENTITY_ID"
+          do
+            echo ""
+            echo ""
+            echo "========"
+            echo "${BASE_URL}${PATHNAME}"
+            echo "========"
+            echo ""
+            time curl --head "${BASE_URL}${PATHNAME}"
+          done
         env:
-          BASE_URL: ${{ github.event.deployment_status.target_url || 'https://blockprotocol.org' }}
+          BASE_URL: "${{ github.event.deployment_status ? github.event.deployment_status.target_url : 'https://blockprotocol.org' }}"

--- a/.github/workflows/warm-up-vercel.yml
+++ b/.github/workflows/warm-up-vercel.yml
@@ -8,7 +8,8 @@ on:
 jobs:
   ##  && github.event.deployment.environment == 'refs/heads/main'
   warm-up:
-    if: \!github.event.deployment_status || (github.event.deployment_status.state == 'success')
+    if: |
+      !github.event.deployment_status || (github.event.deployment_status.state == 'success')
     runs-on: ubuntu-20.04
     steps:
       - name: Visit URLs that use AWS Lambda

--- a/.github/workflows/warm-up-vercel.yml
+++ b/.github/workflows/warm-up-vercel.yml
@@ -9,7 +9,7 @@ jobs:
   fetch:
     name: "Fetch"
     if: |
-      !github.event.deployment_status || (github.event.deployment_status.state == 'success')
+      !github.event.deployment_status || github.event.deployment_status.state == "success"
     runs-on: ubuntu-20.04
     steps:
       - name: Fetch URLs that use AWS Lambda
@@ -26,4 +26,4 @@ jobs:
             curl --output /dev/null --silent --write-out "@curl-format.txt" "${BASE_URL}${PATHNAME}"
           done
         env:
-          BASE_URL: ${{ github.event.deployment_status && github.event.deployment_status.target_url || 'https://blockprotocol.org' }}
+          BASE_URL: ${{ github.event.deployment_status && github.event.deployment_status.target_url || "https://blockprotocol.org" }}

--- a/.github/workflows/warm-up-vercel.yml
+++ b/.github/workflows/warm-up-vercel.yml
@@ -6,10 +6,9 @@ on:
     - cron: "*/10 * * * *" ## every 10 minutes
 
 jobs:
+  ##  && github.event.deployment.environment == 'refs/heads/main'
   warm-up:
-    if: |
-      (github.event.type == 'DeploymentStatus' && github.event.deployment_status.state == 'success')
-      || github.event.type == 'Schedule'
+    if: \!github.event.deployment_status || (github.event.deployment_status.state == 'success')
     runs-on: ubuntu-20.04
     steps:
       - name: Visit URLs that use AWS Lambda

--- a/.github/workflows/warm-up-vercel.yml
+++ b/.github/workflows/warm-up-vercel.yml
@@ -9,7 +9,7 @@ jobs:
   fetch:
     name: "Fetch"
     if: |
-      !github.event.deployment_status || github.event.deployment_status.state == "success"
+      !github.event.deployment_status || github.event.deployment_status.state == 'success'
     runs-on: ubuntu-20.04
     steps:
       - name: Fetch URLs that use AWS Lambda
@@ -21,8 +21,7 @@ jobs:
             \n
           EOF
 
-          for PATHNAME in "/@hash" "/types/DUMMY_ENTITY_ID"
-          do
+          for PATHNAME in "/@hash" "/types/DUMMY_ENTITY_ID"; do
             curl --output /dev/null --silent --write-out "@curl-format.txt" "${BASE_URL}${PATHNAME}"
           done
         env:

--- a/.github/workflows/warm-up-vercel.yml
+++ b/.github/workflows/warm-up-vercel.yml
@@ -1,0 +1,20 @@
+name: Warm-up Vercel
+
+on:
+  deployment_status:
+  schedule:
+    - cron: "*/10 * * * *" ## every 10 minutes
+
+jobs:
+  warm-up:
+    if: |
+      (github.event.type == 'DeploymentStatus' && github.event.deployment_status.state == 'success')
+      || github.event.type == 'Schedule'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Visit URLs that use AWS Lambda
+        run: |
+          curl "${BASE_URL}/@hash"
+          curl "${BASE_URL}/types/DUMMY_ENTITY_ID"
+        env:
+          BASE_URL: ${{ github.event.deployment_status.target_url || 'https://blockprotocol.org' }}

--- a/.github/workflows/warm-up-vercel.yml
+++ b/.github/workflows/warm-up-vercel.yml
@@ -6,22 +6,24 @@ on:
     - cron: "*/10 * * * *" ## every 10 minutes
 
 jobs:
-  warm-up:
+  fetch:
+    name: "Fetch"
     if: |
       !github.event.deployment_status || (github.event.deployment_status.state == 'success')
     runs-on: ubuntu-20.04
     steps:
-      - name: Visit URLs that use AWS Lambda
+      - name: Fetch URLs that use AWS Lambda
         run: |
+          cat << EOF > curl-format.txt
+            %{url}\n
+              Status code: %{http_code}\n
+              Time: %{time_total}\n
+            \n
+          EOF
+
           for PATHNAME in "/@hash" "/types/DUMMY_ENTITY_ID"
           do
-            echo ""
-            echo ""
-            echo "========"
-            echo "${BASE_URL}${PATHNAME}"
-            echo "========"
-            echo ""
-            time curl --head "${BASE_URL}${PATHNAME}"
+            curl --output /dev/null --silent --write-out "@curl-format.txt" "${BASE_URL}${PATHNAME}"
           done
         env:
-          BASE_URL: "${{ github.event.deployment_status && github.event.deployment_status.target_url || 'https://blockprotocol.org' }}"
+          BASE_URL: ${{ github.event.deployment_status && github.event.deployment_status.target_url || 'https://blockprotocol.org' }}

--- a/.github/workflows/warm-up-vercel.yml
+++ b/.github/workflows/warm-up-vercel.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           cat << EOF > curl-format.txt
             %{url_effective}\n
-              Status code: %{http_code}\n
+              Status code: %{response_code}\n
               Time: %{time_total}\n
             \n
           EOF
@@ -26,4 +26,4 @@ jobs:
             curl --output /dev/null --silent --write-out "@curl-format.txt" "${BASE_URL}${PATHNAME}"
           done
         env:
-          BASE_URL: ${{ github.event.deployment_status && github.event.deployment_status.target_url || "https://blockprotocol.org" }}
+          BASE_URL: ${{ github.event.deployment_status && github.event.deployment_status.target_url || 'https://blockprotocol.org' }}

--- a/.github/workflows/warm-up-vercel.yml
+++ b/.github/workflows/warm-up-vercel.yml
@@ -24,4 +24,4 @@ jobs:
             time curl --head "${BASE_URL}${PATHNAME}"
           done
         env:
-          BASE_URL: "${{ github.event.deployment_status ? github.event.deployment_status.target_url : 'https://blockprotocol.org' }}"
+          BASE_URL: "${{ github.event.deployment_status && github.event.deployment_status.target_url || 'https://blockprotocol.org' }}"

--- a/site/src/pages/[shortname]/[[...profileTabs]].page.tsx
+++ b/site/src/pages/[shortname]/[[...profileTabs]].page.tsx
@@ -24,11 +24,8 @@ export const getServerSideProps: GetServerSideProps<
     return { notFound: true };
   }
 
-  const [blocksResponse, entityTypesResponse] = await Promise.all([
+  const [blocksResponse] = await Promise.all([
     apiClient.getUserBlocks({
-      shortname: shortname.replace("@", ""),
-    }),
-    apiClient.getUserEntityTypes({
       shortname: shortname.replace("@", ""),
     }),
   ]);
@@ -44,7 +41,7 @@ export const getServerSideProps: GetServerSideProps<
   return {
     props: {
       blocks: blocksResponse.data?.blocks || [],
-      entityTypes: entityTypesResponse.data?.entityTypes || [],
+      entityTypes: [],
       initialActiveTab,
       user: {},
     },

--- a/site/src/pages/[shortname]/[[...profileTabs]].page.tsx
+++ b/site/src/pages/[shortname]/[[...profileTabs]].page.tsx
@@ -24,23 +24,14 @@ export const getServerSideProps: GetServerSideProps<
     return { notFound: true };
   }
 
-  const [userResponse, blocksResponse, entityTypesResponse] = await Promise.all(
-    [
-      apiClient.getUser({
-        shortname: shortname.replace("@", ""),
-      }),
-      apiClient.getUserBlocks({
-        shortname: shortname.replace("@", ""),
-      }),
-      apiClient.getUserEntityTypes({
-        shortname: shortname.replace("@", ""),
-      }),
-    ],
-  );
-
-  if (userResponse.error || !userResponse.data) {
-    return { notFound: true };
-  }
+  const [blocksResponse, entityTypesResponse] = await Promise.all([
+    apiClient.getUserBlocks({
+      shortname: shortname.replace("@", ""),
+    }),
+    apiClient.getUserEntityTypes({
+      shortname: shortname.replace("@", ""),
+    }),
+  ]);
 
   let initialActiveTab: TabValue = TABS[0].value;
 
@@ -55,7 +46,7 @@ export const getServerSideProps: GetServerSideProps<
       blocks: blocksResponse.data?.blocks || [],
       entityTypes: entityTypesResponse.data?.entityTypes || [],
       initialActiveTab,
-      user: userResponse.data?.user,
+      user: {},
     },
   };
 };

--- a/site/src/pages/[shortname]/[[...profileTabs]].page.tsx
+++ b/site/src/pages/[shortname]/[[...profileTabs]].page.tsx
@@ -24,12 +24,6 @@ export const getServerSideProps: GetServerSideProps<
     return { notFound: true };
   }
 
-  const [blocksResponse] = await Promise.all([
-    apiClient.getUserBlocks({
-      shortname: shortname.replace("@", ""),
-    }),
-  ]);
-
   let initialActiveTab: TabValue = TABS[0].value;
 
   const matchingTab = TABS.find((tab) => tab.slug === profileTabs?.[0]);
@@ -40,7 +34,7 @@ export const getServerSideProps: GetServerSideProps<
 
   return {
     props: {
-      blocks: blocksResponse.data?.blocks || [],
+      blocks: [],
       entityTypes: [],
       initialActiveTab,
       user: {},

--- a/site/src/pages/[shortname]/index.page.tsx
+++ b/site/src/pages/[shortname]/index.page.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { NextPage, GetServerSideProps } from "next";
 
-import { apiClient } from "../../lib/apiClient";
-
 import {
   UserPageComponent,
   UserPageProps,


### PR DESCRIPTION
This PR speeds up TTFB for pages like `/@hash` or `/types/UUID`. This is done via:

- **Pro-active page warm-ups with a new GitHub workflow**
  This trick significantly  reduces TTFB. See diff comment for details. Related discussions:
  - https://github.com/vercel/vercel/discussions/6878
  - https://github.com/vercel/vercel/discussions/5422
  
  Pipeline example: https://github.com/blockprotocol/blockprotocol/actions/runs/1956402602
  
  <img width="644" alt="Screenshot 2022-03-09 at 09 07 08" src="https://user-images.githubusercontent.com/608862/157413100-9652d98d-cc59-497e-9fb0-b98987f72c88.png">
   
   Event docs (used in a new GitHub workflow):
   - https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#deployment_status
   - https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
  - https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#deployment_status

- **Replacing `getServerSideProps` with `getStaticProps` + 60s cache on the profile page**
   The effect of this change is quite small compared to Lambda warm-ups. However, we still benefit from fewer calls to Mongo DB by not calling `getServerSideProps` on every request.

   I haven’t switched from `getServerSideProps` to `getStaticProps` in `site/src/pages/types/[entityTypeId].page.tsx` because we use `req` and `res` there.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201837296904631