### PR TITLE
Rename `warm-up-vercel.yml`

### DIFF
--- a/.github/workflows/site-deployment.yml
+++ b/.github/workflows/site-deployment.yml
@@ -1,8 +1,4 @@
-## Vercel uses AWS Lambda. When we call getStaticProps in fallback mode or getServerSideProps,
-## a cold Lambda function may take 5-15 seconds to execute. This pipeline warms up Lambda
-## containers for new deployments and keeps them up by fetching affected URLs every 10 minutes.
-
-name: Warm up Vercel
+name: Site deployment
 
 on:
   deployment_status:
@@ -10,8 +6,11 @@ on:
     - cron: "*/10 * * * *"
 
 jobs:
-  fetch:
-    name: "Fetch"
+  warm_up_vercel:
+    ## Vercel uses AWS Lambda. When we call getStaticProps in fallback mode or getServerSideProps,
+    ## a cold Lambda function may take 5-15 seconds to execute. This pipeline warms up Lambda
+    ## containers for new deployments and keeps them up by fetching affected URLs every 10 minutes.
+    name: Warm up Vercel
     if: github.event_name == 'schedule' || github.event.deployment_status.state == 'success'
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
This mini-PR is extracted from #434. It replaces file creation and deletion with file renaming in git history:

<img width="390" alt="Screenshot 2022-07-13 at 19 37 48" src="https://user-images.githubusercontent.com/608862/178806913-440e8623-c1ef-4018-a278-d5613df9fa59.png">

↓

<img width="661" alt="Screenshot 2022-07-13 at 19 38 09" src="https://user-images.githubusercontent.com/608862/178806897-fc289bb9-93ee-4839-8616-d676aac18c23.png">

With this PR, I expect ‘Warm up Vercel’ to disappear in https://github.com/blockprotocol/blockprotocol/actions instead of being duplicated. This trick somehow worked when I [renamed](https://github.com/blockprotocol/blockprotocol/pull/431) `check-codebase.yml` to `ci.yml`.