### PR TITLE
Replace outdated links to `/spec` and `/docs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We welcome [contributions](#contributing) to this repository. Within it you will
 
 1.  `site`: the code for [blockprotocol.org](https://blockprotocol.org), including:
 
-    - the [Block Protocol specification](https://blockprotocol.org/spec) at [src/\_pages/spec](https://github.com/blockprotocol/blockprotocol/tree/main/site/src/_pages/spec)
+    - the [Block Protocol specification](https://blockprotocol.org/docs/spec) at [src/\_pages/spec](https://github.com/blockprotocol/blockprotocol/tree/main/site/src/_pages/docs/3_spec)
     - the [explanatory documentation](https://blockprotocol.org/docs) at [src/\_pages/docs](https://github.com/blockprotocol/blockprotocol/tree/main/site/src/_pages/docs)
 
 1.  `packages`: utility packages for constructing Block Protocol blocks. These are all available via `yarn add <package_name>` or `npm install <package_name>`. See the individual README files in each folder for more details.

--- a/packages/block-template/templates/custom-element/README.md
+++ b/packages/block-template/templates/custom-element/README.md
@@ -34,7 +34,7 @@ Other templates are available. See `npx create-block-app --help`
         - `image`: a preview image showing your block in action
         - `icon`: an icon to be associated with your block
       - lists the `externals` - libraries the block expects the host app to provide
-    - Once uploaded to a remote folder, embedding applications can access `block-metadata.json` to load a block and its schema. This file is documented in full [here](https://blockprotocol.org/spec).
+    - Once uploaded to a remote folder, embedding applications can access `block-metadata.json` to load a block and its schema. This file is documented in full [here](https://blockprotocol.org/docs/spec).
 
 Please see [the Block Protocol docs](https://blockprotocol.org/docs/developing-blocks)
 for help in creating and updating data from your block.

--- a/packages/block-template/templates/html/README.md
+++ b/packages/block-template/templates/html/README.md
@@ -23,7 +23,7 @@ Other templates are available. See `npx create-block-app --help`
 1.  When finished, run `yarn build`, which:
 
     - Bundles the component into a single source file
-    - Once uploaded to a remote folder, embedding applications can access `block-metadata.json` to load a block and its schema. This file is documented in full [here](https://blockprotocol.org/spec).
+    - Once uploaded to a remote folder, embedding applications can access `block-metadata.json` to load a block and its schema. This file is documented in full [here](https://blockprotocol.org/docs/spec).
 
 Please see [the Block Protocol docs](https://blockprotocol.org/docs/developing-blocks)
 for help in creating and updating data from your block.

--- a/packages/block-template/templates/react/README.md
+++ b/packages/block-template/templates/react/README.md
@@ -32,7 +32,7 @@ Other templates are available. See `npx create-block-app --help`
         - `image`: a preview image showing your block in action
         - `icon`: an icon to be associated with your block
       - lists the `externals` - libraries the block expects the host app to provide (React, unless modified)
-    - Once uploaded to a remote folder, embedding applications can access `block-metadata.json` to load a block and its schema. This file is documented in full [here](https://blockprotocol.org/spec).
+    - Once uploaded to a remote folder, embedding applications can access `block-metadata.json` to load a block and its schema. This file is documented in full [here](https://blockprotocol.org/docs/spec).
 
 Please see [the Block Protocol docs](https://blockprotocol.org/docs/developing-blocks)
 for help in reading and updating data from your block.

--- a/packages/react-block-loader/README.md
+++ b/packages/react-block-loader/README.md
@@ -11,7 +11,7 @@ A component which loads a [Block Protocol](https://blockprotocol.org) block from
 `yarn install "react-block-loader"`
 
 Pass RemoteBlock (at a minimum) a source url (`sourceUrl`), the properties the block expects (`blockProperties`),
-and functions for it to call (`blockProtocolFunctions`), as set out in [the specification](https://blockprotocol.org/spec).
+and functions for it to call (`blockProtocolFunctions`), as set out in [the specification](https://blockprotocol.org/docs/spec).
 
 ```jsx
 import { RemoteBlock } from "react-block-loader";
