### PR TITLE
Fix externals in blockprotocol metadata type. Fix aggregate type in docs

### DIFF
--- a/packages/blockprotocol/core.d.ts
+++ b/packages/blockprotocol/core.d.ts
@@ -62,9 +62,9 @@ export type BlockMetadata = {
    */
   examples?: JSONObject[] | null;
   /**
-   * The dependencies a block relies on but expects the embedding application to provide
+   * The dependencies a block relies on but expects the embedding application to provide, e.g. { "react": "^17.0.2" }
    */
-  externals?: JSONObject[];
+  externals?: JSONObject;
   /**
    * An icon for the block, to be displayed when the user is selecting from available blocks (as well as elsewhere as appropriate, e.g. in a website listing the block).
    */

--- a/site/src/_pages/spec/1_block-types.mdx
+++ b/site/src/_pages/spec/1_block-types.mdx
@@ -292,12 +292,14 @@ We are considering moving to the cursor-based [Connections pattern](https://rela
   - `entityTypeVersionId?` \[_string_]\[_optional_]:: limit results to entities of a specific version of a type
   - `pageNumber?` \[_integer_]\[_optional_]: the page number to request.
   - `itemsPerPage?` \[_integer_]\[_optional_]: the number of results to return.
-  - `multiFilter?` \[_array_]\[_optional_]: filter entities by a given field value:
-    - `field` \[_string_]: the field name to filter by.
-    - `operator` \[_enum_]: the filter operator.
-      One of IS, IS_NOT, CONTAINS, DOES_NOT_CONTAIN, STARTS_WITH, ENDS_WITH, IS_EMPTY, IS_NOT_EMPTY.
-    - `value` \[_string_]: the value to match against.
-  - `multiSort?` \[_array_]\[_optional_]: specify how to sort results by providing one or more objects with the following shape:
+  - `multiFilter?` \[_object_]\[_optional_]: filter entities by a given field value:
+    - `operator` \[_enum_]: one of "AND" or "OR": determines whether all filters must be matched ("AND"), or only one ("OR").
+    - `filters` \[_array_]: an array of filter objects of the following shape:
+      - `field` \[_string_]: the field name to filter by.
+      - `operator` \[_enum_]: the filter operator.
+        One of IS, IS_NOT, CONTAINS, DOES_NOT_CONTAIN, STARTS_WITH, ENDS_WITH, IS_EMPTY, IS_NOT_EMPTY.
+      - `value` \[_string_]: the value to match against.
+  - `multiSort?` \[_array_]\[_optional_]: specify how to sort results by providing one or more objects, inside an array, of the following shape:
     - `field` \[_string_]: the field name to sort on.
     - `desc?` \[_boolean_]\[_optional_]: whether to sort descending.
 - Embedding apps SHOULD provide a default aggregation if not provided.


### PR DESCRIPTION
1. Correct type for `externals` in `blockprotocol` 

currently typed as an array, but should be an object. Correct data is being flagged as incorrect:
![Screenshot 2022-03-16 at 10 54 06](https://user-images.githubusercontent.com/37743469/158582209-5aea63dc-3694-45c2-9c61-a27b6e004dc1.png)

2. Correct docs on the structure of aggregate to match types
