### PR TITLE
Update Blocks API to return icon URLs and unique IDs 

### DIFF
--- a/packages/blockprotocol/core.d.ts
+++ b/packages/blockprotocol/core.d.ts
@@ -27,7 +27,7 @@ export type BlockVariant = {
   /**
    * @deprecated - Use the `name` field instead.
    */
-  displayName: string;
+  displayName?: string;
   properties: JSONObject;
   examples?: JSONObject[] | null;
 };

--- a/site/src/lib/blocks.ts
+++ b/site/src/lib/blocks.ts
@@ -113,6 +113,7 @@ export const readBlocksFromDisk = (): ExpandedBlockMetadata[] => {
           ...variant,
           icon: getBlockMediaUrl(variant.icon, metadata.packagePath)!,
         })),
+        schema: getBlockMediaUrl(metadata.schema, metadata.packagePath)!,
         repository,
         blockPackagePath: `/${metadata.packagePath
           .split("/")

--- a/site/src/lib/blocks.ts
+++ b/site/src/lib/blocks.ts
@@ -1,11 +1,13 @@
 import { BlockMetadata, BlockMetadataRepository } from "blockprotocol";
 import hostedGitInfo from "hosted-git-info";
+import { FRONTEND_URL } from "./config";
 
 /** @todo type as JSON object */
 export type BlockProps = object;
 
 export type ExpandedBlockMetadata = BlockMetadata & {
   blockPackagePath: string;
+  componentId: string;
   lastUpdated?: string | null;
   packagePath: string;
   // repository is passed down as a string upon expansion
@@ -85,6 +87,7 @@ export const readBlocksFromDisk = (): ExpandedBlockMetadata[] => {
 
       const metadata: ExpandedBlockMetadata = {
         // @todo should be redundant to block's package.json#name
+        componentId: `${FRONTEND_URL}/blocks/${packagePath}`,
         packagePath,
         ...JSON.parse(fs.readFileSync(path, { encoding: "utf8" })),
       };

--- a/site/src/lib/blocks.ts
+++ b/site/src/lib/blocks.ts
@@ -23,7 +23,7 @@ export interface StoredBlockInfo {
   workspace?: string;
 }
 
-const getBlockMediaUrl = (
+const generateBlockFileUrl = (
   mediaPath: string | undefined | null,
   packagePath: string,
 ): string | null => {
@@ -35,7 +35,10 @@ const getBlockMediaUrl = (
     return mediaPath;
   }
 
-  return `${FRONTEND_URL}/blocks/${packagePath}/${mediaPath}`;
+  return `${FRONTEND_URL}/blocks/${packagePath}/${mediaPath.replace(
+    /^\//,
+    "",
+  )}`;
 };
 
 // this only runs on the server-side because hosted-git-info uses some nodejs dependencies
@@ -106,14 +109,14 @@ export const readBlocksFromDisk = (): ExpandedBlockMetadata[] => {
       return {
         ...metadata,
         author: metadata.packagePath.split("/")[0]!.replace(/^@/, ""),
-        icon: getBlockMediaUrl(metadata.icon, metadata.packagePath),
-        image: getBlockMediaUrl(metadata.image, metadata.packagePath),
-        source: getBlockMediaUrl(metadata.source, metadata.packagePath)!,
+        icon: generateBlockFileUrl(metadata.icon, metadata.packagePath),
+        image: generateBlockFileUrl(metadata.image, metadata.packagePath),
+        source: generateBlockFileUrl(metadata.source, metadata.packagePath)!,
         variants: metadata.variants?.map((variant) => ({
           ...variant,
-          icon: getBlockMediaUrl(variant.icon, metadata.packagePath)!,
+          icon: generateBlockFileUrl(variant.icon, metadata.packagePath)!,
         })),
-        schema: getBlockMediaUrl(metadata.schema, metadata.packagePath)!,
+        schema: generateBlockFileUrl(metadata.schema, metadata.packagePath)!,
         repository,
         blockPackagePath: `/${metadata.packagePath
           .split("/")

--- a/site/src/lib/blocks.ts
+++ b/site/src/lib/blocks.ts
@@ -35,7 +35,7 @@ const getBlockMediaUrl = (
     return mediaPath;
   }
 
-  return `/blocks/${packagePath}/${mediaPath}`;
+  return `${FRONTEND_URL}/blocks/${packagePath}/${mediaPath}`;
 };
 
 // this only runs on the server-side because hosted-git-info uses some nodejs dependencies
