### PR TITLE
Don't add an accountId to mock-block-dock if none is provided

### DIFF
--- a/packages/mock-block-dock/src/MockBlockDock.tsx
+++ b/packages/mock-block-dock/src/MockBlockDock.tsx
@@ -56,7 +56,7 @@ export const MockBlockDock: VoidFunctionComponent<MockBlockDockProps> = ({
       ...(blockSchema ?? {}),
     };
 
-    const accountId = children.props.accountId ?? "accountId";
+    const accountId = children.props.accountId;
 
     const initialBlockEntity: BlockProtocolEntity = {
       accountId,


### PR DESCRIPTION
In the mock data in `mock-block-dock`'s datastore, we currently default to an `accountId` of `"accountId"` if none is provided to the component. 

This could be confusing if a user is supplying their own `initialEntities`, without accountIds, since the block entity will silently gain an `accountId` which doesn't match the entities in the datastore, causing queries for other entities/types to fail if they pass the `accountId` the block is given. 

This change removes the default `accountId` to leave management of the mock `accountId` entirely in the hands of the user.

We could alternatively also give a default `accountId` to any `initialEntities` which require it, but it feels preferable to leave it up to the user, so they can more easily debug/control it. 

N.B. I already published this as part of `0.0.9` to test it (as part of introducing the use of `initialEntities` etc to https://github.com/hashintel/hash/pull/519). But can revert and publish 0.0.10 if required.