### PR TITLE
Block template: add target 'es6', module 'commonjs' to tsconfig

### DIFF
--- a/packages/block-template/package.json
+++ b/packages/block-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "block-template",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "description": "Block template",
   "keywords": [
     "blockprotocol",

--- a/packages/block-template/tsconfig.json
+++ b/packages/block-template/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "compilerOptions": {
     "allowJs": true,
+    "allowSyntheticDefaultImports": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "noEmit": true,
     "lib": ["dom", "dom.iterable", "esnext"],
-    "allowSyntheticDefaultImports": true
+    "module": "commonjs",
+    "noEmit": true,
+    "target": "es6"
   },
   "include": ["src"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
In our block template's `tsconfig.json`, we didn't set a `target` nor `module`.

This PR adds some sensible defaults.