### PR TITLE
Bump TS to 4.6.2, enable `noUncheckedIndexedAccess`

### DIFF
--- a/packages/block-template/package.json
+++ b/packages/block-template/package.json
@@ -52,7 +52,7 @@
     "regenerator-runtime": "^0.13.9",
     "rimraf": "^3.0.2",
     "twind": "^0.16.16",
-    "typescript": "^4.5.5",
+    "typescript": "^4.6.2",
     "typescript-json-schema": "^0.53.0",
     "webpack": "^5.68.0",
     "webpack-assets-manifest": "^5.1.0",

--- a/packages/mock-block-dock/package.json
+++ b/packages/mock-block-dock/package.json
@@ -57,7 +57,7 @@
     "react-dom": "^17.0.2",
     "regenerator-runtime": "^0.13.9",
     "rimraf": "^3.0.2",
-    "typescript": "^4.5.5",
+    "typescript": "^4.6.2",
     "webpack": "^5.68.0",
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.7.4"

--- a/site/package.json
+++ b/site/package.json
@@ -107,6 +107,6 @@
     "micromatch": "^4.0.4",
     "rimraf": "^3.0.2",
     "ts-node": "10.5.0",
-    "typescript": "^4.5.5"
+    "typescript": "^4.6.2"
   }
 }

