### PR TITLE
Fixing scrolling on docs when clicking on a tab

### DIFF
--- a/site/src/components/mdx-page-content.tsx
+++ b/site/src/components/mdx-page-content.tsx
@@ -62,7 +62,22 @@ export const MdxPageContent: VFC<MdxPageContentProps> = ({
         scrolledOnce.current = true;
       }
 
-      if (
+      if (anchor === "" && shouldScrollToAnchor) {
+        currentHeading.current = headings[0]!;
+        setDetectHeadingFromScroll(false);
+
+        window.scrollTo({
+          top: 0,
+        });
+
+        if (detectHeadingFromScrollTimer) {
+          clearTimeout(detectHeadingFromScrollTimer);
+        }
+        detectHeadingFromScrollTimer = setTimeout(
+          () => setDetectHeadingFromScroll(true),
+          1500,
+        );
+      } else if (
         headingWithCurrentAnchor &&
         shouldScrollToAnchor &&
         (!currentHeading.current ||


### PR DESCRIPTION
## What this PR does

It fixes weird scrolling behaviour when clicking on a tab under the `/docs` page.

## Cause

We have custom scrolling logic with some gated conditions to try and handle when to scroll to a given anchor when changing pages. This was implemented in #179. The tabs push a new route to something _without_ an anchor though, which was causing weird scrolling to one of the other headings. 

## Solution
I've fixed this by adding a new condition (checked first) where if the anchor part of the route is "" (e.g. there's no heading in the URL) **and** the previous logic for deciding if it _should scroll_ is true, then it scrolls to the top of the page (rather than some other incorrect anchor's position).

## Checking this

You can see this problem on the [current site](https://blockprotocol.org/docs/) by clicking on one of the tabs (for example "Embedding Blocks"). And you can see this fixed in the deployment attached to this PR.

It's also worth checking that the previous logic is still working as intended, I have tried to understand it and check for some boundary conditions, as well as re-running the test logic that was supplied in #179. Most notably clicking on headings in the side-bar and such should continue to correctly scroll the page.