### PR TITLE
Fix block-template externals and main source file detection

### DIFF
--- a/packages/block-template/package.json
+++ b/packages/block-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "block-template",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Block template",
   "keywords": [
     "blockprotocol",
@@ -62,8 +62,7 @@
   },
   "peerDependencies": {
     "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "twind": "^0.16.16"
+    "react-dom": "^17.0.2"
   },
   "blockprotocol": {
     "displayName": "Template",

--- a/packages/block-template/package.json
+++ b/packages/block-template/package.json
@@ -51,7 +51,6 @@
     "react-dom": "^17.0.2",
     "regenerator-runtime": "^0.13.9",
     "rimraf": "^3.0.2",
-    "twind": "^0.16.16",
     "typescript": "^4.5.5",
     "typescript-json-schema": "^0.53.0",
     "webpack": "^5.68.0",

--- a/packages/block-template/webpack-block-metadata-plugin.js
+++ b/packages/block-template/webpack-block-metadata-plugin.js
@@ -11,9 +11,8 @@ const {
   author,
   license,
   blockprotocol,
+  peerDependencies,
 } = require("./package.json");
-
-const { externals } = require("./webpack-main.config");
 
 const variants = fs.existsSync("./variants.json")
   ? require("./variants.json")
@@ -22,8 +21,8 @@ const variants = fs.existsSync("./variants.json")
 class StatsPlugin {
   apply(compiler) {
     compiler.hooks.done.tap(this.constructor.name, (stats) => {
-      const main = Object.keys(stats.compilation.assets).find((asset) =>
-        asset.startsWith("main"),
+      const main = Object.keys(stats.compilation.assets).find(
+        (asset) => asset.startsWith("main") && asset.endsWith(".js"),
       );
 
       const blockMetadata = {
@@ -32,7 +31,7 @@ class StatsPlugin {
         description,
         author,
         license,
-        externals,
+        externals: peerDependencies,
         schema: "block-schema.json",
         source: main,
         variants,

--- a/packages/block-template/webpack-main.config.js
+++ b/packages/block-template/webpack-main.config.js
@@ -9,6 +9,7 @@ const WebpackAssetsManifest = require("webpack-assets-manifest");
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 const CopyPlugin = require("copy-webpack-plugin");
 const { StatsPlugin } = require("./webpack-block-metadata-plugin");
+const { peerDependencies } = require("./package.json");
 
 module.exports = {
   plugins: [
@@ -34,11 +35,9 @@ module.exports = {
     libraryTarget: "commonjs",
     filename: "main.[contenthash].js",
   },
-  externals: {
-    react: "react",
-    "react-dom": "react-dom",
-    twind: "twind",
-  },
+  externals: Object.fromEntries(
+    Object.keys(peerDependencies).map((key) => [key, key]),
+  ),
   module: {
     rules: [
       {


### PR DESCRIPTION
A couple of fixes to `block-template`, which will need publishing after merging:

1. Feed `externals` properly from `peerDependencies` (following on from counterpart https://github.com/hashintel/hash/pull/398)
2. More reliable detection of the main source entry point (there was a false positive on a `main.[hash].js.LICENSE.txt` that ended up in a build)
3. remove `twind` from dependencies

[Asana task](https://app.asana.com/0/1201864704093982/1201953502543830/f) _(internal)_