### PR TITLE
Ensure `Cache-Control: no-store` header in `block-scripts`

### DIFF
--- a/packages/block-scripts/package.json
+++ b/packages/block-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "block-scripts",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Block development framework",
   "keywords": [
     "blockprotocol",

--- a/packages/block-scripts/scripts/dev.js
+++ b/packages/block-scripts/scripts/dev.js
@@ -83,6 +83,7 @@ const script = async () => {
         "Authorization",
         "sentry-trace",
       ],
+      "Cache-Control": "no-store",
     },
     hot: true,
     open: process.env.BROWSER !== "none",

--- a/packages/block-scripts/scripts/serve.js
+++ b/packages/block-scripts/scripts/serve.js
@@ -6,6 +6,7 @@ import { getPort } from "../shared/config.js";
 const script = async () => {
   const server = http.createServer((request, response) => {
     response.setHeader("Access-Control-Allow-Origin", "*"); // cors
+    response.setHeader("Cache-Control", "no-store");
     return handler(request, response, {
       public: "dist",
     });

--- a/packages/block-template/package.json
+++ b/packages/block-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "block-template",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Block template",
   "keywords": [
     "blockprotocol",
@@ -27,7 +27,7 @@
     "blockprotocol": "0.0.8"
   },
   "devDependencies": {
-    "block-scripts": "0.0.5",
+    "block-scripts": "0.0.6",
     "mock-block-dock": "0.0.8",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"


### PR DESCRIPTION
This PR ensures [`Cache-Control: no-store`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#no-store) in `block-scripts`‘s `yarn dev` and `yarn serve`. This improves DX.

`yarn dev`

<img width="615" alt="Screenshot 2022-05-04 at 09 31 37" src="https://user-images.githubusercontent.com/608862/166647300-92a63999-421f-4ecc-963a-000ed8d12dd2.png">


`yarn serve`

<img width="477" alt="Screenshot 2022-05-04 at 09 32 10" src="https://user-images.githubusercontent.com/608862/166647309-75086ecb-d48d-4d89-960c-d8ea76943b39.png">



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202203992095715