### PR TITLE
Call `excludeHiddenBlocks()` in two more places

### DIFF
--- a/site/src/pages/[shortname]/blocks/[block-slug].page.tsx
+++ b/site/src/pages/[shortname]/blocks/[block-slug].page.tsx
@@ -11,7 +11,7 @@ import { formatDistance } from "date-fns";
 import { GetStaticPaths, GetStaticProps, NextPage } from "next";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import React, { useMemo, VoidFunctionComponent } from "react";
+import React, { VoidFunctionComponent } from "react";
 
 import { BlocksSlider } from "../../../components/blocks-slider";
 import { FontAwesomeIcon } from "../../../components/icons";
@@ -19,6 +19,7 @@ import { Link } from "../../../components/link";
 import { BlockDataContainer } from "../../../components/pages/hub/block-data-container";
 import { BlockSchema } from "../../../components/pages/hub/hub-utils";
 import {
+  excludeHiddenBlocks,
   ExpandedBlockMetadata as BlockMetadata,
   readBlockDataFromDisk,
   readBlocksFromDisk,
@@ -82,9 +83,9 @@ const Bullet: VoidFunctionComponent = () => {
 
 type BlockPageProps = {
   blockMetadata: BlockMetadata;
-  catalog: BlockMetadata[];
   sandboxBaseUrl: string;
   schema: BlockSchema;
+  sliderItems: BlockMetadata[];
 };
 
 type BlockPageQueryParams = {
@@ -163,7 +164,9 @@ export const getStaticProps: GetStaticProps<
   return {
     props: {
       blockMetadata,
-      catalog,
+      sliderItems: excludeHiddenBlocks(catalog).filter(
+        ({ name }) => name !== blockMetadata.name,
+      ),
       sandboxBaseUrl: generateSandboxBaseUrl(),
       schema,
     },
@@ -173,9 +176,9 @@ export const getStaticProps: GetStaticProps<
 
 const BlockPage: NextPage<BlockPageProps> = ({
   blockMetadata,
-  catalog,
   sandboxBaseUrl,
   schema,
+  sliderItems,
 }) => {
   const { query } = useRouter();
   const { shortname } = parseQueryParams(query || {});
@@ -184,10 +187,6 @@ const BlockPage: NextPage<BlockPageProps> = ({
 
   const md = useMediaQuery(theme.breakpoints.up("md"));
   const isDesktopSize = md;
-
-  const sliderItems = useMemo(() => {
-    return catalog.filter(({ name }) => name !== blockMetadata.name);
-  }, [catalog, blockMetadata]);
 
   const repositoryDisplayUrl = blockMetadata.repository
     ? generateRepositoryDisplayUrl(blockMetadata.repository)

--- a/site/src/pages/hub.page.tsx
+++ b/site/src/pages/hub.page.tsx
@@ -18,11 +18,7 @@ interface PageProps {
  * used to create an index of all available blocks, the catalog
  */
 export const getStaticProps: GetStaticProps<PageProps> = async () => {
-  return {
-    props: {
-      catalog: excludeHiddenBlocks(readBlocksFromDisk()),
-    },
-  };
+  return { props: { catalog: excludeHiddenBlocks(readBlocksFromDisk()) } };
 };
 
 const HubPage: VFC<PageProps> = ({ catalog }) => {

--- a/site/src/pages/index.page.tsx
+++ b/site/src/pages/index.page.tsx
@@ -7,6 +7,7 @@ import { RegistrySection } from "../components/pages/home/registry-section";
 import { Section2 } from "../components/pages/home/section2";
 import { WhyBlockProtocolSection } from "../components/pages/home/why-block-protocol-section";
 import {
+  excludeHiddenBlocks,
   ExpandedBlockMetadata as BlockMetadata,
   readBlocksFromDisk,
 } from "../lib/blocks";
@@ -18,7 +19,7 @@ interface PageProps {
 }
 
 export const getStaticProps: GetStaticProps<PageProps> = async () => {
-  return { props: { catalog: readBlocksFromDisk() } };
+  return { props: { catalog: excludeHiddenBlocks(readBlocksFromDisk()) } };
 };
 
 const HomePage: VFC<PageProps> = ({ catalog }) => {


### PR DESCRIPTION
This PR follows https://github.com/blockprotocol/blockprotocol/pull/331 and improves UI consistency. Hidden blocks are no longer shown in `<BlocksSlider />` (both on the home page and on the block page). Hidden blocks are still available via direct URLs and are still embeddable.