### PR TITLE
Fix metadata updates in create-block-app for html blocks

### DIFF
--- a/packages/create-block-app/package.json
+++ b/packages/create-block-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-block-app",
-  "version": "0.0.6",
+  "version": "0.0.8",
   "description": "Create new https://blockprotocol.org blocks",
   "keywords": [
     "blockprotocol",


### PR DESCRIPTION
`create-block-app` attempts to update bits of metadata in `package.json["blockprotocol"]`, which are then used to generate `block-metadata.json` at build time.

The new HTML template doesn't have automatic `block-metadata.json` creation, and thus doesn't have the `blockprotocol` object in `package.json` – since we only use that as a staging ground for data we pull to create `block-metadata.json` - and this was causing a crash in `create-block-app block --template html`, because the script assumed that `blockprotocol` was present.

This PR fixes that and sets a few bits of metadata for HTML blocks. I've already published the fix.