### PR TITLE
Hide mobile sign up button when signed in

### DIFF
--- a/site/src/components/navbar.tsx
+++ b/site/src/components/navbar.tsx
@@ -1,5 +1,4 @@
-import { faArrowRight, faBars, faZap } from "@fortawesome/free-solid-svg-icons";
-import { ArrowRight } from "@mui/icons-material";
+import { faBars } from "@fortawesome/free-solid-svg-icons";
 import {
   Box,
   Collapse,
@@ -343,21 +342,8 @@ export const Navbar: VFC<NavbarProps> = ({
                     </Link>
                   )}
                   {user !== "loading" && !user?.isSignedUp ? (
-                    <LinkButton
-                      href="/docs"
-                      size="small"
-                      variant="primary"
-                      endIcon={
-                        <FontAwesomeIcon
-                          icon={faArrowRight}
-                          sx={{
-                            fontSize: "16px !important",
-                            color: ({ palette }) => palette.gray[10],
-                          }}
-                        />
-                      }
-                    >
-                      Read the Docs
+                    <LinkButton href="/signup" size="small" variant="primary">
+                      Sign Up
                     </LinkButton>
                   ) : null}
                 </>
@@ -419,30 +405,30 @@ export const Navbar: VFC<NavbarProps> = ({
             <MobileNavItems onClose={() => setDisplayMobileNav(false)} />
           </Box>
 
-          <Box
-            flexShrink={0}
-            display="flex"
-            flexDirection="column"
-            alignItems="center"
-            sx={{
-              paddingY: 4,
-              paddingX: 4.25,
-              borderTopStyle: "solid",
-              borderTopWidth: 1,
-              borderTopColor: theme.palette.gray[40],
-              "> button, a": {
-                width: {
-                  xs: "100%",
-                  sm: "unset",
+          {user ? null : router.pathname === "/login" ? null : (
+            <Box
+              flexShrink={0}
+              display="flex"
+              flexDirection="column"
+              alignItems="center"
+              sx={{
+                paddingY: 4,
+                paddingX: 4.25,
+                borderTopStyle: "solid",
+                borderTopWidth: 1,
+                borderTopColor: theme.palette.gray[40],
+                "> button, a": {
+                  width: {
+                    xs: "100%",
+                    sm: "unset",
+                  },
+                  minWidth: {
+                    xs: "unset",
+                    sm: 320,
+                  },
                 },
-                minWidth: {
-                  xs: "unset",
-                  sm: 320,
-                },
-              },
-            }}
-          >
-            {user ? null : router.pathname === "/login" ? null : (
+              }}
+            >
               <LinkButton
                 href="#"
                 variant="secondary"
@@ -458,28 +444,19 @@ export const Navbar: VFC<NavbarProps> = ({
               >
                 Log in
               </LinkButton>
-            )}
-            <LinkButton
-              href="/docs"
-              sx={{
-                fontSize: 18,
-              }}
-              startIcon={
-                <FontAwesomeIcon
-                  icon={faZap}
-                  sx={{
-                    color: ({ palette }) => palette.gray[10],
-                    marginRight: 0.5,
-                    fontSize: "16px !important",
-                  }}
-                />
-              }
-              variant="primary"
-              onClick={() => setDisplayMobileNav(false)}
-            >
-              Read the Docs
-            </LinkButton>
-          </Box>
+
+              <LinkButton
+                href="/signup"
+                sx={{
+                  fontSize: 18,
+                }}
+                variant="primary"
+                onClick={() => setDisplayMobileNav(false)}
+              >
+                Sign Up
+              </LinkButton>
+            </Box>
+          )}
         </Box>
       </Slide>
     </Box>

--- a/site/src/components/navbar.tsx
+++ b/site/src/components/navbar.tsx
@@ -1,4 +1,5 @@
-import { faBars } from "@fortawesome/free-solid-svg-icons";
+import { faArrowRight, faBars, faZap } from "@fortawesome/free-solid-svg-icons";
+import { ArrowRight } from "@mui/icons-material";
 import {
   Box,
   Collapse,
@@ -342,8 +343,21 @@ export const Navbar: VFC<NavbarProps> = ({
                     </Link>
                   )}
                   {user !== "loading" && !user?.isSignedUp ? (
-                    <LinkButton href="/signup" size="small" variant="primary">
-                      Sign Up
+                    <LinkButton
+                      href="/docs"
+                      size="small"
+                      variant="primary"
+                      endIcon={
+                        <FontAwesomeIcon
+                          icon={faArrowRight}
+                          sx={{
+                            fontSize: "16px !important",
+                            color: ({ palette }) => palette.gray[10],
+                          }}
+                        />
+                      }
+                    >
+                      Read the Docs
                     </LinkButton>
                   ) : null}
                 </>
@@ -406,12 +420,13 @@ export const Navbar: VFC<NavbarProps> = ({
           </Box>
 
           <Box
-            p={5}
             flexShrink={0}
             display="flex"
             flexDirection="column"
             alignItems="center"
             sx={{
+              paddingY: 4,
+              paddingX: 4.25,
               borderTopStyle: "solid",
               borderTopWidth: 1,
               borderTopColor: theme.palette.gray[40],
@@ -437,24 +452,32 @@ export const Navbar: VFC<NavbarProps> = ({
                   event?.preventDefault();
                 }}
                 sx={{
-                  marginBottom: 1,
+                  fontSize: 18,
+                  marginBottom: 1.25,
                 }}
               >
                 Log in
               </LinkButton>
             )}
             <LinkButton
-              href="/signup"
+              href="/docs"
               sx={{
-                width: "100%",
-                py: 1.5,
-                px: 3,
-                textTransform: "none",
+                fontSize: 18,
               }}
+              startIcon={
+                <FontAwesomeIcon
+                  icon={faZap}
+                  sx={{
+                    color: ({ palette }) => palette.gray[10],
+                    marginRight: 0.5,
+                    fontSize: "16px !important",
+                  }}
+                />
+              }
               variant="primary"
               onClick={() => setDisplayMobileNav(false)}
             >
-              Sign Up
+              Read the Docs
             </LinkButton>
           </Box>
         </Box>


### PR DESCRIPTION
When Logged in, the `Sign Up` button was still being displayed inside the mobile navbar. This PR fixes this problem and also fixes some of the button styles according to this [figma document](https://www.figma.com/file/Fpmde3E9nJMb4VLkPTYgrM/blockprotocol.org?node-id=3134%3A21678).

Before:

![image](https://user-images.githubusercontent.com/37453800/174114531-8cd286e6-4c39-47d1-ab98-29b66bf43f6d.png)


After:

![image](https://user-images.githubusercontent.com/37453800/174113904-f60cf2b3-f8c6-42ff-bb7a-321b9c24e239.png)


[Asana Task](https://app.asana.com/0/1201095311341924/1202452908638532/f)

 