### PR TITLE
Further improve `block-scripts`

### DIFF
--- a/packages/block-scripts/package.json
+++ b/packages/block-scripts/package.json
@@ -20,7 +20,7 @@
   "type": "module",
   "bin": "./bin.js",
   "scripts": {
-    "lint:tsc": "echo \"Skipping: TypeScript not configured\""
+    "lint:tsc": "tsc --noEmit"
   },
   "dependencies": {
     "@babel/cli": "^7.17.6",

--- a/packages/block-scripts/package.json
+++ b/packages/block-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "block-scripts",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Block development framework",
   "keywords": [
     "blockprotocol",

--- a/packages/block-scripts/scripts/build.js
+++ b/packages/block-scripts/scripts/build.js
@@ -34,7 +34,7 @@ const script = async () => {
       : baseWebpackConfig.plugins,
   };
 
-  const stats = await promisifiedWebpack(webpackConfig);
+  const stats = await promisifiedWebpack([webpackConfig]);
 
   if (stats.hasErrors()) {
     console.log(stats.toString());

--- a/packages/block-scripts/scripts/dev.js
+++ b/packages/block-scripts/scripts/dev.js
@@ -68,6 +68,9 @@ const script = async () => {
     stats: "minimal",
   };
 
+  /**
+   * @type import("webpack-dev-server").Configuration
+   */
   const webpackDevServerConfig = {
     headers: {
       "Access-Control-Allow-Origin": "*",
@@ -86,6 +89,12 @@ const script = async () => {
       directory: "dist",
     },
     port: await getPort("development"),
+    watchFiles: [
+      "block-schema.json",
+      "package.json",
+      "public/**/*",
+      "README.md",
+    ],
   };
 
   const compiler = webpack(webpackConfig);

--- a/packages/block-scripts/shared/generate-base-webpack-config.js
+++ b/packages/block-scripts/shared/generate-base-webpack-config.js
@@ -25,6 +25,9 @@ export const generateBaseWebpackConfig = async (mode) => {
       new webpack.EnvironmentPlugin({
         "process.env.NODE_ENV": mode,
       }),
+      new webpack.optimize.LimitChunkCountPlugin({
+        maxChunks: 1,
+      }),
       new BlockAssetsPlugin(),
       new CopyPlugin({ patterns: [{ from: "./public/", to: "./public/" }] }),
       new WebpackAssetsManifest(),

--- a/packages/block-scripts/shared/generate-dist-block-metadata.js
+++ b/packages/block-scripts/shared/generate-dist-block-metadata.js
@@ -12,7 +12,6 @@ export const generateDistBlockMetadata = async (source) => {
 
   const {
     name,
-    displayName,
     version,
     description,
     author,
@@ -27,7 +26,6 @@ export const generateDistBlockMetadata = async (source) => {
 
   const blockMetadata = {
     name,
-    displayName,
     version,
     description,
     author,

--- a/packages/block-scripts/shared/generate-dist-block-metadata.js
+++ b/packages/block-scripts/shared/generate-dist-block-metadata.js
@@ -12,6 +12,7 @@ export const generateDistBlockMetadata = async (source) => {
 
   const {
     name,
+    displayName,
     version,
     description,
     author,
@@ -26,6 +27,7 @@ export const generateDistBlockMetadata = async (source) => {
 
   const blockMetadata = {
     name,
+    displayName,
     version,
     description,
     author,
@@ -33,6 +35,7 @@ export const generateDistBlockMetadata = async (source) => {
     externals: peerDependencies,
     schema: "block-schema.json",
     source,
+    builtAt: new Date().toISOString(),
     variants,
     ...blockprotocol,
   };

--- a/packages/block-scripts/tsconfig.json
+++ b/packages/block-scripts/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "module": "es2022",
+    "moduleResolution": "node",
+    "target": "es2018",
+    "skipLibCheck": true,
+    "lib": ["dom", "dom.iterable", "esnext"]
+  },
+  "include": ["scripts", "shared"],
+  "exclude": ["node_modules"]
+}

--- a/packages/block-template/package.json
+++ b/packages/block-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "block-template",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Block template",
   "keywords": [
     "blockprotocol",
@@ -27,7 +27,7 @@
     "blockprotocol": "0.0.8"
   },
   "devDependencies": {
-    "block-scripts": "0.0.4",
+    "block-scripts": "0.0.5",
     "mock-block-dock": "0.0.8",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"


### PR DESCRIPTION
Continues #295 

In scope

- Limit number of webpack chunks to 1 to avoid issues with `require()`

- Watch for changes in `block-schema.json`, `package.json`, `public/**/*" and `README.md` in dev

- Add `block-metadata.json` → `builtAt`. We can use this for hot reloading in the embedding apps (alternative suggestions are welcome)

- Check `block-scripts` package with `tsc` (this is possible despite using `*.js`)