### PR TITLE
Bump graph

### DIFF
--- a/packages/@blockprotocol/graph/package.json
+++ b/packages/@blockprotocol/graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockprotocol/graph",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Implementation of the Block Protocol Graph service specification for blocks and embedding applications",
   "keywords": [
     "blockprotocol",


### PR DESCRIPTION
Looks like `@blockprotocol/graph` was bumped whilst https://github.com/blockprotocol/blockprotocol/pull/405 was being written, so it needs bumping again in order to publish the changes. 