### PR TITLE
Add `/api/me` to the list of routes to warm up

### DIFF
--- a/.github/workflows/warm-up-vercel.yml
+++ b/.github/workflows/warm-up-vercel.yml
@@ -24,7 +24,7 @@ jobs:
             \n
           EOF
 
-          for PATHNAME in "/@hash" "/types/DUMMY_ENTITY_ID"; do
+          for PATHNAME in "/@hash" "/types/DUMMY_ENTITY_ID" "/api/me" ; do
             curl --output /dev/null --silent --write-out "@curl-format.txt" "${BASE_URL}${PATHNAME}"
           done
         env:

--- a/.github/workflows/warm-up-vercel.yml
+++ b/.github/workflows/warm-up-vercel.yml
@@ -24,7 +24,7 @@ jobs:
             \n
           EOF
 
-          for PATHNAME in "/@hash" "/types/DUMMY_ENTITY_ID" "/api/me" ; do
+          for PATHNAME in "/@hash" "/api/me" "/types/DUMMY_ENTITY_ID"; do
             curl --output /dev/null --silent --write-out "@curl-format.txt" "${BASE_URL}${PATHNAME}"
           done
         env:


### PR DESCRIPTION
This quick PR is a by-product of https://github.com/vercel/community/discussions/496.

[Asana task](https://app.asana.com/0/1200211978612931/1201962884263629/f) _(internal)_

Although the homepage is static, we see a pretty annoying layout shift in the header because `/api/me` takes ~10 seconds to complete.


<img width="626" alt="Screenshot 2022-03-18 at 14 10 34" src="https://user-images.githubusercontent.com/608862/159029181-63e16d86-23da-459c-96d4-d11c3fc7632b.png">

↓

<img width="678" alt="Screenshot 2022-03-18 at 14 42 52" src="https://user-images.githubusercontent.com/608862/159029185-88ea1317-7ad5-4296-ba86-30da38793a59.png">

Example:

https://user-images.githubusercontent.com/608862/159029217-e4769c0d-89c5-49de-aede-ffe879eab090.mp4

By warming-up `/api/me` like two other pages, we reduce the probability of this issue. We still have plenty of API routes that are not warmed up, but they are less critical. If there’s no luck with https://github.com/vercel/community/discussions/496, we can implement a script that lists files in `site/pages/api` and thus automatically pokes all API routes.