### PR TITLE
Spec tweaks & redirect

### DIFF
--- a/packages/blockprotocol/package.json
+++ b/packages/blockprotocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blockprotocol",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "TypeScript typings for https://blockprotocol.org developers",
   "keywords": [
     "blockprotocol",

--- a/packages/react-block-loader/README.md
+++ b/packages/react-block-loader/README.md
@@ -2,7 +2,7 @@
 
 This package is not yet updated to Block Protocol version 0.2.
 
-# React Block Loader
+## React Block Loader
 
 A component which loads a [Block Protocol](https://blockprotocol.org) block from a remote URL, and passes on the properties and functions you provide.
 

--- a/packages/react-block-loader/README.md
+++ b/packages/react-block-loader/README.md
@@ -1,3 +1,7 @@
+# WARNING
+
+This package is not yet updated to Block Protocol version 0.2.
+
 # React Block Loader
 
 A component which loads a [Block Protocol](https://blockprotocol.org) block from a remote URL, and passes on the properties and functions you provide.

--- a/packages/react-block-loader/package.json
+++ b/packages/react-block-loader/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@lit-labs/react": "^1.0.4",
-    "blockprotocol": "0.0.10",
+    "blockprotocol": "0.0.11",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "uuid": "^8.3.2"

--- a/site/next.config.js
+++ b/site/next.config.js
@@ -41,6 +41,11 @@ const nextConfig = {
         destination: "/docs/developing-blocks#publish",
         permanent: true,
       },
+      {
+        source: "/spec/block-types",
+        destination: "/spec/core-specification",
+        permanent: true,
+      },
     ];
   },
 

--- a/site/src/_pages/spec/0_index.mdx
+++ b/site/src/_pages/spec/0_index.mdx
@@ -24,8 +24,12 @@ The [core specification](Block%20Protocol%20v0%202%209ae60f02aaf745eba5fa488b31b
 Each **service specification** defines _what_ applications and blocks communicate. A service is a logical grouping of messages blocks and applications may exchange.
 
 Each specification is versioned separately, allowing them to evolve independently.
-
 Any reference to the ‘protocol version’ should be read as _the version of the core specification_.
+
+Separate core and service specifications were introduced in version 0.2 of the Block Protocol, with both the
+[core specification](/spec/core-specification) and [the first service specification](/spec/graph-service-specification)
+starting on version 0.2 in recognition of how they each are an iteration of requirements
+that were previously specified in version 0.1.
 
 ## Overview
 

--- a/site/src/_pages/spec/1_core-specification.mdx
+++ b/site/src/_pages/spec/1_core-specification.mdx
@@ -1,4 +1,4 @@
-# Core Specification
+# Core Specification 0.2
 
 This document specifies how to define and use "blocks" – discrete components which can be used across multiple applications.
 

--- a/site/src/_pages/spec/2_graph-service-specification.mdx
+++ b/site/src/_pages/spec/2_graph-service-specification.mdx
@@ -1,4 +1,4 @@
-# Graph Service Specification
+# Graph Service Specification 0.2
 
 This document defines a **graph service** according to the terms set out in the core specification.
 

--- a/site/src/_pages/spec/3_rfcs_and_roadmap.mdx
+++ b/site/src/_pages/spec/3_rfcs_and_roadmap.mdx
@@ -55,13 +55,6 @@ While embedding applications can handle displaying an interface for reloading bl
 
 #### Block definition
 
-##### Entity types
-
-We’re intending to move away from entities having to fully describe the constraints of each of their properties.
-Instead, type definitions are going to become shareable and reusable in a new type system which establishes
-a hierarchy of types to address a number of shortcomings in our current system.
-For in-depth motivation, a proposed implementation plan, and the wide-reaching implications [please see the RFC](https://github.com/blockprotocol/blockprotocol/pull/352).
-
 ##### Self-contained blocks and sandboxing
 
 At the moment, the specification is largely silent on sandboxing, and blocks should be designed to work whether in their own scope or in the scope of a wider application, e.g. by not polluting the global scope.
@@ -127,6 +120,13 @@ The most detailed version of this would be for blocks to be able to:
 
 ### Graph
 
+##### Entity types
+
+We’re intending to move away from entities having to fully describe the constraints of each of their properties.
+Instead, type definitions are going to become shareable and reusable in a new type system which establishes
+a hierarchy of types to address a number of shortcomings in our current system.
+For in-depth motivation, a proposed implementation plan, and the wide-reaching implications [please see the RFC](https://github.com/blockprotocol/blockprotocol/pull/352).
+
 #### Pagination
 
 We intend to move to a cursor-based method for paginating aggregations of entities, likely based on the [Connections](https://relay.dev/graphql/connections.htm) specification.
@@ -141,4 +141,4 @@ This does, however, mean there is a possibility of competing schemas attempting 
 
 The ability to translate between schemas would help - e.g. some way expressing an equivalence relationship between properties in different schema. This might be a keyword such as `sameAs` or `equivalentTo` mapping between schemas and their properties. Then, either blocks or embedding applications could programmatically translate between schemas.
 
-Note that this is about translating between different JSON Schemas, and is not to be confused with the process of translating JSON schema to schema.org (and equivalent) types, which has an established technical approach mentioned **[here](https://blockprotocol.org/spec/embedding-applications#machine-readable-pages)**.
+Note that this is about translating between different JSON Schemas, and is not to be confused with the process of translating JSON schema to schema.org (and equivalent) types, which has an established technical approach mentioned **[here](/docs/faq#how-does-the-block-protocol-advance-the-semantic-web)**.

--- a/yarn.lock
+++ b/yarn.lock
@@ -3714,6 +3714,13 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
+blockprotocol@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/blockprotocol/-/blockprotocol-0.0.10.tgz#8ffb1c45ea789d6909012f101b9591b2e6213c7e"
+  integrity sha512-YyEEPQDyf+LGKSoiXjsOXySTvkT9TL/hyh1zKKua2HnsigdDSJ30fjHNWeiXAKO/6VEyjpHFXpEI7mmBjWDyig==
+  dependencies:
+    "@types/react" "^17.0.39"
+
 bn.js@^4.0.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"


### PR DESCRIPTION
A few small tweaks:
1. redirect `/spec/block-types`, since the path no longer exists
2. add `0.2` to specs and mention why in overview
3. bump `blockprotocol` package (now deprecated) to `0.0.11` to publish with new README
4. move Entity types RFC to correct section
5. Add warning to `react-block-loader`  that it needs updating to 0.2