### PR TITLE
Improve how Vercel Lambdas are warmed up

### DIFF
--- a/.github/workflows/warm-up-vercel.yml
+++ b/.github/workflows/warm-up-vercel.yml
@@ -28,4 +28,4 @@ jobs:
             curl --output /dev/null --silent --write-out "@curl-format.txt" "${BASE_URL}${PATHNAME}"
           done
         env:
-          BASE_URL: ${{ github.event.deployment-check.environment != 'production' && github.event.deployment_status.target_url || 'https://blockprotocol.org' }}
+          BASE_URL: ${{ github.event.deployment.environment != 'production' && github.event.deployment_status.target_url || 'https://blockprotocol.org' }}

--- a/.github/workflows/warm-up-vercel.yml
+++ b/.github/workflows/warm-up-vercel.yml
@@ -2,7 +2,7 @@
 ## a cold Lambda function may take 5-15 seconds to execute. This pipeline warms up Lambda
 ## containers for new deployments and keeps them up by fetching affected URLs every 10 minutes.
 
-name: Warm-up Vercel
+name: Warm up Vercel
 
 on:
   deployment_status:
@@ -12,8 +12,7 @@ on:
 jobs:
   fetch:
     name: "Fetch"
-    if: |
-      !github.event.deployment_status || github.event.deployment_status.state == 'success'
+    if: github.event_name == 'schedule' || github.event.deployment_status.state == 'success'
     runs-on: ubuntu-20.04
     steps:
       - name: Fetch URLs that use AWS Lambda
@@ -29,4 +28,4 @@ jobs:
             curl --output /dev/null --silent --write-out "@curl-format.txt" "${BASE_URL}${PATHNAME}"
           done
         env:
-          BASE_URL: ${{ github.event.deployment_status && github.event.deployment_status.target_url || 'https://blockprotocol.org' }}
+          BASE_URL: ${{ github.event.deployment-check.environment != 'production' && github.event.deployment_status.target_url || 'https://blockprotocol.org' }}


### PR DESCRIPTION
This PR follows #250. It makes sure that we warm up `blockprotocol.org/*` instead of `blockprotocol-*-hashintel.vercel.app/*` once a PR is merged into `main`.

I have noticed that fetching a permalink domain does not warm up the main domain for some reason. Maybe it was a co-incidence of some sort, but might be worth fixing. ATM, `blockprotocol.org` pages seem to remain cold till they are refetched on schedule.