### PR TITLE
Introduce local `warm-up-repo` action to reliably skip Playwright installs

### DIFF
--- a/.github/actions/warm-up-repo/action.yml
+++ b/.github/actions/warm-up-repo/action.yml
@@ -1,0 +1,25 @@
+name: Warm-up repo
+description: Prepares Node and Yarn dependencies
+
+inputs:
+  playwright-deps:
+    default: ""
+    description: "List of browsers separated by space, e.g. 'chrome firefox'"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16 ## aligned with Node version on Vercel
+        cache: yarn
+
+    - run: yarn install
+      shell: bash
+      env:
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: ${{ inputs.playwright-deps == '' }}
+
+    - run: yarn playwright install-deps ${{ inputs.playwright-deps }}
+      if: ${{ inputs.playwright-deps != '' }}
+      shell: bash

--- a/.github/workflows/algolia-upload-index.yml
+++ b/.github/workflows/algolia-upload-index.yml
@@ -13,13 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: yarn
-
-      - run: yarn install
+      - uses: ./.github/actions/warm-up-repo
 
       - name: Sync Algolia Index
         run: yarn workspace @blockprotocol/site exe scripts/sync-algolia-index.ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 on: pull_request
 
-env:
-  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
-
 jobs:
   linting:
     name: Linting
@@ -11,12 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: yarn
-
-      - run: yarn install
+      - uses: ./.github/actions/warm-up-repo
 
       - name: Run yarn lint:dependency-version-consistency
         if: ${{ success() || failure() }}
@@ -137,17 +129,10 @@ jobs:
       BLOCK_DIR_PATH: ~/test-block
 
     steps:
-      - uses: actions/checkout@v3
-
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: yarn
+      - uses: ./.github/actions/warm-up-repo
 
       - name: Downgrade global NPM version
         run: npm install --global npm@8.4.1 ## https://github.com/blockprotocol/blockprotocol/pull/281
-
-      - run: yarn install
 
       - name: Run local registry
         run: |
@@ -181,8 +166,6 @@ jobs:
   site-integration-tests:
     name: "Site integration tests"
     runs-on: ubuntu-latest
-    env:
-      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: false
     steps:
       - uses: actions/checkout@v3
 
@@ -194,12 +177,9 @@ jobs:
             ${{ runner.os }}-site-next-cache-${{ hashFiles('yarn.lock') }}-
             ${{ runner.os }}-site-next-cache
 
-      - uses: actions/setup-node@v3
+      - uses: ./.github/actions/warm-up-repo
         with:
-          node-version: 16
-          cache: yarn
-
-      - run: yarn install
+          playwright-deps: chrome firefox safari
 
       - name: Create temp files and folders
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
 
       - uses: ./.github/actions/warm-up-repo
         with:
-          playwright-deps: chrome firefox safari
+          playwright-deps: chrome firefox webkit
 
       - name: Create temp files and folders
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,8 @@ jobs:
       BLOCK_DIR_PATH: ~/test-block
 
     steps:
+      - uses: actions/checkout@v3
+
       - uses: ./.github/actions/warm-up-repo
 
       - name: Downgrade global NPM version

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -25,12 +25,7 @@ jobs:
 
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: yarn
-
-      - run: yarn install
+      - uses: ./.github/actions/warm-up-repo
 
       - run: yarn exe scripts/packages/publish-to-npmjscom.ts
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,12 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: yarn
-
-      - run: yarn install
+      - uses: ./.github/actions/warm-up-repo
 
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1.3.0

--- a/.github/workflows/site-deployment.yml
+++ b/.github/workflows/site-deployment.yml
@@ -41,6 +41,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: ./.github/actions/warm-up-repo
+        with:
+          playwright-deps: chrome
 
       - run: yarn playwright install-deps chrome
 

--- a/.github/workflows/site-deployment.yml
+++ b/.github/workflows/site-deployment.yml
@@ -6,9 +6,6 @@ on:
     - cron: "*/10 * * * *" ## Every 10 minutes
     - cron: "0 4 * * *" ## Around 4am every night (UTC time)
 
-env:
-  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
-
 jobs:
   warm_up_vercel:
     ## Vercel uses AWS Lambda. When we call getStaticProps in fallback mode or getServerSideProps,
@@ -40,17 +37,10 @@ jobs:
     needs: [warm_up_vercel]
     if: github.event.deployment_status.state == 'success' || github.event.schedule == '0 4 * * *'
     runs-on: ubuntu-20.04
-    env:
-      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: false
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 16
-          cache: yarn
-
-      - run: yarn install
+      - uses: ./.github/actions/warm-up-repo
 
       - run: yarn playwright install-deps chrome
 


### PR DESCRIPTION
The goal of this PR is to optimise `yarn install` performance in jobs that don’t involve Playwright (which is the majority of them). `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD` is now implicitly  set to `false` by default in all workflows. This is done via a newly introduced GitHub action. The new action also makes sure that workflows are aligned on node version and yarn cache.

Inspired by: https://github.com/hashintel/hash/tree/main/.github/actions/warm-up-repo