### PR TITLE
Fix broken links in specification

### DIFF
--- a/site/src/_pages/docs/0_index.mdx
+++ b/site/src/_pages/docs/0_index.mdx
@@ -31,4 +31,4 @@ Following these requirements allows BP blocks to do more than regular web blocks
 
 BP blocks can also be published to the [Block Hub](/hub) – an open-source registry where anyone can publish their blocks for other people to discover and use.
 
-Any application can accept BP blocks, as long as they follow the [requirements for embedding applications](/spec/embedding-applications).
+Any application can accept BP blocks, as long as they follow the [requirements for embedding applications](/docs/spec/embedding-applications).

--- a/site/src/_pages/docs/1_developing-blocks.mdx
+++ b/site/src/_pages/docs/1_developing-blocks.mdx
@@ -82,7 +82,7 @@ The starter blocks created by `create-block-app` implement a simple example of t
 
 The Graph Service describes how entities can be created, queried, updated, and linked together, including the block entity. It enables your block to create, read, update, and delete data in the embedding application.
 
-The Graph Service is available via the `graphService` property in each starter template. It has a number of methods corresponding to the messages defined in the [specification](/spec/graph-service-specification).
+The Graph Service is available via the `graphService` property in each starter template. It has a number of methods corresponding to the messages defined in the [specification](/docs/spec/graph-service-specification).
 
 Using these methods in combination, you can create complex graphs from within a block without having to know anything about the implementation details of the application embedding it.
 
@@ -145,7 +145,7 @@ Any entities linked to the block will appear in the `linkedEntities` property, w
 
 If you are using TypeScript, the types for methods available on `graphService` (as defined in the `@blockprotocol/graph` package) should help you understand what methods are available and how they operate.
 
-You can also review the messages defined in the graph specification [here](/spec/graph-service-specification). If you do so, bear in mind the following:
+You can also review the messages defined in the graph specification [here](/docs/spec/graph-service-specification). If you do so, bear in mind the following:
 
 - only the ones marked as `source: "block"` are available as methods to your block.
 - any message marked as `sentOnInitialization` with `source: "embeder"` will be passed to your block as soon as it’s loaded. Remember that `custom-element` and `react`-type blocks receive these messages as properties under a `graph` object, whereas `html` blocks can register callbacks for each message.

--- a/site/src/_pages/docs/3_spec/0_index.mdx
+++ b/site/src/_pages/docs/3_spec/0_index.mdx
@@ -27,7 +27,7 @@ Each specification is versioned separately, allowing them to evolve independentl
 Any reference to the ‘protocol version’ should be read as _the version of the core specification_.
 
 Separate core and service specifications were introduced in version 0.2 of the Block Protocol, with both the
-[core specification](/spec/core-specification) and [the first service specification](/spec/graph-service-specification)
+[core specification](/docs/spec/core-specification) and [the first service specification](/docs/spec/graph-service-specification)
 starting on version 0.2 in recognition of how they each are an iteration of requirements
 that were previously specified in version 0.1.
 

--- a/site/src/_pages/docs/4_faq.mdx
+++ b/site/src/_pages/docs/4_faq.mdx
@@ -60,7 +60,7 @@ Entity data can be hosted in any application which implements the Block Protocol
 
 Blocks can fetch their own data from external services. For example, a map block might fetch data from a mapping service.
 
-We believe the best blocks will communicate data back and forth with the embedding application, making use of the [operations defined in the spec](/spec/graph-service-specification).
+We believe the best blocks will communicate data back and forth with the embedding application, making use of the [operations defined in the spec](/docs/spec/graph-service-specification).
 
 For example, a mapping block which persists a user’s choices about map positioning or styling back to the application – all without the application having to know anything about the block, or the block having to know anything about the application.
 
@@ -70,7 +70,7 @@ One aim of the Block Protocol is that blocks can store and retrieve data in an a
 
 Blocks can have their own local state - they might use this to allow users to explore data or draft changes, without saving anything.
 
-To save data beyond the session, blocks should make use of the [operations defined in the spec](/spec/graph-service-specification) to send updates to the embedding application.
+To save data beyond the session, blocks should make use of the [operations defined in the spec](/docs/spec/graph-service-specification) to send updates to the embedding application.
 
 ### How are Block Protocol blocks different to Web Components?
 
@@ -203,7 +203,7 @@ We expect to have to add custom keywords to cover relationships which JSON Schem
 
 We encourage applications to include JSON-LD describing entities on their public pages to make them machine-readable.
 
-In theory, the Block Protocol could use JSON-LD as the format in which entities are passed between applications and blocks. We did not pursue this because we believe it will be easier and more scalable to handle links between entities outside the JSON for the entity itself, [as described here](/spec/graph-service-specification). We have also taken a different approach to identifying entities, which may not have a public URI and may require a combination of fields to identify.
+In theory, the Block Protocol could use JSON-LD as the format in which entities are passed between applications and blocks. We did not pursue this because we believe it will be easier and more scalable to handle links between entities outside the JSON for the entity itself, [as described here](/docs/spec/graph-service-specification). We have also taken a different approach to identifying entities, which may not have a public URI and may require a combination of fields to identify.
 
 ### How does the Block Protocol relate to GraphQL?
 


### PR DESCRIPTION
This PR fixes several broken links in the specification, which relied on a redirect defined in `next.config.js` to work.