### PR TITLE
Use `npx retry-cli` in ‘Warm up Vercel‘ CI

### DIFF
--- a/.github/workflows/warm-up-vercel.yml
+++ b/.github/workflows/warm-up-vercel.yml
@@ -25,7 +25,8 @@ jobs:
           EOF
 
           for PATHNAME in "/@hash" "/api/me" "/types/DUMMY_ENTITY_ID"; do
-            curl --output /dev/null --silent --write-out "@curl-format.txt" "${BASE_URL}${PATHNAME}"
+            npx retry-cli@0.6.0 -- curl --output /dev/null --silent --write-out "@curl-format.txt" "${BASE_URL}${PATHNAME}"
           done
         env:
           BASE_URL: ${{ github.event.deployment.environment != 'production' && github.event.deployment_status.target_url || 'https://blockprotocol.org' }}
+          NODE_OPTIONS: --no-deprecation ## https://github.com/tirsen/retry-cli/issues/7


### PR DESCRIPTION
Our [Warm up Vercel](https://github.com/blockprotocol/blockprotocol/actions/workflows/warm-up-vercel.yml) workflow is occasionally failing with the following output:

```
Run cat << EOF > curl-format.txt
  https://blockprotocol-mtco3evop-hashintel.vercel.app/@hash
    Status code: 200
    Time: 19.349816
  
  https://blockprotocol-mtco3evop-hashintel.vercel.app/api/me
    Status code: 000
    Time: 75.022621  
 
 Error: Process completed with exit code 35.
 ```

Searching for `curl exit code 35` suggests that this may be to do with TLS or a firewall. Adding `npx `[`retry-cli`](https://www.npmjs.com/package/retry-cli) may help. I’ve used default options, which means 10 retries with `1, 2, 4...` seconds in between. Let’s see what happens, but hopefully we’ll see fewer false alarms in CI. ❌ → ✅