### PR TITLE
Update block commits

### DIFF
--- a/hub/@hash/callout.json
+++ b/hub/@hash/callout.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "bd9a2427546f4cdd5fd00eb9d319fd028ecba648",
+  "commit": "80b954d984baff4bfbd6ab6908fd0f46c419b09e",
 
   "workspace": "@hashintel/block-callout",
   "distDir": "dist"

--- a/hub/@hash/code.json
+++ b/hub/@hash/code.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "bd9a2427546f4cdd5fd00eb9d319fd028ecba648",
+  "commit": "80b954d984baff4bfbd6ab6908fd0f46c419b09e",
 
   "workspace": "@hashintel/block-code",
   "distDir": "dist"

--- a/hub/@hash/divider.json
+++ b/hub/@hash/divider.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "bd9a2427546f4cdd5fd00eb9d319fd028ecba648",
+  "commit": "80b954d984baff4bfbd6ab6908fd0f46c419b09e",
 
   "workspace": "@hashintel/block-divider",
   "distDir": "dist"

--- a/hub/@hash/embed.json
+++ b/hub/@hash/embed.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "bd9a2427546f4cdd5fd00eb9d319fd028ecba648",
+  "commit": "80b954d984baff4bfbd6ab6908fd0f46c419b09e",
 
   "workspace": "@hashintel/block-embed",
   "distDir": "dist"

--- a/hub/@hash/header.json
+++ b/hub/@hash/header.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "bd9a2427546f4cdd5fd00eb9d319fd028ecba648",
+  "commit": "80b954d984baff4bfbd6ab6908fd0f46c419b09e",
 
   "workspace": "@hashintel/block-header",
   "distDir": "dist"

--- a/hub/@hash/image.json
+++ b/hub/@hash/image.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "bd9a2427546f4cdd5fd00eb9d319fd028ecba648",
+  "commit": "80b954d984baff4bfbd6ab6908fd0f46c419b09e",
 
   "workspace": "@hashintel/block-image",
   "distDir": "dist"

--- a/hub/@hash/paragraph.json
+++ b/hub/@hash/paragraph.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "bd9a2427546f4cdd5fd00eb9d319fd028ecba648",
+  "commit": "80b954d984baff4bfbd6ab6908fd0f46c419b09e",
 
   "workspace": "@hashintel/block-paragraph",
   "distDir": "dist"

--- a/hub/@hash/person.json
+++ b/hub/@hash/person.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "bd9a2427546f4cdd5fd00eb9d319fd028ecba648",
+  "commit": "80b954d984baff4bfbd6ab6908fd0f46c419b09e",
 
   "workspace": "@hashintel/block-person",
   "distDir": "dist"

--- a/hub/@hash/table.json
+++ b/hub/@hash/table.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "bd9a2427546f4cdd5fd00eb9d319fd028ecba648",
+  "commit": "80b954d984baff4bfbd6ab6908fd0f46c419b09e",
 
   "workspace": "@hashintel/block-table",
   "distDir": "dist"

--- a/hub/@hash/video.json
+++ b/hub/@hash/video.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "bd9a2427546f4cdd5fd00eb9d319fd028ecba648",
+  "commit": "80b954d984baff4bfbd6ab6908fd0f46c419b09e",
 
   "workspace": "@hashintel/block-video",
   "distDir": "dist"

--- a/hub/@timdiekmann/countdown.json
+++ b/hub/@timdiekmann/countdown.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "bd9a2427546f4cdd5fd00eb9d319fd028ecba648",
+  "commit": "80b954d984baff4bfbd6ab6908fd0f46c419b09e",
   "workspace": "@hashintel/block-countdown",
   "distDir": "dist"
 }

--- a/hub/@timdiekmann/timer.json
+++ b/hub/@timdiekmann/timer.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "bd9a2427546f4cdd5fd00eb9d319fd028ecba648",
+  "commit": "80b954d984baff4bfbd6ab6908fd0f46c419b09e",
 
   "workspace": "@hashintel/block-timer",
   "distDir": "dist"

--- a/hub/@tldraw/drawing-canvas.json
+++ b/hub/@tldraw/drawing-canvas.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "bd9a2427546f4cdd5fd00eb9d319fd028ecba648",
+  "commit": "80b954d984baff4bfbd6ab6908fd0f46c419b09e",
   "workspace": "@hashintel/drawing",
   "distDir": "dist"
 }


### PR DESCRIPTION
This PR updates commits on the HASH blocks so that they get the revised READMEs introduced in https://github.com/hashintel/hash/pull/657 - these READMEs now display on their page on the hub.