### PR TITLE
Fix names of font sizes

### DIFF
--- a/packages/block-template/src/base.module.scss
+++ b/packages/block-template/src/base.module.scss
@@ -118,8 +118,8 @@
   --font-size-md: clamp(1.25rem, 0.61vw + 1.1rem, 1.58rem);
   --font-size-lg: clamp(1.56rem, 1vw + 1.31rem, 2.11rem);
   --font-size-xl: clamp(1.95rem, 1.56vw + 1.56rem, 2.81rem);
-  --font-size-xxl: clamp(2.44rem, 2.38vw + 1.85rem, 3.75rem);
-  --font-size-xxl: clamp(3.05rem, 3.54vw + 2.17rem, 5rem);
+  --font-size-2xl: clamp(2.44rem, 2.38vw + 1.85rem, 3.75rem);
+  --font-size-3xl: clamp(3.05rem, 3.54vw + 2.17rem, 5rem);
 
   /* line heights */
   --line-height-tight: 1.25;


### PR DESCRIPTION
In https://github.com/blockprotocol/blockprotocol/pull/342 we set the wrong names for extra large font sizes. These are now `2xl` and `3xl`. 