### PR TITLE
Fix ‘NPM Packages’ CI by downgrading NPM to 8.4.1

### DIFF
--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -147,8 +147,8 @@ jobs:
 
       - name: Run local registry
         run: |
-          docker pull verdaccio/verdaccio
-          docker run -it --detach --rm --name verdaccio -p 4873:4873  verdaccio/verdaccio
+          docker pull verdaccio/verdaccio:5
+          docker run -it --detach --rm --name verdaccio -p 4873:4873  verdaccio/verdaccio:5
           yarn wait-on --timeout 30000 http://localhost:4873
 
       - name: Publish NPM packages to local registry

--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -141,6 +141,10 @@ jobs:
           node-version: 16.14.0
           cache: yarn
 
+      - run: |
+          npm install --global npm@8.6.0
+          npm --version
+
       - run: yarn install
 
       - name: Run local registry

--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -138,12 +138,8 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.14.0
+          node-version: 16
           cache: yarn
-
-      - run: |
-          npm install --global npm@8.6.0
-          npm --version
 
       - run: yarn install
 

--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -142,7 +142,7 @@ jobs:
           cache: yarn
 
       - name: Downgrade global NPM version
-        run: npm install --global npm@8.3.1 ## https://github.com/blockprotocol/blockprotocol/pull/281
+        run: npm install --global npm@8.4.0 ## https://github.com/blockprotocol/blockprotocol/pull/281
 
       - run: yarn install
 

--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -141,6 +141,8 @@ jobs:
           node-version: 16.4.0
           cache: yarn
 
+      - run: npm --version
+
       - run: yarn install
 
       - name: Run local registry

--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -141,6 +141,8 @@ jobs:
           node-version: 16
           cache: yarn
 
+      - run: npm install --global npm@8.5.5
+
       - run: yarn install
 
       - name: Run local registry

--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -138,7 +138,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.4.0
+          node-version: 16.14.2
           cache: yarn
 
       - run: npm --version

--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -138,10 +138,8 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 16.4.0
           cache: yarn
-
-      - run: npm install --global npm@8.5.5
 
       - run: yarn install
 

--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -142,7 +142,7 @@ jobs:
           cache: yarn
 
       - name: Downgrade global NPM version
-        run: npm install --global npm@8.4.0 ## https://github.com/blockprotocol/blockprotocol/pull/281
+        run: npm install --global npm@8.4.1 ## https://github.com/blockprotocol/blockprotocol/pull/281
 
       - run: yarn install
 

--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -141,6 +141,9 @@ jobs:
           node-version: 16
           cache: yarn
 
+      - name: Downgrade global NPM version
+        run: npm install --global npm@8.3.1 ## https://github.com/blockprotocol/blockprotocol/pull/281
+
       - run: yarn install
 
       - name: Run local registry

--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -138,7 +138,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 16.14.2
+          node-version: 16.14.0
           cache: yarn
 
       - run: npm --version

--- a/.github/workflows/check-codebase.yml
+++ b/.github/workflows/check-codebase.yml
@@ -141,8 +141,6 @@ jobs:
           node-version: 16.14.0
           cache: yarn
 
-      - run: npm --version
-
       - run: yarn install
 
       - name: Run local registry

