### PR TITLE
Fix: don't use object.hasOwn

### DIFF
--- a/site/src/components/navbar.tsx
+++ b/site/src/components/navbar.tsx
@@ -136,7 +136,10 @@ const useScrollingNavbar = (
   const [scrolledPast, setScrolledPast] =
     useState<Record<string, boolean>>(defaultScrolledPast);
 
-  if (threshold !== null && !Object.hasOwn(defaultScrolledPast, threshold)) {
+  if (
+    threshold !== null &&
+    !Object.prototype.hasOwnProperty.call(defaultScrolledPast, threshold)
+  ) {
     setScrolledPast(defaultScrolledPast);
   }
 
@@ -153,7 +156,10 @@ const useScrollingNavbar = (
           );
 
           return (threshold !== null &&
-            !Object.hasOwn(nextScrolledPast, threshold)) ||
+            !Object.prototype.hasOwnProperty.call(
+              nextScrolledPast,
+              threshold,
+            )) ||
             Object.keys(nextScrolledPast).some(
               (key) => nextScrolledPast[key] !== currentValue[key],
             )


### PR DESCRIPTION
Support for `Object.hasOwn` was only [introduced to Safari in March 2022](https://caniuse.com/mdn-javascript_builtins_object_hasown) in version 15.4. 

This means that blockprotocol.org currently crashes when visited with an older version of Safari.

The PR replaces uses of `Object.hasOwn` to fix this.