### PR TITLE
Upgrade Person Block

### DIFF
--- a/hub/@hash/person.json
+++ b/hub/@hash/person.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "ec9e50601629207f1fde76a817b02aa8733762fe",
+  "commit": "56da8fca6103d3c7568e501d0ddedec4de661eaf",
 
   "workspace": "@hashintel/block-person",
   "distDir": "dist"

--- a/site/scripts/prepare-blocks.ts
+++ b/site/scripts/prepare-blocks.ts
@@ -174,7 +174,6 @@ const ensureRepositorySnapshot = async ({
         "--extract",
         `--file=${path.resolve(tarDirPath, "repo.tar.gz")}`,
         `--directory=${outputDirPath}`,
-        "--verbose",
       ],
       defaultExecaOptions,
     );


### PR DESCRIPTION
## What this Does

This PR is a quick follow-up to https://github.com/hashintel/hash/pull/350, updating the commit on the `person` block to update the person-block demo in hub to the latest commit.

The `verbose` flag [was also removed](https://github.com/blockprotocol/blockprotocol/pull/263/files#diff-1bfd9bc24cbe283f91405cd2d044a05277ad4dc7a566503dfcaa52d5837c1858L177) from the `tar` command on @kachkaev's request to prevent CI log pollution.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201884100967648