--- a/site/src/components/MdxPageContent.tsx
+++ b/site/src/components/MdxPageContent.tsx
@@ -91,7 +91,7 @@ export const MdxPageContent: VFC<MdxPageContentProps> = ({
     const onScroll = () => {
       if (!detectHeadingFromScroll) return;
 
-      let headingAtScrollPosition: Heading = headings[0];
+      let headingAtScrollPosition: Heading = headings[0]!;
 
       for (const heading of headings.slice(1)) {
         const { element } = heading;

--- a/site/src/components/Modal/CreateSchemaModal.tsx
+++ b/site/src/components/Modal/CreateSchemaModal.tsx
@@ -32,8 +32,9 @@ export const CreateSchemaModal: FC<CreateSchemaModalProps> = ({
     formattedText = formattedText.replace(/\s/g, "");
 
     // capitalize text
-    if (formattedText.length > 0) {
-      formattedText = formattedText[0].toUpperCase() + formattedText.slice(1);
+    const firstChar = formattedText[0];
+    if (typeof firstChar === "string") {
+      formattedText = firstChar.toUpperCase() + formattedText.slice(1);
     }
 
     setNewSchemaTitle(formattedText);

--- a/site/src/components/PageSidebar.tsx
+++ b/site/src/components/PageSidebar.tsx
@@ -317,7 +317,7 @@ export const Sidebar: VFC<SidebarProps> = ({
 
     if (cachedRef) {
       const observer = new IntersectionObserver(
-        ([event]) => setIsSticky(event.intersectionRatio < 1),
+        ([event]) => setIsSticky(event!.intersectionRatio < 1),
         { threshold: [1] },
       );
 
@@ -432,11 +432,11 @@ export const Sidebar: VFC<SidebarProps> = ({
                 />
               ))
             : pages.length === 1
-            ? pages[0].sections.map((section, i) => (
+            ? pages[0]!.sections.map((section, i) => (
                 <SidebarPageSection
                   isSelectedByDefault={i === 0}
                   key={section.anchor}
-                  pageHref={pages[0].href}
+                  pageHref={pages[0]!.href}
                   section={section}
                   maybeUpdateSelectedOffsetTop={maybeUpdateSelectedOffsetTop}
                   setSelectedAnchorElement={setSelectedAnchorElement}

--- a/site/src/components/entityTypes/SchemaEditor/schemaEditorReducer.ts
+++ b/site/src/components/entityTypes/SchemaEditor/schemaEditorReducer.ts
@@ -210,8 +210,8 @@ export const schemaEditorReducer: Reducer<
           // Update the subschema property
           if (Array.isArray(dependentProperty)) {
             return updatePropertyType(
-              $defs![dependentProperty[0]],
-              dependentProperty[1],
+              $defs![dependentProperty[0]!]!,
+              dependentProperty[1]!,
               "string",
             );
           }
@@ -295,7 +295,7 @@ export const schemaEditorReducer: Reducer<
 
       return produce(schemaState, (draftRootSchema) => {
         const schemaToEdit = selectSubSchema(draftRootSchema, pathToSubSchema);
-        schemaToEdit.properties![propertyName].description =
+        schemaToEdit.properties![propertyName]!.description =
           newPropertyDescription;
       });
     }
@@ -351,7 +351,7 @@ export const schemaEditorReducer: Reducer<
         const schemaToEdit = selectSubSchema(draftRootSchema, pathToSubSchema);
         schemaToEdit.properties ??= {};
         schemaToEdit.properties[newPropertyName] =
-          schemaToEdit.properties[oldPropertyName];
+          schemaToEdit.properties[oldPropertyName]!;
         delete schemaToEdit.properties[oldPropertyName];
       });
     }

--- a/site/src/components/entityTypes/SchemaEditor/schemaEditorReducer.ts
+++ b/site/src/components/entityTypes/SchemaEditor/schemaEditorReducer.ts
@@ -100,7 +100,7 @@ const getDependentProperties = (
     if (
       property?.$ref?.includes(subSchemaNameToDelete) ||
       (Array.isArray(property?.items)
-        ? property?.items[0].$ref?.includes(subSchemaNameToDelete)
+        ? property?.items[0]?.$ref?.includes(subSchemaNameToDelete)
         : property?.items?.$ref?.includes(subSchemaNameToDelete))
     ) {
       dependentProperties.push(prefix ? [prefix, propertyName] : propertyName);

--- a/site/src/components/hooks/useVerificationCodeTextField.ts
+++ b/site/src/components/hooks/useVerificationCodeTextField.ts
@@ -7,7 +7,7 @@ type UseVerificationCodeTextFieldProps = {
 
 export const isVerificationCodeFormatted = (verificationCode: string) => {
   const units = verificationCode.split("-");
-  return units.length >= 4 && units?.[3].length > 0;
+  return units.length >= 4 && units?.[3]!.length > 0;
 };
 
 export const useVerificationCodeTextField = ({

--- a/site/src/components/pages/docs/Search/index.tsx
+++ b/site/src/components/pages/docs/Search/index.tsx
@@ -158,7 +158,7 @@ const Search: React.VoidFunctionComponent<SearchProps> = ({
     event.preventDefault();
 
     if (searchResults.length > 0 && searchResults[activeResult]) {
-      const { slug } = searchResults[activeResult];
+      const { slug } = searchResults[activeResult]!;
 
       (document.querySelector(".search-bar input") as HTMLElement).blur();
 

--- a/site/src/components/pages/home/Section2/Steps.tsx
+++ b/site/src/components/pages/home/Section2/Steps.tsx
@@ -307,7 +307,7 @@ const SchemaBlock: VFC<SchemaBlockProps> = ({
   withTitle,
   titleLocation = "top",
 }) => {
-  const { title, content } = SCHEMA_CONTENT[name ?? "definedTerm"];
+  const { title, content } = SCHEMA_CONTENT[name ?? "definedTerm"] ?? {};
   return (
     <Box
       sx={{
@@ -347,7 +347,7 @@ const SchemaBlock: VFC<SchemaBlockProps> = ({
           borderRadius: "6px",
         }}
       >
-        {content.map(({ key, value, id }) => (
+        {content?.map(({ key, value, id }) => (
           <Box
             sx={{
               display: "flex",
@@ -576,11 +576,9 @@ export const Step2: VFC<StepProps> = ({ isMobile }) => {
 };
 
 export const Step3: VFC<StepProps> = ({ isMobile, isActive }) => {
-  const [titles, setTitles] = useState<AppProps["name"][]>([
-    "todo",
-    "docs",
-    "notes",
-  ]);
+  const [titles, setTitles] = useState<
+    [AppProps["name"], AppProps["name"], AppProps["name"]]
+  >(["todo", "docs", "notes"]);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
@@ -589,9 +587,8 @@ export const Step3: VFC<StepProps> = ({ isMobile, isActive }) => {
         clearInterval(timerRef.current);
       }
       timerRef.current = setInterval(() => {
-        const newTitles = [...titles];
-        newTitles.unshift(newTitles.pop()!);
-        setTitles([...newTitles]);
+        const [title0, title1, title2] = titles;
+        setTitles([title2, title0, title1]);
       }, 3000);
     }
 

--- a/site/src/lib/api/middleware/multipartUploads.middleware.ts
+++ b/site/src/lib/api/middleware/multipartUploads.middleware.ts
@@ -47,7 +47,7 @@ const parseForm = async (
     form.on("file", (fieldName, file, info) => {
       buffers[fieldName] = [];
       file.on("data", (data) => {
-        buffers[fieldName].push(data);
+        buffers[fieldName]!.push(data);
       });
       file.on("limit", () => {
         reject(
@@ -59,7 +59,7 @@ const parseForm = async (
       file.on("end", () => {
         uploads[fieldName] = {
           mime: info.mimeType,
-          buffer: Buffer.concat(buffers[fieldName]),
+          buffer: Buffer.concat(buffers[fieldName]!),
         };
       });
     });

--- a/site/src/lib/api/model/apiKey.model.ts
+++ b/site/src/lib/api/model/apiKey.model.ts
@@ -172,7 +172,11 @@ export class ApiKey {
 
     const INVALID_KEY_ERROR_MSG = "Invalid API key.";
 
-    const [_prefix, publicId, privateId] = apiKeyString.split(".");
+    const [_prefix, publicId, privateId] = apiKeyString.split(".") as [
+      string,
+      string,
+      string,
+    ]; // This assertion is based on KEY_FORMAT_REGEXP;
 
     const apiKey = await ApiKey.getByPublicId(db, { publicId });
 

--- a/site/src/lib/blocks.ts
+++ b/site/src/lib/blocks.ts
@@ -102,7 +102,7 @@ export const readBlocksFromDisk = (): ExpandedBlockMetadata[] => {
 
       return {
         ...metadata,
-        author: metadata.packagePath.split("/")[0].replace(/^@/, ""),
+        author: metadata.packagePath.split("/")[0]!.replace(/^@/, ""),
         icon: getBlockMediaUrl(metadata.icon, metadata.packagePath),
         image: getBlockMediaUrl(metadata.image, metadata.packagePath),
         repository,

--- a/site/src/pages/[shortname]/blocks/[blockSlug].page.tsx
+++ b/site/src/pages/[shortname]/blocks/[blockSlug].page.tsx
@@ -59,7 +59,7 @@ const blockComponentFromSource = (source: string): ComponentType => {
     return exports.App;
   }
   if (Object.keys(exports).length === 1) {
-    return exports[Object.keys(exports)[0]]!;
+    return exports[Object.keys(exports)[0]!]!;
   }
 
   throw new Error(

--- a/site/src/pages/[shortname]/types/[title].page.tsx
+++ b/site/src/pages/[shortname]/types/[title].page.tsx
@@ -71,10 +71,17 @@ const EntityTypePage: NextPage = () => {
         });
     };
 
-  const updateEntityTypes: BlockProtocolUpdateEntityTypesFunction = ([
-    { entityTypeId, schema },
-  ]) =>
-    apiClient
+  const updateEntityTypes: BlockProtocolUpdateEntityTypesFunction = (
+    actions,
+  ) => {
+    if (actions.length !== 1) {
+      throw new Error(
+        `Current implementation of updateEntityTypes supports only one action, ${actions.length} given.`,
+      );
+    }
+    const { entityTypeId, schema } = actions[0]!;
+
+    return apiClient
       .updateEntityType({ schema: JSON.stringify(schema) }, entityTypeId)
       .then(({ data }) => {
         if (data) {
@@ -82,6 +89,7 @@ const EntityTypePage: NextPage = () => {
         }
         throw new Error("Could not update entity type");
       });
+  };
 
   if (isLoading) {
     // @todo proper loading state

--- a/site/src/pages/spec/[[...specSlug]].page.tsx
+++ b/site/src/pages/spec/[[...specSlug]].page.tsx
@@ -170,7 +170,7 @@ export const getStaticProps: GetStaticProps<
   const { specSlug } = params || {};
 
   const fileNameWithoutIndex =
-    specSlug && specSlug.length > 0 ? specSlug[0] : "index";
+    specSlug && specSlug.length > 0 ? specSlug[0]! : "index";
 
   // As of Jan 2022, { fallback: false } in getStaticPaths does not prevent Vercel
   // from calling getStaticProps for unknown pages. This causes 500 instead of 404:

--- a/site/src/util/mdxUtils.tsx
+++ b/site/src/util/mdxUtils.tsx
@@ -169,9 +169,9 @@ export const getPage = (params: {
           ? [
               ...prev.slice(0, -1),
               {
-                ...prev[prev.length - 1],
+                ...prev[prev.length - 1]!,
                 subSections: [
-                  ...(prev[prev.length - 1].subSections || []),
+                  ...(prev[prev.length - 1]!.subSections || []),
                   {
                     title: subSectionTitle,
                     anchor: slugify(subSectionTitle, { lower: true }),

--- a/site/src/util/mdxUtils.tsx
+++ b/site/src/util/mdxUtils.tsx
@@ -58,14 +58,14 @@ const getHeadingsFromParent = (parent: Parent): Heading[] =>
     .flat();
 
 // Parses the name from a MDX file name (removing the prefix index and the .mdx file extension)
-const parseNameFromFileName = (fileName: string) => {
+const parseNameFromFileName = (fileName: string): string => {
   const matches = fileName.match(/^\d+_(.*?)\.mdx$/);
 
   if (!matches || matches.length < 2) {
     throw new Error(`Invalid MDX fileName: ${fileName}`);
   }
 
-  return matches[1];
+  return matches[1]!;
 };
 
 // Gets all hrefs corresponding to the MDX files in a directory

--- a/site/tsconfig.json
+++ b/site/tsconfig.json
@@ -10,6 +10,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmit": true,
+    "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,6 +7,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmit": true,
+    "noUncheckedIndexedAccess": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9314,7 +9314,12 @@ typescript-json-schema@^0.53.0:
     typescript "~4.5.0"
     yargs "^17.1.1"
 
-typescript@^4.5.5, typescript@~4.5.0:
+typescript@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
+  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
+
+typescript@~4.5.0:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==


### PR DESCRIPTION
The main purpose of this PR is to add [`"noUncheckedIndexedAccess"`](https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess) to our repo‘s `tsconfig`. I have also upgraded TS from 4.5 to 4.6 given the opportunity. See [release announcement](https://devblogs.microsoft.com/typescript/announcing-typescript-4-6/).

Most cases of unchecked indexes are ‘fixed’ by adding `!`. This means we can still get runtime errors for the existing code, and if we do, we can refactor it case-by-case. Newly written code will be better type-checked from now on. In general, we should avoid `!` as much as possible.

- [Asana task](https://app.asana.com/0/0/1201950599278304) _(internal)_
- [Slack thread](https://hashintel.slack.com/archives/C022217GAHF/p1645736187865989) _(internal)_
- https://github.com/hashintel/hash/pull/401