### PR TITLE
Override Tailwind :focus outline

### DIFF
--- a/site/twind.config.js
+++ b/site/twind.config.js
@@ -15,4 +15,9 @@ module.exports = {
       backgroundColor: ["odd", "even"],
     },
   },
+  preflight: {
+    "button:focus": {
+      outline: "none",
+    },
+  },
 };


### PR DESCRIPTION
Some buttons on BlockProtocol were displaying an outline when clicked due to Tailwind's default `:focus` styling.
This was fixed by overriding the `outline` to `none` in `twind.config.js`. Keyboard navigation still shows an outline so it doesn't seem like an update to the `:focus-visible` selector is needed.

Before:

![before](https://user-images.githubusercontent.com/37453800/172710884-c4715117-db54-4408-ab9c-791068ed65c1.gif)

After:

![after](https://user-images.githubusercontent.com/37453800/172710899-cb95cb47-da47-4137-ae6d-e1b2a0c36aa9.gif)


[Asana Ticket](https://app.asana.com/0/1201095311341924/1202341139706565/f)