### PR TITLE
Add Timer block to the BP Hub

### DIFF
--- a/hub/@timdiekmann/timer.json
+++ b/hub/@timdiekmann/timer.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "39bcbfbee73fc16e6256ac5b3cea5ea229647b6c",
+  "commit": "fd44bb6272da18f294b2e91fa54465f0cef4e6be",
 
   "workspace": "@hashintel/block-timer",
   "distDir": "dist"


### PR DESCRIPTION
Related to https://github.com/hashintel/hash/pull/576. Click on the bottom-most _View deployment_ for preview.

<img width="393" alt="Screenshot 2022-05-26 at 23 05 51" src="https://user-images.githubusercontent.com/608862/170589180-64b855a7-0539-42b0-b232-f3af4fc8d4bf.png">

<img width="1220" alt="Screenshot 2022-05-26 at 23 21 00" src="https://user-images.githubusercontent.com/608862/170589181-234501bc-9844-44a1-83ae-fed3ac3b817e.png">

