### PR TITLE
Update HASH blocks

### DIFF
--- a/hub/@hash/callout.json
+++ b/hub/@hash/callout.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "ec9e50601629207f1fde76a817b02aa8733762fe",
+  "commit": "d78a996e77a9f4b0a744a9217a7af509215e21de",
 
   "workspace": "@hashintel/block-callout",
   "distDir": "dist"

--- a/hub/@hash/callout.json
+++ b/hub/@hash/callout.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "d78a996e77a9f4b0a744a9217a7af509215e21de",
+  "commit": "a5e5bfa508ed515ab1baac285c377ad8c72ed206",
 
   "workspace": "@hashintel/block-callout",
   "distDir": "dist"

--- a/hub/@hash/callout.json
+++ b/hub/@hash/callout.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "a5e5bfa508ed515ab1baac285c377ad8c72ed206",
+  "commit": "c943e77b6cc1bcb7f4006c23c46bd4d51ccb62ba",
 
   "workspace": "@hashintel/block-callout",
   "distDir": "dist"

--- a/hub/@hash/code.json
+++ b/hub/@hash/code.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "d78a996e77a9f4b0a744a9217a7af509215e21de",
+  "commit": "a5e5bfa508ed515ab1baac285c377ad8c72ed206",
 
   "workspace": "@hashintel/block-code",
   "distDir": "dist"

--- a/hub/@hash/code.json
+++ b/hub/@hash/code.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "ec9e50601629207f1fde76a817b02aa8733762fe",
+  "commit": "d78a996e77a9f4b0a744a9217a7af509215e21de",
 
   "workspace": "@hashintel/block-code",
   "distDir": "dist"

--- a/hub/@hash/code.json
+++ b/hub/@hash/code.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "a5e5bfa508ed515ab1baac285c377ad8c72ed206",
+  "commit": "c943e77b6cc1bcb7f4006c23c46bd4d51ccb62ba",
 
   "workspace": "@hashintel/block-code",
   "distDir": "dist"

--- a/hub/@hash/divider.json
+++ b/hub/@hash/divider.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "a5e5bfa508ed515ab1baac285c377ad8c72ed206",
+  "commit": "c943e77b6cc1bcb7f4006c23c46bd4d51ccb62ba",
 
   "workspace": "@hashintel/block-divider",
   "distDir": "dist"

--- a/hub/@hash/divider.json
+++ b/hub/@hash/divider.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "ec9e50601629207f1fde76a817b02aa8733762fe",
+  "commit": "d78a996e77a9f4b0a744a9217a7af509215e21de",
 
   "workspace": "@hashintel/block-divider",
   "distDir": "dist"

--- a/hub/@hash/divider.json
+++ b/hub/@hash/divider.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "d78a996e77a9f4b0a744a9217a7af509215e21de",
+  "commit": "a5e5bfa508ed515ab1baac285c377ad8c72ed206",
 
   "workspace": "@hashintel/block-divider",
   "distDir": "dist"

--- a/hub/@hash/embed.json
+++ b/hub/@hash/embed.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "ec9e50601629207f1fde76a817b02aa8733762fe",
+  "commit": "d78a996e77a9f4b0a744a9217a7af509215e21de",
 
   "workspace": "@hashintel/block-embed",
   "distDir": "dist"

--- a/hub/@hash/embed.json
+++ b/hub/@hash/embed.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "a5e5bfa508ed515ab1baac285c377ad8c72ed206",
+  "commit": "c943e77b6cc1bcb7f4006c23c46bd4d51ccb62ba",
 
   "workspace": "@hashintel/block-embed",
   "distDir": "dist"

--- a/hub/@hash/embed.json
+++ b/hub/@hash/embed.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "d78a996e77a9f4b0a744a9217a7af509215e21de",
+  "commit": "a5e5bfa508ed515ab1baac285c377ad8c72ed206",
 
   "workspace": "@hashintel/block-embed",
   "distDir": "dist"

--- a/hub/@hash/header.json
+++ b/hub/@hash/header.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "d78a996e77a9f4b0a744a9217a7af509215e21de",
+  "commit": "a5e5bfa508ed515ab1baac285c377ad8c72ed206",
 
   "workspace": "@hashintel/block-header",
   "distDir": "dist"

--- a/hub/@hash/header.json
+++ b/hub/@hash/header.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "ec9e50601629207f1fde76a817b02aa8733762fe",
+  "commit": "d78a996e77a9f4b0a744a9217a7af509215e21de",
 
   "workspace": "@hashintel/block-header",
   "distDir": "dist"

--- a/hub/@hash/header.json
+++ b/hub/@hash/header.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "a5e5bfa508ed515ab1baac285c377ad8c72ed206",
+  "commit": "c943e77b6cc1bcb7f4006c23c46bd4d51ccb62ba",
 
   "workspace": "@hashintel/block-header",
   "distDir": "dist"

--- a/hub/@hash/image.json
+++ b/hub/@hash/image.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "a5e5bfa508ed515ab1baac285c377ad8c72ed206",
+  "commit": "c943e77b6cc1bcb7f4006c23c46bd4d51ccb62ba",
 
   "workspace": "@hashintel/block-image",
   "distDir": "dist"

