### PR TITLE
Fix specification page link

### DIFF
--- a/site/src/_pages/spec/2_embedding-applications.mdx
+++ b/site/src/_pages/spec/2_embedding-applications.mdx
@@ -29,7 +29,7 @@ To render a block which defines a schema for the data it accepts, embedding appl
 
 Embedding applications SHOULD supply blocks with functions to get, aggregate, create, delete and update entities, entity types, and links between entities (subject to any permissions restrictions).
 
-These functions MUST conform to the naming conventions and function signatures outlined in [the previous section](https://blockprotocol.org/spec/embedding-applications).
+These functions MUST conform to the naming conventions and function signatures outlined in [the previous section](https://blockprotocol.org/spec/block-types#entity-functions).
 
 Embedding applications SHOULD provide defaults for aggregation operations to handle cases where the block doesn’t specify its own requirements (e.g. default sort, default items per response)
 


### PR DESCRIPTION
Currently the "Previous Section" url points to the "Embedding Application", whereas it's my understanding that this should link to the "Block Types" page where function signatures are outlined.