### PR TITLE
Add calculation block to the hub

### DIFF
--- a/hub/@hash/callout.json
+++ b/hub/@hash/callout.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "2b4e35bc326af65343703482defba78a2d1f45de",
+  "commit": "e81d810ed6ef0c80c5ccab941d8e494d7444ff94",
 
   "workspace": "@hashintel/block-callout",
   "distDir": "dist"

--- a/hub/@hash/code.json
+++ b/hub/@hash/code.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "2b4e35bc326af65343703482defba78a2d1f45de",
+  "commit": "e81d810ed6ef0c80c5ccab941d8e494d7444ff94",
 
   "workspace": "@hashintel/block-code",
   "distDir": "dist"

--- a/hub/@hash/divider.json
+++ b/hub/@hash/divider.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "2b4e35bc326af65343703482defba78a2d1f45de",
+  "commit": "e81d810ed6ef0c80c5ccab941d8e494d7444ff94",
 
   "workspace": "@hashintel/block-divider",
   "distDir": "dist"

--- a/hub/@hash/embed.json
+++ b/hub/@hash/embed.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "2b4e35bc326af65343703482defba78a2d1f45de",
+  "commit": "e81d810ed6ef0c80c5ccab941d8e494d7444ff94",
 
   "workspace": "@hashintel/block-embed",
   "distDir": "dist"

--- a/hub/@hash/header.json
+++ b/hub/@hash/header.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "2b4e35bc326af65343703482defba78a2d1f45de",
+  "commit": "e81d810ed6ef0c80c5ccab941d8e494d7444ff94",
 
   "workspace": "@hashintel/block-header",
   "distDir": "dist"

--- a/hub/@hash/image.json
+++ b/hub/@hash/image.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "2b4e35bc326af65343703482defba78a2d1f45de",
+  "commit": "e81d810ed6ef0c80c5ccab941d8e494d7444ff94",
 
   "workspace": "@hashintel/block-image",
   "distDir": "dist"

--- a/hub/@hash/paragraph.json
+++ b/hub/@hash/paragraph.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "2b4e35bc326af65343703482defba78a2d1f45de",
+  "commit": "e81d810ed6ef0c80c5ccab941d8e494d7444ff94",
 
   "workspace": "@hashintel/block-paragraph",
   "distDir": "dist"

--- a/hub/@hash/person.json
+++ b/hub/@hash/person.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "2b4e35bc326af65343703482defba78a2d1f45de",
+  "commit": "e81d810ed6ef0c80c5ccab941d8e494d7444ff94",
 
   "workspace": "@hashintel/block-person",
   "distDir": "dist"

--- a/hub/@hash/table.json
+++ b/hub/@hash/table.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "2b4e35bc326af65343703482defba78a2d1f45de",
+  "commit": "e81d810ed6ef0c80c5ccab941d8e494d7444ff94",
 
   "workspace": "@hashintel/block-table",
   "distDir": "dist"

--- a/hub/@hash/video.json
+++ b/hub/@hash/video.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "2b4e35bc326af65343703482defba78a2d1f45de",
+  "commit": "e81d810ed6ef0c80c5ccab941d8e494d7444ff94",
 
   "workspace": "@hashintel/block-video",
   "distDir": "dist"

--- a/hub/@thehabbos007/calculation.json
+++ b/hub/@thehabbos007/calculation.json
@@ -1,0 +1,7 @@
+{
+  "repository": "https://github.com/hashintel/hash.git",
+  "commit": "e81d810ed6ef0c80c5ccab941d8e494d7444ff94",
+
+  "workspace": "@hashintel/calculation",
+  "distDir": "dist"
+}

--- a/hub/@timdiekmann/countdown.json
+++ b/hub/@timdiekmann/countdown.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "2b4e35bc326af65343703482defba78a2d1f45de",
+  "commit": "e81d810ed6ef0c80c5ccab941d8e494d7444ff94",
   "workspace": "@hashintel/block-countdown",
   "distDir": "dist"
 }

--- a/hub/@timdiekmann/timer.json
+++ b/hub/@timdiekmann/timer.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "2b4e35bc326af65343703482defba78a2d1f45de",
+  "commit": "e81d810ed6ef0c80c5ccab941d8e494d7444ff94",
 
   "workspace": "@hashintel/block-timer",
   "distDir": "dist"

--- a/hub/@tldraw/drawing.json
+++ b/hub/@tldraw/drawing.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "2b4e35bc326af65343703482defba78a2d1f45de",
+  "commit": "e81d810ed6ef0c80c5ccab941d8e494d7444ff94",
   "workspace": "@hashintel/drawing",
   "distDir": "dist"
 }


### PR DESCRIPTION
This PR adds the calculation block to the hub. It also bumps other HASH block commit ids to make it easier to search/replace later.