### PR TITLE
Fix a typo in action version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: bahmutov/npm-install@v1
 
       - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@1.3.0
+        uses: changesets/action@v1.3.0
         with:
           publish: yarn changesets publish
         env:


### PR DESCRIPTION
Follows #420

Fixes https://github.com/blockprotocol/blockprotocol/runs/7235813803?check_suite_focus=true#step:1:35
```
Error: Unable to resolve action `changesets/action@1.3.0`, unable to find version `1.3.0`
```

`v` prefix should help match repo tags at https://github.com/changesets/action/tags. I'm using a pinned version because of:

https://github.com/blockprotocol/blockprotocol/blob/9c38dcd0f8c2f843bd7276bd42e1fea9833b4a2f/.changeset/config.json#L13-L15