--- a/hub/@hash/image.json
+++ b/hub/@hash/image.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "d78a996e77a9f4b0a744a9217a7af509215e21de",
+  "commit": "a5e5bfa508ed515ab1baac285c377ad8c72ed206",
 
   "workspace": "@hashintel/block-image",
   "distDir": "dist"

--- a/hub/@hash/image.json
+++ b/hub/@hash/image.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "ec9e50601629207f1fde76a817b02aa8733762fe",
+  "commit": "d78a996e77a9f4b0a744a9217a7af509215e21de",
 
   "workspace": "@hashintel/block-image",
   "distDir": "dist"

--- a/hub/@hash/paragraph.json
+++ b/hub/@hash/paragraph.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "d78a996e77a9f4b0a744a9217a7af509215e21de",
+  "commit": "a5e5bfa508ed515ab1baac285c377ad8c72ed206",
 
   "workspace": "@hashintel/block-paragraph",
   "distDir": "dist"

--- a/hub/@hash/paragraph.json
+++ b/hub/@hash/paragraph.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "ec9e50601629207f1fde76a817b02aa8733762fe",
+  "commit": "d78a996e77a9f4b0a744a9217a7af509215e21de",
 
   "workspace": "@hashintel/block-paragraph",
   "distDir": "dist"

--- a/hub/@hash/paragraph.json
+++ b/hub/@hash/paragraph.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "a5e5bfa508ed515ab1baac285c377ad8c72ed206",
+  "commit": "c943e77b6cc1bcb7f4006c23c46bd4d51ccb62ba",
 
   "workspace": "@hashintel/block-paragraph",
   "distDir": "dist"

--- a/hub/@hash/person.json
+++ b/hub/@hash/person.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "d78a996e77a9f4b0a744a9217a7af509215e21de",
+  "commit": "a5e5bfa508ed515ab1baac285c377ad8c72ed206",
 
   "workspace": "@hashintel/block-person",
   "distDir": "dist"

--- a/hub/@hash/person.json
+++ b/hub/@hash/person.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "a5e5bfa508ed515ab1baac285c377ad8c72ed206",
+  "commit": "c943e77b6cc1bcb7f4006c23c46bd4d51ccb62ba",
 
   "workspace": "@hashintel/block-person",
   "distDir": "dist"

--- a/hub/@hash/person.json
+++ b/hub/@hash/person.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "ec9e50601629207f1fde76a817b02aa8733762fe",
+  "commit": "d78a996e77a9f4b0a744a9217a7af509215e21de",
 
   "workspace": "@hashintel/block-person",
   "distDir": "dist"

--- a/hub/@hash/table.json
+++ b/hub/@hash/table.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "81eef9dc847b355b8122e1ff256e0bb9155fe66a",
+  "commit": "d78a996e77a9f4b0a744a9217a7af509215e21de",
 
   "workspace": "@hashintel/block-table",
   "distDir": "dist"

--- a/hub/@hash/table.json
+++ b/hub/@hash/table.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "d78a996e77a9f4b0a744a9217a7af509215e21de",
+  "commit": "a5e5bfa508ed515ab1baac285c377ad8c72ed206",
 
   "workspace": "@hashintel/block-table",
   "distDir": "dist"

--- a/hub/@hash/table.json
+++ b/hub/@hash/table.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "a5e5bfa508ed515ab1baac285c377ad8c72ed206",
+  "commit": "c943e77b6cc1bcb7f4006c23c46bd4d51ccb62ba",
 
   "workspace": "@hashintel/block-table",
   "distDir": "dist"

--- a/hub/@hash/video.json
+++ b/hub/@hash/video.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "d78a996e77a9f4b0a744a9217a7af509215e21de",
+  "commit": "a5e5bfa508ed515ab1baac285c377ad8c72ed206",
 
   "workspace": "@hashintel/block-video",
   "distDir": "dist"

--- a/hub/@hash/video.json
+++ b/hub/@hash/video.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "ec9e50601629207f1fde76a817b02aa8733762fe",
+  "commit": "d78a996e77a9f4b0a744a9217a7af509215e21de",
 
   "workspace": "@hashintel/block-video",
   "distDir": "dist"

--- a/hub/@hash/video.json
+++ b/hub/@hash/video.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "a5e5bfa508ed515ab1baac285c377ad8c72ed206",
+  "commit": "c943e77b6cc1bcb7f4006c23c46bd4d51ccb62ba",
 
   "workspace": "@hashintel/block-video",
   "distDir": "dist"

--- a/site/scripts/prepare-blocks.ts
+++ b/site/scripts/prepare-blocks.ts
@@ -174,7 +174,6 @@ const ensureRepositorySnapshot = async ({
         "--extract",
         `--file=${path.resolve(tarDirPath, "repo.tar.gz")}`,
         `--directory=${outputDirPath}`,
-        "--verbose",
       ],
       defaultExecaOptions,
     );


### PR DESCRIPTION
This PR updates block commit hashes to publish changes in https://github.com/hashintel/hash/pull/398 and https://github.com/hashintel/hash/pull/399

\+ see a [small bonus](https://github.com/blockprotocol/blockprotocol/pull/258#discussion_r824829920)
