### PR TITLE
Accept all npm-supported repository URLs in blocks

### DIFF
--- a/site/scripts/prepare-blocks.ts
+++ b/site/scripts/prepare-blocks.ts
@@ -189,7 +189,7 @@ const ensureRepositorySnapshot = async ({
     console.log(`Repository snapshot ready in ${repositorySnapshotDirPath}`);
     return repositorySnapshotDirPath;
   } finally {
-    await cleanupTarDirPath();
+    await cleanupTarDir();
   }
 };
 

--- a/site/scripts/prepare-blocks.ts
+++ b/site/scripts/prepare-blocks.ts
@@ -163,11 +163,16 @@ const ensureRepositorySnapshot = async ({
       defaultExecaOptions,
     );
 
-    console.log(chalk.green(`Unpacking archive...`));
     const untarPath = path.resolve(untarDirPath, "repo");
+
+    console.log(chalk.green(`Creating output directory...`));
+    await execa("mkdir", ["-p", untarPath]);
+
+    console.log(chalk.green(`Unpacking archive...`));
+
     await execa(
       "tar",
-      ["-xfv", path.resolve(untarDirPath, "repo.tar.gz"), "-C", untarPath],
+      ["-xvf", path.resolve(untarDirPath, "repo.tar.gz"), "-C", untarPath],
       defaultExecaOptions,
     );
 

--- a/site/scripts/prepare-blocks.ts
+++ b/site/scripts/prepare-blocks.ts
@@ -148,7 +148,7 @@ const ensureRepositorySnapshot = async ({
     return repositorySnapshotDirPath;
   }
 
-  const { path: tarDirPath, cleanup: cleanupTarDirPath } = await tmp.dir({
+  const { path: tarDirPath, cleanup: cleanupTarDir } = await tmp.dir({
     unsafeCleanup: true,
   });
 

--- a/site/scripts/prepare-blocks.ts
+++ b/site/scripts/prepare-blocks.ts
@@ -124,11 +124,9 @@ const ensureRepositorySnapshot = async ({
     ?.tarball({ committish: commit });
 
   if (!tarballUrl) {
-    {
-      throw new Error(
-        `Cannot get tarball for repository URL ${repositoryHref}. It needs to be a valid repository URL.`,
-      );
-    }
+    throw new Error(
+      `Cannot get tarball for repository URL ${repositoryHref}. It needs to be a valid repository URL.`,
+    );
   }
 
   const repositorySnapshotSlug = slugify(

--- a/site/scripts/prepare-blocks.ts
+++ b/site/scripts/prepare-blocks.ts
@@ -154,7 +154,7 @@ const ensureRepositorySnapshot = async ({
 
   try {
     console.log(chalk.green(`Downloading ${tarballUrl}...`));
-    // @todo Consider finding cross-platform NPM packages for curl and tar commands
+    // @todo Consider finding cross-platform NPM packages for `curl` and `tar` commands
     await execa(
       "curl",
       ["-sL", "-o", path.resolve(tarDirPath, `repo.tar.gz`), tarballUrl],

--- a/site/src/lib/blocks.ts
+++ b/site/src/lib/blocks.ts
@@ -8,6 +8,7 @@ export type ExpandedBlockMetadata = BlockMetadata & {
   blockPackagePath: string;
   lastUpdated?: string | null;
   packagePath: string;
+  // repository is passed down as a string upon expansion
   repository?: string;
   schema?: string | null;
 };
@@ -15,7 +16,6 @@ export type ExpandedBlockMetadata = BlockMetadata & {
 export interface StoredBlockInfo {
   repository: string;
   commit: string;
-
   distDir?: string;
   folder?: string;
   workspace?: string;

--- a/site/src/pages/[shortname]/blocks/[blockSlug].page.tsx
+++ b/site/src/pages/[shortname]/blocks/[blockSlug].page.tsx
@@ -58,7 +58,6 @@ type BlockPageProps = {
   blockMetadata: BlockMetadata;
   blockStringifiedSource: string;
   catalog: BlockMetadata[];
-  repositoryDisplayUrl: string;
   schema: BlockSchema;
 };
 
@@ -140,9 +139,6 @@ export const getStaticProps: GetStaticProps<
   }
 
   // getStaticProps doesn't parse undefined, so returning an empty string instead
-  const repositoryDisplayUrl = blockMetadata.repository
-    ? generateRepositoryUrl(blockMetadata.repository)
-    : "";
 
   const { schema, source: blockStringifiedSource } =
     readBlockDataFromDisk(blockMetadata);
@@ -152,7 +148,6 @@ export const getStaticProps: GetStaticProps<
       blockMetadata,
       blockStringifiedSource,
       catalog,
-      repositoryDisplayUrl,
       schema,
     },
     revalidate: 1800,
@@ -163,7 +158,6 @@ const BlockPage: NextPage<BlockPageProps> = ({
   blockMetadata,
   blockStringifiedSource,
   catalog,
-  repositoryDisplayUrl,
   schema,
 }) => {
   const { query } = useRouter();
@@ -185,6 +179,10 @@ const BlockPage: NextPage<BlockPageProps> = ({
   const sliderItems = useMemo(() => {
     return catalog.filter(({ name }) => name !== blockMetadata.name);
   }, [catalog, blockMetadata]);
+
+  const repositoryDisplayUrl = blockMetadata.repository
+    ? generateRepositoryDisplayUrl(blockMetadata.repository)
+    : "";
 
   return (
     <>

--- a/site/src/pages/[shortname]/blocks/[blockSlug].page.tsx
+++ b/site/src/pages/[shortname]/blocks/[blockSlug].page.tsx
@@ -102,8 +102,11 @@ const parseQueryParams = (params: BlockPageQueryParams) => {
   return { shortname, blockSlug };
 };
 
-// Show `github.com/org/repo` instead of full URL with protocol, commit hash and path
-const generateRepositoryUrl = (repository: string): string => {
+/**
+ * Helps display `github.com/org/repo` instead of a full URL with protocol, commit hash and path.
+ * If a URL is not recognised as a GitHub repo, only `https://` is removed.
+ */
+const generateRepositoryDisplayUrl = (repository: string): string => {
   const repositoryUrlObject = new URL(repository);
   const displayUrl = `${repositoryUrlObject.hostname}${repositoryUrlObject.pathname}`;
 

--- a/site/src/pages/[shortname]/blocks/[blockSlug].page.tsx
+++ b/site/src/pages/[shortname]/blocks/[blockSlug].page.tsx
@@ -104,9 +104,10 @@ const parseQueryParams = (params: BlockPageQueryParams) => {
 
 // Show `github.com/org/repo` instead of full URL with protocol, commit hash and path
 const generateRepositoryUrl = (repository: string): string => {
-  const displayUrl = repository.replace(/^https?:\/\//, "");
+  const repositoryUrlObject = new URL(repository);
+  const displayUrl = `${repositoryUrlObject.hostname}${repositoryUrlObject.pathname}`;
 
-  if (repository.includes("github.com/")) {
+  if (repositoryUrlObject.hostname === "github.com") {
     return displayUrl.split("/").slice(0, 3).join("/");
   }
 

--- a/site/src/pages/[shortname]/blocks/[blockSlug].page.tsx
+++ b/site/src/pages/[shortname]/blocks/[blockSlug].page.tsx
@@ -138,8 +138,6 @@ export const getStaticProps: GetStaticProps<
     return { notFound: true };
   }
 
-  // getStaticProps doesn't parse undefined, so returning an empty string instead
-
   const { schema, source: blockStringifiedSource } =
     readBlockDataFromDisk(blockMetadata);
 


### PR DESCRIPTION
## What this Does

The blockprotocol website presently only builds blocks which are in the GitHub URL format, ie, `https://github.com/user/repository`. However, users should be free to add any npm-supported repository link, as long as we can parse it. 

Hence, this PR allows blockprotocol to do just that, by utilizing the `npm/hosted-git-info` package. We use it to get the source URL from any repository URL, and use it to download and build the blocks.

## How to test this?

Run `yarn build` locally, or have a look at the CI output below.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201934058330698