### PR TITLE
Allow APIs to optionally be made public

### DIFF
--- a/site/src/lib/api/handler/apiKeyRequiredHandler.ts
+++ b/site/src/lib/api/handler/apiKeyRequiredHandler.ts
@@ -10,4 +10,4 @@ export const createApiKeyRequiredHandler = <
   RequestBody = unknown,
   Response = unknown,
 >(): NextConnect<BaseApiRequest<RequestBody>, BaseApiResponse<Response>> =>
-  createBaseHandler().use(hasValidApiKeyMiddleware);
+  createBaseHandler({ isPublicApi: true }).use(hasValidApiKeyMiddleware);

--- a/site/src/lib/api/handler/baseHandler.ts
+++ b/site/src/lib/api/handler/baseHandler.ts
@@ -25,9 +25,17 @@ type ErrorResponse = {
 
 export type BaseApiResponse<T = unknown> = NextApiResponse<T | ErrorResponse>;
 
-export const createBaseHandler = <RequestBody = unknown, Response = any>() =>
-  nextConnect<BaseApiRequest<RequestBody>, BaseApiResponse<Response>>()
-    .use(cors({ origin: FRONTEND_URL, credentials: true }))
+export const createBaseHandler = <
+  RequestBody = unknown,
+  Response = any,
+>(options?: {
+  isPublicApi?: boolean;
+}) => {
+  const { isPublicApi } = options ?? {};
+
+  return nextConnect<BaseApiRequest<RequestBody>, BaseApiResponse<Response>>()
+    .use(cors({ origin: isPublicApi ? "*" : FRONTEND_URL, credentials: true }))
     .use(dbMiddleware)
     .use(sessionMiddleware)
     .use(...passportMiddleware);
+};


### PR DESCRIPTION
## What this Does?

This PR does some pre-work for https://github.com/hashintel/hash/pull/407, allowing the BlockProtocol `/blocks` API to be accessible from all clients. This is done so that a client which consumes BlockProtocol blocks with an appropriate API key isn't blocked by CORS errors while trying to fetch the desired data.

## What does this change?

An optional `isPublicApi` option is added to `createBaseHandler` [here](https://github.com/blockprotocol/blockprotocol/pull/273/files#diff-bf353d5aba9cfe2a44444fb44f092418bf23327517de62a90af518a061ac1583R32) to optionally allow an API to be accessible from all CORS sources.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201997200034318