### PR TITLE
Remove h4s from the sitemap

### DIFF
--- a/site/src/theme/components/navigation/mui-breadcrumbs-theme-options.ts
+++ b/site/src/theme/components/navigation/mui-breadcrumbs-theme-options.ts
@@ -10,9 +10,6 @@ export const MuiBreadcrumbsThemeOptions: Components<Theme>["MuiBreadcrumbs"] = {
       "> a": {
         borderBottomColor: "transparent",
       },
-      "&:not(:last-child)": {
-        maxWidth: 150,
-      },
       "&:last-child": {
         color: theme.palette.purple[700],
       },

--- a/site/src/util/mdx-components.tsx
+++ b/site/src/util/mdx-components.tsx
@@ -180,24 +180,13 @@ export const mdxComponents: Record<string, ComponentType> = {
     );
   },
   h4: (props: TypographyProps) => {
-    const anchor = slugify(stringifyChildren(props.children), {
-      lower: true,
-    });
-
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const { headingRef } = usePageHeading({ anchor });
-
     return (
       <Heading
-        ref={headingRef}
-        mt={HEADING_MARGIN_TOP.H4}
+        mt={HEADING_MARGIN_TOP.H5}
         mb={HEADING_MARGIN_BOTTOM}
-        variant="bpHeading4"
+        variant="bpHeading5"
         {...props}
-      >
-        {props.children}
-        <HeadingAnchor anchor={anchor} depth={4} />
-      </Heading>
+      />
     );
   },
   h5: (props: TypographyProps) => {

--- a/site/src/util/mdx-utils.tsx
+++ b/site/src/util/mdx-utils.tsx
@@ -190,28 +190,6 @@ export const getPage = (params: {
               },
             ]
           : prev;
-      } else if (currentHeading.depth === 4) {
-        if (prev.length > 0) {
-          const heading2 = prev[prev.length - 1]!;
-          const heading3 =
-            heading2.subSections[heading2.subSections.length - 1]!;
-
-          return [
-            ...prev.slice(0, -1),
-            {
-              ...heading2,
-              subSections: [
-                ...(heading2.subSections || []).slice(0, -1),
-                {
-                  ...heading3,
-                  subSections: [...(heading3.subSections || []), newSection],
-                },
-              ],
-            },
-          ];
-        } else {
-          return prev;
-        }
       }
       return prev;
     }, []),


### PR DESCRIPTION
The docs sidebar is too granular right now. This makes it a bit easier to work with. 

This also fixes the breadcrumbs by removing the max width on them, and also removing the direct linking to h4s. 