### PR TITLE
Bump block-template version

### DIFF
--- a/packages/block-template/package.json
+++ b/packages/block-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "block-template",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Block template",
   "keywords": [
     "blockprotocol",


### PR DESCRIPTION
I published `block-template` together with `block-scripts` from #291. Because I forgot to remove some temp CSS, the template accidentally got [`index.css` with green page background](https://unpkg.com/browse/block-template@0.0.10/src/index.css).

I have already published [0.0.11 without this file](https://unpkg.com/browse/block-template@0.0.11/src/), so the fix is out there. This PR makes sure we have the correct latest version in the repo too.