### PR TITLE
Bump block-scripts and block-template version numbers

### DIFF
--- a/packages/block-scripts/package.json
+++ b/packages/block-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "block-scripts",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Block development framework",
   "keywords": [
     "blockprotocol",

--- a/packages/block-template/package.json
+++ b/packages/block-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "block-template",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Block template",
   "keywords": [
     "blockprotocol",

--- a/packages/block-template/package.json
+++ b/packages/block-template/package.json
@@ -27,7 +27,7 @@
     "blockprotocol": "0.0.8"
   },
   "devDependencies": {
-    "block-scripts": "0.0.2",
+    "block-scripts": "0.0.3",
     "mock-block-dock": "0.0.8",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"


### PR DESCRIPTION
#293 made `block-scripts` and `block-template` dependent on a newer version of `mock-block-dock`, but it did not increase their own version numbers.

This PR does that – I will publish a new version of each after merging.