### PR TITLE
Make more block variant types nullable

### DIFF
--- a/packages/block-template/package.json
+++ b/packages/block-template/package.json
@@ -30,7 +30,7 @@
     "serve": "npx serve --cors --listen 61234 ./dist/"
   },
   "dependencies": {
-    "blockprotocol": "0.0.7"
+    "blockprotocol": "0.0.8"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.0",

--- a/packages/blockprotocol/core.d.ts
+++ b/packages/blockprotocol/core.d.ts
@@ -21,8 +21,8 @@ export interface JSONArray extends Array<JSONValue> {}
 // -------------------------- BLOCK METADATA -------------------------- //
 
 export type BlockVariant = {
-  description: string;
-  icon: string;
+  description?: string | null;
+  icon?: string | null;
   name: string;
   /**
    * @deprecated - Use the `name` field instead.

--- a/packages/blockprotocol/package.json
+++ b/packages/blockprotocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockprotocol",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "TypeScript typings for https://blockprotocol.org developers",
   "keywords": [
     "blockprotocol",

--- a/packages/mock-block-dock/package.json
+++ b/packages/mock-block-dock/package.json
@@ -36,7 +36,7 @@
     "run-dev-server": "cross-env NODE_ENV=development webpack-dev-server --config dev/webpack.config.js"
   },
   "dependencies": {
-    "blockprotocol": "0.0.7",
+    "blockprotocol": "0.0.8",
     "lodash": "^4.17.21",
     "uuid": "^8.3.2"
   },

--- a/site/package.json
+++ b/site/package.json
@@ -33,7 +33,7 @@
     "ajv": "^8.9.0",
     "algoliasearch": "4.12.1",
     "axios": "^0.24.0",
-    "blockprotocol": "0.0.7",
+    "blockprotocol": "0.0.8",
     "busboy": "^1.4.0",
     "clsx": "^1.1.1",
     "connect-mongo": "^4.6.0",

--- a/site/src/_pages/spec/1_block-types.mdx
+++ b/site/src/_pages/spec/1_block-types.mdx
@@ -58,7 +58,7 @@ A block package SHOULD contain:
 
   - MAY specify:
 
-    - `variants` – an array of objects, each with a `name`, `description`, `icon`, `properties`, and `examples`, which represents different variants of the block that the user can create. As a simple example, a ‘header’ block might have variants with the `name` ‘Heading 1’ and ‘Heading 2’, which start with `{ level: 1 }` and `{ level: 2 }` as `properties`, respectively.
+    - `variants` – an array of objects, each with a `name` and `properties`, and optionally `description`, `icon`, and `examples`. These objects represents different variants of the block that the user can create, where `properties` sets the starting properties. As a simple example, a ‘header’ block might have variants with the `name` ‘Heading 1’ and ‘Heading 2’, which start with `{ level: 1 }` and `{ level: 2 }` as `properties`, respectively.
 
 ## Data transfer
 


### PR DESCRIPTION
This corrects an oddity where the `BlockVariant` type required `icon` and `description`, where these are optional in the block metadata as a whole.

Correcting this avoids users of the type relying on the property where it may not exist. The spec has also been updated to clarify.