### PR TITLE
Styling and copy fixes

### DIFF
--- a/site/src/_pages/docs/1_developing-blocks.mdx
+++ b/site/src/_pages/docs/1_developing-blocks.mdx
@@ -16,7 +16,7 @@ In practice, most block developers will not need to know the lower-level details
 
 We provide three templates which allow you to define the entry point for your block in different ways:
 
-- `custom-element`: create a block defined as a custom element (or Web Component).
+- `custom-element`: create a block defined as a custom element (also known as Web Components).
 - `html`: create a block defined as an HTML file, with JavaScript added via `<script>` tags.
 - `react`: create a block defined as a React component.
 
@@ -217,7 +217,7 @@ If you want to write blocks **using other technologies or frameworks**, you have
 
 1.  use a `custom-element` template and use different approaches when constructing the element-i.e. use a custom element as a wrapper for anything else you like.
 1.  use an `html` template and import and use your additional libraries inside the `<script>` tag.
-1.  use a React component as a wrapper around something else. As an example, see [this blog post](https://hash.dev/blog/build-blocks-in-any-language) on writing a block in F#, wrapped as a React component.
+1.  use languages which can be transpiled to JavaScript. As an example, see [this blog post](https://hash.dev/blog/build-blocks-in-any-language) on writing a block using F#. This block uses React, you can use transpiled JavaScript in blocks defined as HTML files or custom elements too.
 
 ### I don’t want to use TypeScript
 

--- a/site/src/components/navbar/mobile-nav-items.tsx
+++ b/site/src/components/navbar/mobile-nav-items.tsx
@@ -111,9 +111,7 @@ const MobileNavNestedPage = <T extends SiteMapPage | SiteMapPageSection>({
           <ListItemText
             primary={title}
             sx={{
-              whiteSpace: "nowrap",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
+              wordBreak: "break-word",
               "> .MuiListItemText-primary": {
                 display: "inline",
               },

--- a/site/src/components/page-sidebar.tsx
+++ b/site/src/components/page-sidebar.tsx
@@ -40,9 +40,7 @@ const SidebarLink = styled(Link)(({ theme }) => ({
   fontSize: 15,
   paddingTop: 8,
   paddingBottom: 8,
-  whiteSpace: "nowrap",
-  textOverflow: "ellipsis",
-  overflow: "hidden",
+  wordBreak: "break-word",
 }));
 
 type SidebarPageSectionProps = {
@@ -434,6 +432,7 @@ export const Sidebar: VFC<SidebarProps> = ({
             "padding-top",
             "padding-bottom",
           ]),
+          wordBreak: "break-word",
         }}
       >
         <Box

--- a/site/src/components/pages/docs/docs-content.tsx
+++ b/site/src/components/pages/docs/docs-content.tsx
@@ -69,6 +69,7 @@ export const DocsContent: VFC<DocsPageProps> = ({
         sx={{
           margin: 0,
           marginTop: { xs: 5, md: 8 },
+          width: "inherit",
         }}
       >
         {title ? (

--- a/site/src/components/pages/hub/block-data-container.tsx
+++ b/site/src/components/pages/hub/block-data-container.tsx
@@ -6,6 +6,7 @@ import {
   Snackbar,
   Tab,
   Tabs,
+  Typography,
   useMediaQuery,
   useTheme,
 } from "@mui/material";
@@ -315,7 +316,13 @@ export const BlockDataContainer: VoidFunctionComponent<
                 sx={{ listStyleType: "square" }}
               >
                 {errors.map((err) => (
-                  <li key={err}>{err}</li>
+                  <Typography
+                    component="li"
+                    key={err}
+                    sx={{ wordBreak: "break-word" }}
+                  >
+                    {err}
+                  </Typography>
                 ))}
               </Box>
             </Box>

--- a/site/src/pages/docs/[[...docs-slug]].page.tsx
+++ b/site/src/pages/docs/[[...docs-slug]].page.tsx
@@ -176,7 +176,7 @@ const gitHubInfoCard = (
       }}
     >
       <LinkButton
-        href="https://github.com/blockprotocol/blockprotocol/tree/main/site/src/_pages/spec"
+        href="https://github.com/blockprotocol/blockprotocol/tree/main/site/src/_pages/docs/3_spec"
         variant="primary"
         color="teal"
         size="small"


### PR DESCRIPTION
This PR fixes a few small issues:

### 1. Sidebar width and list item wrapping
Previously, the sidebar was not taking up the width specified in the designs and the code (300px), because the body content to the right was squeezing it out when it shouldn't.

Also, sidebar items were being cut off with an ellipsis, which meant that it was impossible to tell what many were about.
 
**Before**
<img width="1470" alt="Screenshot 2022-06-16 at 10 38 15" src="https://user-images.githubusercontent.com/37743469/174045724-41400e67-d745-45d0-8a59-fbec97f30da4.png">

**After**
<img width="1477" alt="Screenshot 2022-06-16 at 10 37 28" src="https://user-images.githubusercontent.com/37743469/174045765-c0704768-1d94-4936-9b7d-1884b49eaeac.png">

**Before**
<img width="1369" alt="Screenshot 2022-06-16 at 10 42 24" src="https://user-images.githubusercontent.com/37743469/174045798-340aee64-bddd-4a5c-b89a-3a68187eb2bd.png">

**After**
<img width="1365" alt="Screenshot 2022-06-16 at 10 43 29" src="https://user-images.githubusercontent.com/37743469/174045939-978e9577-0f0c-40b4-941e-bfd00f091acb.png">

### 2. Spec copy tweaks

Clarify language related to custom elements, and the F# blog post.

### 3. Validation error wrapping

Wrap words in the error list in the block hub.




