### PR TITLE
Add `allow="clipboard-write"` to `iframe`

### DIFF
--- a/site/src/components/pages/hub/sandboxed-block-demo.tsx
+++ b/site/src/components/pages/hub/sandboxed-block-demo.tsx
@@ -34,6 +34,7 @@ export const SandboxedBlockDemo: VoidFunctionComponent<SandboxedBlockProps> = ({
       title="block"
       src={sandboxedDemoUrl}
       sandbox="allow-forms allow-scripts allow-same-origin"
+      allow="clipboard-write"
       onLoad={() => {
         postBlockProps();
       }}


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/1201095311341924/1202435310568394/f) _(internal)_
[The iframe allow attribute on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy#the_iframe_allow_attribute)

1.  Open `@hash/blocks/code` ([main](https://blockprotocol.org/@hash/blocks/code) | [preview](https://blockprotocol-851k5l09n-hashintel.vercel.app/@hash/blocks/code)) in Chrome (FF and Safari work fine already)

1.  Press _Copy_

1.  Before (main): ```app.tsx:120 DOMException: The Clipboard API has been blocked because of a permissions policy applied to the current document. See https://goo.gl/EuHzyv for more details.```  
     
     After (preview):  📋 ☑️