### PR TITLE
Make HTML blocks work on hub

### DIFF
--- a/packages/block-template/templates/html/block-metadata.json
+++ b/packages/block-template/templates/html/block-metadata.json
@@ -7,7 +7,7 @@
   "schema": "block-schema.json",
   "variants": [],
   "blockType": {
-    "blockType": "html"
+    "entryPoint": "html"
   },
   "protocol": "0.2",
   "displayName": "Template",

--- a/packages/block-template/templates/html/block-schema.json
+++ b/packages/block-template/templates/html/block-schema.json
@@ -3,8 +3,7 @@
   "type": "object",
   "properties": {
     "name": {
-      "type": "string",
-      "enum": ["string"]
+      "type": "string"
     }
   },
   "required": ["name"],

--- a/packages/block-template/templates/html/package.json
+++ b/packages/block-template/templates/html/package.json
@@ -30,6 +30,7 @@
     "@parcel/transformer-inline-string": "^2.6.0",
     "mock-block-dock": "0.0.15",
     "parcel": "^2.6.0",
+    "process": "^0.11.10",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   }

--- a/site/package.json
+++ b/site/package.json
@@ -58,7 +58,7 @@
     "lodash": "^4.17.21",
     "md5": "^2.3.0",
     "mime-types": "^2.1.34",
-    "mock-block-dock": "0.0.14",
+    "mock-block-dock": "0.0.15",
     "mongodb": "^4.2.2",
     "next": "^12.1.6",
     "next-connect": "^0.12.1",

--- a/site/src/components/pages/hub/sandboxed-block-demo.tsx
+++ b/site/src/components/pages/hub/sandboxed-block-demo.tsx
@@ -13,10 +13,13 @@ export const SandboxedBlockDemo: VoidFunctionComponent<SandboxedBlockProps> = ({
   props,
   sandboxBaseUrl,
 }) => {
+  const loadedRef = useRef(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   const postBlockProps = useCallback(() => {
-    iframeRef.current?.contentWindow?.postMessage(JSON.stringify(props), "*");
+    if (loadedRef.current) {
+      iframeRef.current?.contentWindow?.postMessage(JSON.stringify(props), "*");
+    }
   }, [props]);
 
   useEffect(() => {
@@ -36,6 +39,7 @@ export const SandboxedBlockDemo: VoidFunctionComponent<SandboxedBlockProps> = ({
       sandbox="allow-forms allow-scripts allow-same-origin"
       allow="clipboard-write"
       onLoad={() => {
+        loadedRef.current = true;
         postBlockProps();
       }}
       // todo: remove 100% after implementing viewport negotiation

--- a/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
+++ b/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
@@ -56,6 +56,7 @@ const handler: NextApiHandler = async (req, res) => {
   const { exampleGraph } = await readBlockDataFromDisk(blockMetadata);
 
   const mockBlockDockVersion = packageJson.dependencies["mock-block-dock"];
+  const graphVersion = packageJson.dependencies["@blockprotocol/graph"];
 
   const reactVersion =
     blockMetadata.externals?.react ?? packageJson.dependencies.react;
@@ -142,8 +143,11 @@ const handler: NextApiHandler = async (req, res) => {
       
           const entryPoint = blockType.entryPoint.toLocaleLowerCase();
           
-          const rawBlockSource = source;
-          const blockExport = entryPoint === "html" ? rawBlockSource : findBlockExport(loadCjsFromSource(rawBlockSource));
+          let blockExport = findBlockExport(loadCjsFromSource(source));
+          // @todo make this unnecessary
+          if (entryPoint === "html") {
+            blockExport = blockExport.replace(/(import.*?from.*?)@blockprotocol\\/graph/g, "$1https://esm.sh/@blockprotocol/graph@${graphVersion}")
+          }
           
           const blockDefinition = {
             ReactComponent: entryPoint === "react" ? blockExport : undefined,


### PR DESCRIPTION
This makes the updates to the hub/HTML block template to make HTML blocks work in the hub.

Follow ups:

- <s>Seems the initial example props don't work - for the template block as is, the name gets set to undefined until you change it?</s> Fixed by waiting until sandbox iframe has loaded before sending props. Seems there was a race condition there. 
- `@blockprotocol/graph` 0.0.9 needs uploading to npm - cc @CiaranMn  / @kachkaev 