### PR TITLE
Update references to HTML functions in spec

### DIFF
--- a/packages/block-template/package.json
+++ b/packages/block-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "block-template",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Block Protocol block templates",
   "keywords": [
     "blockprotocol",

--- a/site/src/_pages/docs/3_spec/1_core-specification.mdx
+++ b/site/src/_pages/docs/3_spec/1_core-specification.mdx
@@ -177,7 +177,7 @@ If blocks generate any scripts dynamically at runtime, they MUST call `markScrip
   </tbody>
 </table>
 
-An example HTML block is available via `npx create-block-app your-block-nam --template html`
+An example HTML block is available via `npx create-block-app your-block-name --template html`
 
 ## Block-application communication
 

--- a/site/src/_pages/docs/3_spec/1_core-specification.mdx
+++ b/site/src/_pages/docs/3_spec/1_core-specification.mdx
@@ -118,12 +118,13 @@ Embedding applications which load ANY block of `kind: "html"` MUST provide a `bl
 
 - MUST contain a `getBlockContainer` key where the value is a function, which the HTML block can call to obtain a reference to the container element for that specific block:
   - this MUST accept a single argument, which MUST be either a single script element, or a URL, and may be omitted
-  - the implementation of these functions relies on embedding applications attaching ids to script tags when loading blocks by which they can be later identified (or when the block provides additional scripts via `markScripts`). A reference implementation is available in our documentation **[TODO: link to functions]**
+  - the implementation of these functions relies on embedding applications attaching ids to script tags when loading blocks by which they can be later identified (or when the block provides additional scripts via `markScripts`).
 - MUST contain a `markScripts` key where the value is a function, which is used to attach ids to dynamically script tags so that they can be identified when calling `getBlockContainer`
   - This MUST accept TWO arguments:
     - the first MUST be the script source
     - the second MUST be either a single script element, or a URL.
-  - A reference implementation is available in our documentation.
+
+The `@blockprotocol/core` package exports a `blockprotocolGlobals` object which implements these functions.
 
 Blocks of `kind: "html"` MUST call `getBlockContainer` from within any script they load, with different strategies depending on whether the script is:
 
@@ -175,6 +176,8 @@ If blocks generate any scripts dynamically at runtime, they MUST call `markScrip
     </tr>
   </tbody>
 </table>
+
+An example HTML block is available via `npx create-block-app your-block-nam --template html`
 
 ## Block-application communication
 


### PR DESCRIPTION
We had some placeholder references to implementations of the functions HTML-type blocks require.

This PR updates those references. It also bumps the `block-template` 