### PR TITLE
Handle non-default block exports, detect non-React

### DIFF
--- a/site/src/components/pages/hub/BlockDataContainer.tsx
+++ b/site/src/components/pages/hub/BlockDataContainer.tsx
@@ -9,6 +9,7 @@ import {
 } from "@mui/material";
 import { Validator } from "jsonschema";
 import {
+  ComponentType,
   useEffect,
   useMemo,
   useRef,
@@ -23,20 +24,20 @@ import { BlockDataTabPanels } from "./BlockDataTabPanels";
 import { BlockDataTabs } from "./BlockDataTabs";
 import { BlockModalButton } from "./BlockModalButton";
 import { BlockTabsModal } from "./BlockTabsModal";
-import { BlockExports, BlockSchema, getEmbedBlock } from "./HubUtils";
+import { BlockSchema, getEmbedBlock } from "./HubUtils";
 import { BlockVariantsTabs } from "./BlockVariantsTabs";
 
 type BlockDataContainerProps = {
   metadata: BlockMetadata;
   schema: BlockSchema;
-  blockModule: BlockExports | undefined;
+  BlockComponent?: ComponentType | undefined;
 };
 
 const validator = new Validator();
 
 export const BlockDataContainer: VoidFunctionComponent<
   BlockDataContainerProps
-> = ({ metadata, schema, blockModule }) => {
+> = ({ metadata, schema, BlockComponent }) => {
   const [blockDataTab, setBlockDataTab] = useState(0);
   const [blockVariantsTab, setBlockVariantsTab] = useState(0);
   const [blockModalOpen, setBlockModalOpen] = useState(false);
@@ -221,9 +222,9 @@ export const BlockDataContainer: VoidFunctionComponent<
                   mx: "auto",
                 }}
               >
-                {blockModule && (
+                {BlockComponent && (
                   <MockBlockDock>
-                    <blockModule.default {...props} />
+                    <BlockComponent {...props} />
                   </MockBlockDock>
                 )}
               </Box>

--- a/site/src/components/pages/hub/HubUtils.tsx
+++ b/site/src/components/pages/hub/HubUtils.tsx
@@ -1,10 +1,10 @@
-import { FC } from "react";
+import { ComponentType } from "react";
 
 /** @todo type as JSON Schema. */
 export type BlockSchema = Record<string, any>;
 export type BlockDependency = keyof typeof blockDependencies;
 export type BlockExports = {
-  default: FC;
+  [key: string]: ComponentType | undefined;
 };
 
 /* eslint-disable global-require */


### PR DESCRIPTION
We currently assume that:
1. Blocks are React components
2. They are the default export from the entry source file

We should implement support for non-React components as they are submitted – until we decide on a prescribed interface for the component. This PR throws an error if something that definitely isn't a React component is encountered, so that the problem is explicit and can be addressed.

We should also handle non-default exports. This PR does that, at least for (1) named `App` exports, and (2) named exports where they are the only one in the file. Since we can't reliably detect other patterns.

[Asana task](https://app.asana.com/0/1200211978612931/1201955153125192/f) (_internal_)