### PR TITLE
Fix cold Vercel builds

### DIFF
--- a/site/scripts/prepare-blocks.ts
+++ b/site/scripts/prepare-blocks.ts
@@ -294,6 +294,14 @@ const prepareBlock = async ({
 
   if (distDirPath !== repositorySnapshotDirPath) {
     console.log(chalk.green(`Installing dependencies...`));
+
+    // Vercel builds may fail on cold starts (when block build cache is empty).
+    // The error says "Could not write file /tmp/..." "ENOSPC: no space left on device"
+    // Clearing yarn cache slows down block builds but helps keep /tmp folder small.
+    if (packageManager === "yarn" && process.env.VERCEL) {
+      await execa("yarn", ["cache", "clean"], defaultExecaOptions);
+    }
+
     // @todo explore focus mode to speed up yarn install in monorepos
     // https://classic.yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-focus
     // https://yarnpkg.com/cli/workspaces/focus

--- a/site/scripts/prepare-blocks.ts
+++ b/site/scripts/prepare-blocks.ts
@@ -152,6 +152,7 @@ const ensureRepositorySnapshot = async ({
   // Vercel builds may fail when block build cache is empty. The error says
   // "Could not write file /tmp/..." "ENOSPC: no space left on device"
   // Preventing workshop folder from growing indefinitely reduces the chances of failure.
+  // See details in https://github.com/blockprotocol/blockprotocol/pull/327
   if (process.env.VERCEL) {
     await fs.emptyDir(workshopDirPath);
   }

--- a/site/scripts/prepare-blocks.ts
+++ b/site/scripts/prepare-blocks.ts
@@ -151,8 +151,7 @@ const ensureRepositorySnapshot = async ({
 
   // Vercel builds may fail when block build cache is empty. The error says
   // "Could not write file /tmp/..." "ENOSPC: no space left on device"
-  // Preventing workshop dir path folder from growing too fast reduces
-  // the chances of failure.
+  // Preventing workshop folder from growing indefinitely reduces the chances of failure.
   if (process.env.VERCEL) {
     await fs.emptyDir(workshopDirPath);
   }
@@ -302,7 +301,6 @@ const prepareBlock = async ({
 
   if (distDirPath !== repositorySnapshotDirPath) {
     console.log(chalk.green(`Installing dependencies...`));
-
     // @todo explore focus mode to speed up yarn install in monorepos
     // https://classic.yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-focus
     // https://yarnpkg.com/cli/workspaces/focus
@@ -358,7 +356,6 @@ const prepareBlock = async ({
   }
 
   await fs.move(distDirPath, blockDirPath);
-
   console.log(chalk.green(`Done!`));
 };
 
@@ -464,10 +461,6 @@ const script = async () => {
 
     console.log("");
     console.log(chalk.blue(`Block ${chalk.bold(blockName)} needs preparing.`));
-
-    console.log("==============");
-    await execa("df", ["-h"], { stdio: "inherit" });
-    console.log("==============");
 
     try {
       await fs.ensureDir(blockDirPath);

--- a/site/scripts/prepare-blocks.ts
+++ b/site/scripts/prepare-blocks.ts
@@ -465,6 +465,10 @@ const script = async () => {
     console.log("");
     console.log(chalk.blue(`Block ${chalk.bold(blockName)} needs preparing.`));
 
+    console.log("==============");
+    await execa("df", ["-h"], { stdio: "inherit" });
+    console.log("==============");
+
     try {
       await fs.ensureDir(blockDirPath);
       await prepareBlock({


### PR DESCRIPTION
Running `df -h` during Vercel build shows this amount of free disk space:

```
Filesystem      Size  Used Avail Use% Mounted on
overlay          30G   18G   11G  64% /
tmpfs            64M     0   64M   0% /dev
shm             7.7G     0  7.7G   0% /dev/shm
tmpfs           7.7G     0  7.7G   0% /sys/fs/cgroup
/dev/nvme1n1     30G   18G   11G  64% /etc/hosts
tmpfs           7.7G     0  7.7G   0% /proc/acpi
tmpfs           7.7G     0  7.7G   0% /sys/firmware
```

After downloading a copy of HASH repo and installing dependencies in it, we end up with significantly less space:

```diff
- overlay          30G   18G   11G  64% /
+ overlay          30G   22G  6.1G  79% /
```

This delta is the size of yarn cache plus the size of the repo contents plus the size of installed node modules.

When we build multiple blocks (e.g. because Vercel cache is not warmed up), we download several copies of the same repo because different blocks refer to different commits.

<img width="445" alt="Screenshot 2022-06-08 at 14 55 10" src="https://user-images.githubusercontent.com/608862/172636959-e5fc7b8c-e48c-42fd-9d02-abaeed7828d9.png">

```
/tmp/tmp-1061-Ni7duiC9hiVJ/codeload.github.comhashintelhashtar.gzac219c56bf2a95d079fd325d1f94bde204937b54
/tmp/tmp-1061-Ni7duiC9hiVJ/codeload.github.comhashintelhashtar.gzef018d9e132a45ec7e68e171a85e1d814ee7501d
/tmp/tmp-1061-Ni7duiC9hiVJ/codeload.github.comhashintelhashtar.gz7e25ced45cceb901da86da7c90cd539050f33ab2
...
```


Thus, the remaining space is taken up quickly and the build fails during a yet another `yarn install`:

```
error An unexpected error occurred: "ENOSPC: no space left on device, copyfile
'/usr/local/share/.cache/yarn/v6/npm-typescript-4.6.3-eefeafa6afdd31d725584c67a0eaba80f6fc6c6c-integrity/node_modules/typescript/lib/tsserver.js' ->
'/tmp/tmp-1061-Ni7duiC9hiVJ/codeload.github.comhashintelhashtar.69d108d9d8ef01312bfc7e3cf919952eed1c0d35/node_modules/typescript/lib/tsserver.js'".
```

This PR empties workshop dir (e.g. `/tmp/tmp-1061-Ni7duiC9hiVJ`) each time the build script switches between repos or commit hashes. This mitigates the issue with disk space.

A permanent solution will separate block build process into a new flow, which is detached from building blockprotocol.org