@@ -108,6 +108,11 @@ export const readBlocksFromDisk = (): ExpandedBlockMetadata[] => {
         author: metadata.packagePath.split("/")[0]!.replace(/^@/, ""),
         icon: getBlockMediaUrl(metadata.icon, metadata.packagePath),
         image: getBlockMediaUrl(metadata.image, metadata.packagePath),
+        source: getBlockMediaUrl(metadata.source, metadata.packagePath)!,
+        variants: metadata.variants?.map((variant) => ({
+          ...variant,
+          icon: getBlockMediaUrl(variant.icon, metadata.packagePath)!,
+        })),
         repository,
         blockPackagePath: `/${metadata.packagePath
           .split("/")

--- a/site/src/lib/blocks.ts
+++ b/site/src/lib/blocks.ts
@@ -138,21 +138,25 @@ export const readBlockDataFromDisk = async ({
   // @todo update to also return the metadata information
   // @see https://github.com/blockprotocol/blockprotocol/pull/66#discussion_r784070161
 
-  const schema = metadataSchema.startsWith("http")
-    ? await fetch(metadataSchema).then((response) => response.json())
-    : JSON.parse(
+  const schema = metadataSchema.startsWith(FRONTEND_URL)
+    ? JSON.parse(
         fs.readFileSync(
-          `${process.cwd()}/public/blocks/${packagePath}/${metadataSchema}`,
+          `${process.cwd()}/public/blocks/${packagePath}/${metadataSchema.substring(
+            metadataSchema.lastIndexOf("/") + 1,
+          )}`,
           { encoding: "utf8" },
         ),
-      );
+      )
+    : await fetch(metadataSchema).then((response) => response.json());
 
-  const source = metadataSource.startsWith("http")
-    ? await fetch(metadataSource).then((response) => response.text())
-    : fs.readFileSync(
-        `${process.cwd()}/public/blocks/${packagePath}/${metadataSource}`,
+  const source = metadataSource.startsWith(FRONTEND_URL)
+    ? fs.readFileSync(
+        `${process.cwd()}/public/blocks/${packagePath}/${metadataSource.substring(
+          metadataSource.lastIndexOf("/") + 1,
+        )}`,
         { encoding: "utf8" },
-      );
+      )
+    : await fetch(metadataSource).then((response) => response.text());
 
   return {
     schema,

--- a/site/src/pages/[shortname]/blocks/[blockSlug].page.tsx
+++ b/site/src/pages/[shortname]/blocks/[blockSlug].page.tsx
@@ -161,7 +161,7 @@ export const getStaticProps: GetStaticProps<
   }
 
   const { schema, source: blockStringifiedSource } =
-    readBlockDataFromDisk(blockMetadata);
+    await readBlockDataFromDisk(blockMetadata);
 
   return {
     props: {

--- a/site/src/pages/api/blocks.api.ts
+++ b/site/src/pages/api/blocks.api.ts
@@ -78,28 +78,34 @@ export default createApiKeyRequiredHandler<null, ApiSearchResponse>()
       const ajv = new Ajv({ removeAdditional: "all" });
 
       data = (
-        data.flatMap((block) => {
-          const schema = readBlockDataFromDisk(block).schema;
-          const validate = ajv.compile(schema);
+        await Promise.all(
+          data.map(async (block) => {
+            const schema = (await readBlockDataFromDisk(block)).schema;
+            const validate = ajv.compile(schema);
 
-          // withoutAdditional is transformed in validate.
-          // eslint-disable-next-line prefer-const
-          let withoutAdditional = cloneDeep(json);
-          const valid = validate(withoutAdditional);
+            // withoutAdditional is transformed in validate.
+            // eslint-disable-next-line prefer-const
+            let withoutAdditional = cloneDeep(json);
+            const valid = validate(withoutAdditional);
 
-          // removeAdditional lets us count how many keys are a part of the schema
-          const keyCountWithoutAdditional =
-            Object.keys(withoutAdditional).length;
+            // removeAdditional lets us count how many keys are a part of the schema
+            const keyCountWithoutAdditional =
+              Object.keys(withoutAdditional).length;
 
-          const keyCountDifference =
-            Object.keys(json).length - keyCountWithoutAdditional;
+            const keyCountDifference =
+              Object.keys(json).length - keyCountWithoutAdditional;
 
-          // Only show valid schemas with at least 1 matching field
-          return valid && keyCountWithoutAdditional >= 1
-            ? [[block, keyCountDifference]]
-            : [];
-        }) as [BlockMetadata, number][]
+            // Only show valid schemas with at least 1 matching field
+            return valid && keyCountWithoutAdditional >= 1
+              ? [block, keyCountDifference]
+              : null;
+          }),
+        )
       )
+        .filter(
+          (blockData): blockData is [BlockMetadata, number] =>
+            blockData !== null,
+        )
         // sort by how many keys are present in the validated output after removeAdditional.
         .sort(([_, a], [__, b]) => a - b)
         .map(([block, _]) => block);

--- a/site/src/pages/api/blocks.api.ts
+++ b/site/src/pages/api/blocks.api.ts
@@ -106,21 +106,6 @@ export default createApiKeyRequiredHandler<null, ApiSearchResponse>()
         .map(([block, _]) => block);
     }
 
-    for (const block of data) {
-      // Generate absolute URLs for block icons
-      if (block.icon && !block.icon.startsWith("http")) {
-        block.icon = `${FRONTEND_URL}${block.icon}`;
-      }
-
-      for (const variant of block.variants ?? []) {
-        if (variant.icon.startsWith("public")) {
-          variant.icon = `${block.icon!.split("public/")[0]}public/${
-            variant.icon.split("public/")[1]
-          }`;
-        }
-      }
-    }
-
     // @todo paginate response
 
     res.status(200).json({

--- a/site/src/pages/api/blocks.api.ts
+++ b/site/src/pages/api/blocks.api.ts
@@ -106,8 +106,8 @@ export default createApiKeyRequiredHandler<null, ApiSearchResponse>()
         .map(([block, _]) => block);
     }
 
-    // Generate absolute URLs for block icons
     for (const block of data) {
+      // Generate absolute URLs for block icons
       if (block.icon && !block.icon.startsWith("http")) {
         block.icon = `${FRONTEND_URL}${block.icon}`;
       }

--- a/site/src/pages/api/blocks.api.ts
+++ b/site/src/pages/api/blocks.api.ts
@@ -7,7 +7,6 @@ import {
   readBlockDataFromDisk,
 } from "../../lib/blocks";
 import { createApiKeyRequiredHandler } from "../../lib/api/handler/apiKeyRequiredHandler";
-import { FRONTEND_URL } from "../../lib/config";
 
 export type ApiSearchRequestQuery = {
   author?: string;

--- a/site/src/pages/api/blocks.api.ts
+++ b/site/src/pages/api/blocks.api.ts
@@ -7,6 +7,7 @@ import {
   readBlockDataFromDisk,
 } from "../../lib/blocks";
 import { createApiKeyRequiredHandler } from "../../lib/api/handler/apiKeyRequiredHandler";
+import { FRONTEND_URL } from "../../lib/config";
 
 export type ApiSearchRequestQuery = {
   author?: string;
@@ -103,6 +104,21 @@ export default createApiKeyRequiredHandler<null, ApiSearchResponse>()
         // sort by how many keys are present in the validated output after removeAdditional.
         .sort(([_, a], [__, b]) => a - b)
         .map(([block, _]) => block);
+    }
+
+    // Generate absolute URLs for block icons
+    for (const block of data) {
+      if (block.icon && !block.icon.startsWith("http")) {
+        block.icon = `${FRONTEND_URL}${block.icon}`;
+      }
+
+      for (const variant of block.variants ?? []) {
+        if (variant.icon.startsWith("public")) {
+          variant.icon = `${block.icon!.split("public/")[0]}public/${
+            variant.icon.split("public/")[1]
+          }`;
+        }
+      }
     }
 
     // @todo paginate response


### PR DESCRIPTION
## What this Does

This PR is a follow-up to https://github.com/hashintel/hash/pull/407, to fix the temporary solutions defined there. This PR: 
1. Returns absolute URLs for icons.
2. Returns a unique `componentId` for each block.

So that any BlockProtocol client can use these details directly. The icons are used in the clients to display a block's icon, while the `componentId` is used to uniquely identify a block in the hash app, and can also be used as a key for objects storing block data.

Changes described in the GH comments below.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201988634400654
  - https://app.asana.com/0/0/1202003755787889
  - https://app.asana.com/0/0/1201988634400672