### PR TITLE
Put service-meta json schema online

### DIFF
--- a/site/next.config.js
+++ b/site/next.config.js
@@ -69,6 +69,10 @@ const nextConfig = {
         source: "/types/services/:servicename/:typename",
         destination: "/types/services/:servicename/:typename.json",
       },
+      {
+        source: "/types/core/:typename",
+        destination: "/types/core/:typename.json",
+      },
     ];
   },
 };

--- a/site/public/types/core/service-meta.json
+++ b/site/public/types/core/service-meta.json
@@ -1,0 +1,59 @@
+{
+  "$id": "https://blockprotocol.org/types/core/service-meta",
+  "type": "object",
+  "properties": {
+    "description": {
+      "type": "string",
+      "description": "A short description of the functionality the service provides and/or the problems it aims to solve. Markdown is permitted."
+    },
+    "name": {
+      "type": "string",
+      "description": "A unique name for the service, consisting of lowercase letters, numbers, and hyphens only.",
+      "pattern": "^[-a-z0-9]$"
+    },
+    "messages": {
+      "type": "array",
+      "description": "The messages that may be exchanged by blocks and embedding applications as part of the service",
+      "items": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "messageName": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string",
+            "enum": ["block", "embedder"]
+          },
+          "data": {
+            "type": "object"
+          },
+          "errorCodes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "sentOnInitialization": {
+              "type": "boolean"
+            },
+            "respondedToBy": {
+              "type": "string"
+            }
+          },
+          "required": ["description", "messageName", "source", "data"]
+        }
+      },
+      "version": {
+        "type": "string",
+        "description": "The semantic version of this service specification"
+      },
+      "coreVersion": {
+        "type": "string",
+        "description": "The version (or version range) of the core specification this is compatible with"
+      }
+    },
+    "required": ["description", "messages", "name", "version"]
+  }
+}

--- a/site/src/_pages/docs/3_spec/1_core-specification.mdx
+++ b/site/src/_pages/docs/3_spec/1_core-specification.mdx
@@ -423,7 +423,7 @@ An entry in `messages` MAY specify:
 
 ```json
 {
-  "$id": "https://blockprotocol.org/spec/service-meta",
+  "$id": "https://blockprotocol.org/types/core/service-meta",
   "type": "object",
   "properties": {
     "description": {
@@ -441,26 +441,44 @@ An entry in `messages` MAY specify:
       "items": {
         "type": "object",
         "properties": {
-          "description": { "type": "string" },
-          "messageName": { "type": "string" },
-          "source": { "type": "string", "enum": ["block", "embedder"] },
-          "data": { "type": "object" },
-          "errorCodes": { "type": "array", "items": { "type": "string" },
-          "sentOnInitialization": { "type": "boolean" },
-          "respondedToBy": { "type": "string" }
-        },
-        "required": ["description", "messageName", "source", "data"]
+          "description": {
+            "type": "string"
+          },
+          "messageName": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string",
+            "enum": ["block", "embedder"]
+          },
+          "data": {
+            "type": "object"
+          },
+          "errorCodes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "sentOnInitialization": {
+              "type": "boolean"
+            },
+            "respondedToBy": {
+              "type": "string"
+            }
+          },
+          "required": ["description", "messageName", "source", "data"]
+        }
+      },
+      "version": {
+        "type": "string",
+        "description": "The semantic version of this service specification"
+      },
+      "coreVersion": {
+        "type": "string",
+        "description": "The version (or version range) of the core specification this is compatible with"
       }
     },
-    "version": {
-      "type": "string",
-      "description": "The semantic version of this service specification"
-    },
-    "coreVersion": {
-      "type": "string",
-      "description": "The version (or version range) of the core specification this is compatible with"
-    }
-   },
-   "required": ["description", "messages", "name", "version"]
+    "required": ["description", "messages", "name", "version"]
+  }
 }
 ```


### PR DESCRIPTION
As flagged [in this comment](https://github.com/blockprotocol/blockprotocol/pull/411#issuecomment-1171142877), we have a JSON schema in the Core spec which has an `$id` of an URL at which it does not exist.

This PR fixes that by making it available at the URL it claims to reside at.

**Known issue:** we duplicate this (and other JSON schema files) in both the spec and the public folder. We should just refer to them in the URL by spec, and have an MDX component that fetches them from the folder and renders them in a code block. ([internal task](https://app.asana.com/0/1201095311341924/1202540795202627/f)).

**How to test:** visit `https://deploymentUrl/types/core/service-meta`