### PR TITLE
Fix Algolia indexing

### DIFF
--- a/site/src/lib/sitemap.ts
+++ b/site/src/lib/sitemap.ts
@@ -9,6 +9,7 @@ export type SiteMapPageSection = {
 export type SiteMapPage = {
   title: string;
   href: string;
+  markdownFilePath?: string;
   subPages: SiteMapPage[];
   sections: SiteMapPageSection[];
 };

--- a/site/src/util/mdx-utils.tsx
+++ b/site/src/util/mdx-utils.tsx
@@ -170,9 +170,8 @@ export const getPage = (params: {
 }): SiteMapPage => {
   const { pathToDirectory, fileName } = params;
 
-  const source = fs.readFileSync(
-    path.join(process.cwd(), `src/_pages/${pathToDirectory}/${fileName}`),
-  );
+  const markdownFilePath = `src/_pages/${pathToDirectory}/${fileName}`;
+  const source = fs.readFileSync(path.join(process.cwd(), markdownFilePath));
 
   const { content } = matter(source);
 
@@ -191,6 +190,7 @@ export const getPage = (params: {
     href: `/${pathToDirectory.replace(/\d+_/g, "")}${
       name === "index" ? "" : `/${slugify(name, { lower: true })}`
     }`,
+    markdownFilePath,
     sections: headings.reduce<SiteMapPageSection[]>((prev, currentHeading) => {
       const newSection = {
         title: getVisibleText(currentHeading),


### PR DESCRIPTION
## Context

- [GitHub Action](https://github.com/blockprotocol/blockprotocol/actions/workflows/algolia-upload-index.yml) (recent runs are broken)
- [Slack thread](https://hashintel.slack.com/archives/C02LG39FJAU/p1656959701248679) (internal)
- [Asana task](https://app.asana.com/0/1202482456346915/1202552815181141/f) (internal)

Historically, Þ markdowns have two distinct categories: `docs` and `spec`. Our `sync-algolia-index.ts` script used to process them separately, which added some complexity to the logic. As the structure of the docs were changing, the script received several incremental patches and became quite hard to follow. It broke after https://github.com/blockprotocol/blockprotocol/pull/410 got merged.

This PR simplifies `sync-algolia-index.ts` thus fixing the bug that was causing a crash in GitHub Actions. The updated script relies on the new optional `markdownFilePath` property in `SiteMapPage` type. This value helps track the origin of each markdown page and thus makes it easier to upload their content to Algolia. `markdownFilePath` also enables _Edit this page_ button if we want to add one.

Algolia index assigns `spec` and `docs` types to each indexed page for backwards compatibility. We can revise this later.

## To test the changes locally

1. Set dummy Algolia credentials `export ALGOLIA_PROJECT=aaa; export ALGOLIA_WRITE_KEY=bbb;` in your terminal

1. Open `site/scripts/sync-algolia-index.ts`

    1. Comment out `await index.browseObjects({...})` (this line won't work with dummy Algolia credentials)

    1. Add something like this around like 96:
       `console.log( indexObjects.map((o) => [o.type, o.slug, ...o.content.split("\n", 1)]) )`

1. `yarn workspace @blockprotocol/site exe scripts/generate-sitemap.ts`

1. `yarn workspace @blockprotocol/site exe scripts/sync-algolia-index.ts`

1. Observe the following output:

    ```
    [
      [ 'docs', '/docs', '# Introduction' ],
      [ 'docs', '/docs/developing-blocks', '# Developing Blocks' ],
      [ 'docs', '/docs/embedding-blocks', '# Embedding Blocks' ],
      [ 'spec', '/docs/spec', '# Specification' ],
      [ 'spec', '/docs/spec/core-specification', '# Core Specification 0.2' ],
      [ 'spec', '/docs/spec/graph-service-specification', '# Graph Service Specification 0.2' ],
      [ 'spec', '/docs/spec/rfcs_and_roadmap', '# RFCs & Roadmap' ],
      [ 'docs', '/docs/faq', '# FAQs' ]
    ]
    ```