@@ -63,20 +63,20 @@ const BlockLoader = ({ blockSourceFolder: string }) => {
 
 ## Props
 
-| name                     | type           | required | default                 | description                                                                                                                                  |
-| ------------------------ | -------------- | -------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `blockMetadata`          | `object`       | no       |                         | the block's [block-metadata.json](https://blockprotocol.org/spec/block-types). Will be used to determine Web Component tag names (TBD soon). |
-| `blockProperties`        | `object`       | yes      |                         | the block's own properties, and BP-specified properties (e.g. entityId, linkGroups)                                                          |
-| `crossFrame`             | `boolean`      | no       | `false`                 | whether this block should make requests to [the parent window](#inside-iframes) for block source                                             |
-| `blockProtocolFunctions` | `object`       | yes      |                         | the [functions provided to blocks](https://blockprotocol.org/spec/block-types#entity-functions) for reading and editing entity and link data |
-| `externalDependencies`   | `object`       | no       |                         | [libraries](#external-dependencies) which the block depends on but does not include in its package                                           |
-| `LoadingIndicator`       | `ReactElement` | no       | `<div>Loading...</div>` | an element to display while the block is loading                                                                                             |
-| `onBlockLoaded`          | `function`     | no       |                         | a callback, called when the block has been successfully parsed and loaded                                                                    |
-| `sourceUrl`              | `string`       | yes      |                         | the URL to the entry source file for the block                                                                                               |
+| name                     | type           | required | default                 | description                                                                                                                                                                           |
+| ------------------------ | -------------- | -------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `blockMetadata`          | `object`       | no       |                         | the block's [block-metadata.json](https://blockprotocol.org/docs/spec/core-specification#types-of-block). Will be used to determine Web Component tag names (TBD soon).               |
+| `blockProperties`        | `object`       | yes      |                         | the block's own properties, and BP-specified properties (e.g. entityId, linkGroups)                                                                                                   |
+| `crossFrame`             | `boolean`      | no       | `false`                 | whether this block should make requests to [the parent window](#inside-iframes) for block source                                                                                      |
+| `blockProtocolFunctions` | `object`       | yes      |                         | the functions provided to blocks for reading and editing entity and link data (replaced by [graph service in Þ 0.2](https://blockprotocol.org/docs/spec/graph-service-specification)) |
+| `externalDependencies`   | `object`       | no       |                         | [libraries](#external-dependencies) which the block depends on but does not include in its package                                                                                    |
+| `LoadingIndicator`       | `ReactElement` | no       | `<div>Loading...</div>` | an element to display while the block is loading                                                                                                                                      |
+| `onBlockLoaded`          | `function`     | no       |                         | a callback, called when the block has been successfully parsed and loaded                                                                                                             |
+| `sourceUrl`              | `string`       | yes      |                         | the URL to the entry source file for the block                                                                                                                                        |
 
 ## External dependencies
 
-A block may indicate `externals` in `block-metadata.json` ([docs](https://blockprotocol.org/spec/block-types)).
+A block may indicate `externals` in `block-metadata.json` ([docs](https://blockprotocol.org/docs/spec/core-specification#defining-blocks)).
 
 These are libraries the blocks expects the embedding application to supply it.
 For example, a block may rely on React, but assume that the embedding application will provide it, to save loading it multiple times on a page.

--- a/packages/react-block-loader/src/web-component-block.tsx
+++ b/packages/react-block-loader/src/web-component-block.tsx
@@ -42,7 +42,10 @@ const generateCustomElementName = (blockName: BlockNameWithNamespace) => {
 
 /**
  * The Block Protocol functions in event form
- * @see https://blockprotocol.org/spec/block-types#entity-functions
+ *
+ * Replaced by graph service in Þ 0.2
+ * @see https://blockprotocol.org/docs/spec/graph-service-specification
+ * @todo refactor this package
  */
 type BpEventData<
   Operation extends keyof BlockProtocolFunctions = keyof BlockProtocolFunctions,


### PR DESCRIPTION
This PR complements https://github.com/hashintel/hash/pull/722. It addresses [Asana task](https://app.asana.com/0/1202482456346912/1202440221033864) (internal).