### PR TITLE
Update github footer link. Move Q&A up in developing blocks docs

### DIFF
--- a/site/src/_pages/docs/1_developing-blocks.mdx
+++ b/site/src/_pages/docs/1_developing-blocks.mdx
@@ -22,7 +22,19 @@ We provide three templates which allow you to define the entry point for your bl
 
 To create a new block, run `npx create-block-app block-name --template template`, replacing `block-name` with the name to give your block, and `template` with one of the template names listed above.
 
-These templates also allow you [to use other technologies](#i-want-to-use-a-different-technology).
+### I want to use a different technology
+
+If you want to write blocks **using other technologies or frameworks**, you have several options:
+
+1.  use a `custom-element` template and use different approaches when constructing the element-i.e. use a custom element as a wrapper for anything else you like.
+1.  use an `html` template and import and use your additional libraries inside the `<script>` tag.
+1.  use a language which can be transpiled to JavaScript. As an example, see [this blog post](https://hash.dev/blog/build-blocks-in-any-language) on writing a block using F#. This block uses React, you can use transpiled JavaScript in blocks defined as HTML files or custom elements too.
+
+### I don’t want to use TypeScript
+
+You can write your block in regular JavaScript using the methods described above - just rename your files from `*.tsx/*.ts` to `*.jsx/*.js`, remove the types, and get coding.
+
+Bear in mind that a block schema will not be automatically generated as part of the build process – you can write your own `block-schema.json` file at the root of your block’s folder, giving the type of props your App component accepts in [JSON Schema format](https://json-schema.org/).
 
 ## Creating a block
 
@@ -208,19 +220,3 @@ We assume that running `yarn install && yarn build` will build your block (after
 The specified `distDir` will be relative to the workspace directory or folder, if provided.
 
 </InfoCard>
-
-## Q&A
-
-### I want to use a different technology
-
-If you want to write blocks **using other technologies or frameworks**, you have several options:
-
-1.  use a `custom-element` template and use different approaches when constructing the element-i.e. use a custom element as a wrapper for anything else you like.
-1.  use an `html` template and import and use your additional libraries inside the `<script>` tag.
-1.  use a language which can be transpiled to JavaScript. As an example, see [this blog post](https://hash.dev/blog/build-blocks-in-any-language) on writing a block using F#. This block uses React, you can use transpiled JavaScript in blocks defined as HTML files or custom elements too.
-
-### I don’t want to use TypeScript
-
-You can write your block in regular JavaScript using the methods described above - just rename your files from `*.tsx/*.ts` to `*.jsx/*.js`, remove the types, and get coding.
-
-Bear in mind that the block schema will not be automatically generated as part of the build process – you can write your own `block-schema.json` file at the root of your block’s folder, giving the type of props your App component accepts in [JSON Schema format](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html).

--- a/site/src/components/footer.tsx
+++ b/site/src/components/footer.tsx
@@ -92,7 +92,7 @@ const SOCIALS: { name: string; icon: ReactNode; href: string }[] = [
   {
     name: "GitHub",
     icon: <FontAwesomeIcon icon={faGithub} />,
-    href: "https://github.com/blockprotocol",
+    href: "https://github.com/blockprotocol/blockprotocol",
   },
 ];
 


### PR DESCRIPTION
A couple of small tweaks:
- Update the footer link to go to the `blockprotocol` repo, not the organization
- Move Q&A on using different block dev approaches up to avoid splitting the topic unnecsesarily