### PR TITLE
Bump block template

### DIFF
--- a/packages/block-template/package.json
+++ b/packages/block-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "block-template",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "Block Protocol block templates",
   "keywords": [
     "blockprotocol",


### PR DESCRIPTION
I forgot to bump the version of `block-template` in https://github.com/blockprotocol/blockprotocol/pull/405 which is necessary to make `create-block-app` work. This PR fixes that