--- a/scripts/packages/publish-to-local-registry.ts
+++ b/scripts/packages/publish-to-local-registry.ts
@@ -76,7 +76,7 @@ const script = async () => {
 
     await execa(
       "npm",
-      ["unpublish", "--force", `${packageName}${packageJson.version}`],
+      ["unpublish", "--force", `${packageName}@${packageJson.version}`],
       {
         ...defaultExecaOptions,
         cwd: packageDirPath,

--- a/scripts/packages/publish-to-local-registry.ts
+++ b/scripts/packages/publish-to-local-registry.ts
@@ -2,7 +2,6 @@ import execa from "execa";
 import sleep from "sleep-promise";
 import path from "path";
 import chalk from "chalk";
-import fs from "fs-extra";
 import { logStepEnd, logStepStart } from "../shared/logging";
 
 // These variables are hardcoded on purpose. We don’t want to publish to a real registry by mistake.
@@ -70,19 +69,12 @@ const script = async () => {
     const packageDirPath = path.resolve(`packages/${packageName}`);
 
     logStepStart(`Unpublish ${packageName} from local registry (if present)`);
-    const packageJson = await fs.readJson(
-      path.resolve(packageDirPath, "package.json"),
-    );
 
-    await execa(
-      "npm",
-      ["unpublish", "--force", `${packageName}@${packageJson.version}`],
-      {
-        ...defaultExecaOptions,
-        cwd: packageDirPath,
-        reject: false,
-      },
-    );
+    await execa("npm", ["unpublish", "--force"], {
+      ...defaultExecaOptions,
+      cwd: packageDirPath,
+      reject: false,
+    });
 
     logStepEnd();
     logStepStart(`Publish ${packageName} to local registry`);

--- a/scripts/packages/publish-to-local-registry.ts
+++ b/scripts/packages/publish-to-local-registry.ts
@@ -2,6 +2,7 @@ import execa from "execa";
 import sleep from "sleep-promise";
 import path from "path";
 import chalk from "chalk";
+import fs from "fs-extra";
 import { logStepEnd, logStepStart } from "../shared/logging";
 
 // These variables are hardcoded on purpose. We don’t want to publish to a real registry by mistake.
@@ -69,12 +70,19 @@ const script = async () => {
     const packageDirPath = path.resolve(`packages/${packageName}`);
 
     logStepStart(`Unpublish ${packageName} from local registry (if present)`);
+    const packageJson = await fs.readJson(
+      path.resolve(packageDirPath, "package.json"),
+    );
 
-    await execa("npm", ["unpublish", "--force"], {
-      ...defaultExecaOptions,
-      cwd: packageDirPath,
-      reject: false,
-    });
+    await execa(
+      "npm",
+      ["unpublish", "--force", `${packageName}${packageJson.version}`],
+      {
+        ...defaultExecaOptions,
+        cwd: packageDirPath,
+        reject: false,
+      },
+    );
 
     logStepEnd();
     logStepStart(`Publish ${packageName} to local registry`);


### PR DESCRIPTION
This PR fixes ‘NPM Packages’ CI which has been failing for about two weeks now.

We define `node-version: 16` in `actions/setup-node@v2`, which gives us the latest Node version. The CI started failing after 16.14.0 got auto-replaced with 16.14.2. These two Node versions come with different NPM versions: 8.3.1 and 8.5.0.

Downgrading NPM from 8.5.0 to 8.4.1 (and 8.3.0, 8.4.0) fixes the problem even without having to downgrade Node itself. Upgrading NPM 8.5.0 to 8.6.0 (the latest at the time of writing) does not fix the issue.

Looking at CI logs, here is one subtle difference that looks a bit odd:

`npm 8.3.1 / 8.4.0 / 8.4.1`

```
=========================================================
Unpublish block-template from local registry (if present)
=========================================================
↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓

npm WARN using --force Recommended protections disabled.
- block-template@0.0.8
```

`npm 8.5.0 / 8.6.0`

```
=========================================================
Unpublish block-template from local registry (if present)
=========================================================
↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓

npm WARN using --force Recommended protections disabled.
- block-template
```

(there’s no `@0.0.8` in the newer versions)

This difference in the output might be related to what request payload Verdaccio receives. I haven’t found any obvious [CHANGELOG items](https://github.com/npm/cli/blob/latest/CHANGELOG.md#v850-2022-02-10) to blame, but I haven’t looked for too long to be honest.

I tried to spoonfeeding `npm unpublish --force` with `block-template@0.0.8` but this did not help in the never versions of NPM.

Let’s hope that this problem self-resolves over time and we’ll be able to unpin NPM.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202094259991222