### PR TITLE
Display non v0.2 blocks in Block Hub

### DIFF
--- a/site/src/components/pages/hub/block-data-container.tsx
+++ b/site/src/components/pages/hub/block-data-container.tsx
@@ -36,13 +36,20 @@ type BlockDataContainerProps = {
   schema: BlockSchema;
   sandboxBaseUrl: string;
   exampleGraph: BlockExampleGraph | null;
+  isUnsupportedBlock?: boolean;
 };
 
 const validator = new Validator();
 
 export const BlockDataContainer: VoidFunctionComponent<
   BlockDataContainerProps
-> = ({ metadata, schema, exampleGraph, sandboxBaseUrl }) => {
+> = ({
+  metadata,
+  schema,
+  exampleGraph,
+  sandboxBaseUrl,
+  isUnsupportedBlock,
+}) => {
   const [blockDataTab, setBlockDataTab] = useState(0);
   const [blockVariantsTab, setBlockVariantsTab] = useState(0);
   const [blockModalOpen, setBlockModalOpen] = useState(false);
@@ -230,11 +237,19 @@ export const BlockDataContainer: VoidFunctionComponent<
                   position: "relative",
                 }}
               >
-                <SandboxedBlockDemo
-                  metadata={metadata}
-                  props={props}
-                  sandboxBaseUrl={sandboxBaseUrl}
-                />
+                {isUnsupportedBlock ? (
+                  <>
+                    This block was written for an earlier version of the Block
+                    Protocol specification and cannot currently be displayed in
+                    the Hub.
+                  </>
+                ) : (
+                  <SandboxedBlockDemo
+                    metadata={metadata}
+                    props={props}
+                    sandboxBaseUrl={sandboxBaseUrl}
+                  />
+                )}
               </Box>
             </Box>
           </Box>

--- a/site/src/lib/blocks.ts
+++ b/site/src/lib/blocks.ts
@@ -165,7 +165,8 @@ export const excludeHiddenBlocks = (
   );
 };
 
-export const isUnsupportedBlock = ({ protocol }: ExpandedBlockMetadata) => {
+/** Blocks that aren't compliant with BP V0.2  */
+export const isNonV0_2Block = ({ protocol }: ExpandedBlockMetadata) => {
   return !(parseFloat(protocol) >= 0.2);
 };
 

--- a/site/src/lib/blocks.ts
+++ b/site/src/lib/blocks.ts
@@ -161,9 +161,12 @@ export const excludeHiddenBlocks = (
   blocks: ExpandedBlockMetadata[],
 ): ExpandedBlockMetadata[] => {
   return blocks.filter(
-    ({ packagePath, protocol }) =>
-      !blocksToHide.includes(packagePath) && parseFloat(protocol) >= 0.2,
+    ({ packagePath }) => !blocksToHide.includes(packagePath),
   );
+};
+
+export const isUnsupportedBlock = ({ protocol }: ExpandedBlockMetadata) => {
+  return !(parseFloat(protocol) >= 0.2);
 };
 
 export const readBlockDataFromDisk = async ({

--- a/site/src/pages/[shortname]/blocks/[block-slug].page.tsx
+++ b/site/src/pages/[shortname]/blocks/[block-slug].page.tsx
@@ -28,6 +28,7 @@ import {
 import {
   excludeHiddenBlocks,
   ExpandedBlockMetadata as BlockMetadata,
+  isUnsupportedBlock,
   readBlockDataFromDisk,
   readBlockReadmeFromDisk,
   readBlocksFromDisk,
@@ -354,6 +355,7 @@ const BlockPage: NextPage<BlockPageProps> = ({
             schema={schema}
             sandboxBaseUrl={sandboxBaseUrl}
             exampleGraph={exampleGraph}
+            isUnsupportedBlock={isUnsupportedBlock(blockMetadata)}
           />
         </Box>
 

--- a/site/src/pages/[shortname]/blocks/[block-slug].page.tsx
+++ b/site/src/pages/[shortname]/blocks/[block-slug].page.tsx
@@ -28,7 +28,7 @@ import {
 import {
   excludeHiddenBlocks,
   ExpandedBlockMetadata as BlockMetadata,
-  isUnsupportedBlock,
+  isNonV0_2Block,
   readBlockDataFromDisk,
   readBlockReadmeFromDisk,
   readBlocksFromDisk,
@@ -107,6 +107,7 @@ type BlockPageProps = {
   schema: BlockSchema;
   sliderItems: BlockMetadata[];
   exampleGraph: BlockExampleGraph | null; // todo fix typing
+  isUnsupportedBlock: boolean;
 };
 
 type BlockPageQueryParams = {
@@ -211,6 +212,7 @@ export const getStaticProps: GetStaticProps<
       sandboxBaseUrl: generateSandboxBaseUrl(),
       schema,
       exampleGraph,
+      isUnsupportedBlock: isNonV0_2Block(blockMetadata),
     },
     revalidate: 1800,
   };
@@ -223,6 +225,7 @@ const BlockPage: NextPage<BlockPageProps> = ({
   schema,
   sliderItems,
   exampleGraph,
+  isUnsupportedBlock,
 }) => {
   const { query } = useRouter();
   const { shortname } = parseQueryParams(query || {});
@@ -355,7 +358,7 @@ const BlockPage: NextPage<BlockPageProps> = ({
             schema={schema}
             sandboxBaseUrl={sandboxBaseUrl}
             exampleGraph={exampleGraph}
-            isUnsupportedBlock={isUnsupportedBlock(blockMetadata)}
+            isUnsupportedBlock={isUnsupportedBlock}
           />
         </Box>
 


### PR DESCRIPTION
This PR displays non v0.2 blocks, which where hidden in https://github.com/blockprotocol/blockprotocol/pull/337, in the BP site. 