### PR TITLE
Package scripts fix for Windows

### DIFF
--- a/packages/@blockprotocol/core/package.json
+++ b/packages/@blockprotocol/core/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean; yarn build:cjs; yarn build:esm",
+    "build": "yarn clean && yarn build:cjs && yarn build:esm",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs ",
     "build:esm": "tsc",
     "clean": "rimraf ./dist/",

--- a/packages/@blockprotocol/graph/package.json
+++ b/packages/@blockprotocol/graph/package.json
@@ -28,7 +28,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean; yarn build:cjs; yarn build:esm",
+    "build": "yarn clean && yarn build:cjs && yarn build:esm",
     "build:cjs": "tsc --module commonjs --outDir dist/cjs ",
     "build:esm": "tsc",
     "clean": "rimraf ./dist/",


### PR DESCRIPTION
Related to #333 

This PR replaces all usage of `;` operators with `&&` in the new @blockprotocol/core and @blockprotocol/graph package scripts so they can be run on Windows.

[Asana Task](https://app.asana.com/0/1202250835094699/1202405291899977/f)