### PR TITLE
Fix block sandbox URL in preview deployments

### DIFF
--- a/site/src/lib/config.ts
+++ b/site/src/lib/config.ts
@@ -9,3 +9,7 @@ export const FRONTEND_DOMAIN = new URL(FRONTEND_URL).hostname;
 export const isUsingHttps = new URL(FRONTEND_URL).protocol === "https";
 
 export const isProduction = process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
+
+export const isFork =
+  process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_OWNER &&
+  process.env.NEXT_PUBLIC_VERCEL_GIT_REPO_OWNER !== "blockprotocol";

--- a/site/src/pages/[shortname]/blocks/[block-slug].page.tsx
+++ b/site/src/pages/[shortname]/blocks/[block-slug].page.tsx
@@ -13,6 +13,7 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import { MDXRemote } from "next-mdx-remote";
 import { serialize } from "next-mdx-remote/serialize";
+import crypto from "node:crypto";
 import React, { VoidFunctionComponent } from "react";
 import remarkGfm from "remark-gfm";
 
@@ -32,7 +33,7 @@ import {
   readBlockReadmeFromDisk,
   readBlocksFromDisk,
 } from "../../../lib/blocks";
-import { isProduction } from "../../../lib/config";
+import { isFork, isProduction } from "../../../lib/config";
 
 // Exclude <FooBar />, but keep <h1 />, <ul />, etc.
 const markdownComponents = Object.fromEntries(
@@ -79,12 +80,26 @@ const generateSandboxBaseUrl = (): string => {
     return "";
   }
 
-  // @see https://vercel.com/docs/concepts/deployments/automatic-urls
+  // @see https://vercel.com/docs/concepts/deployments/generated-urls
+  // @see https://vercel.com/docs/concepts/deployments/generated-urls#url-components
   const branchSlug = branch
     .toLowerCase()
     .replace(/\./g, "")
     .replace(/[^\w-]+/g, "-");
-  const branchSubdomain = `blockprotocol-git-${branchSlug}`.slice(0, 63);
+
+  const projectName = "blockprotocol";
+  const prefix = isFork ? "git-fork-" : "git-";
+  const rawBranchSubdomain = `${projectName}-${prefix}-${branchSlug}`;
+
+  const branchSubdomain =
+    rawBranchSubdomain.length > 63
+      ? `${rawBranchSubdomain.slice(0, 56)}-${crypto
+          .createHash("sha256")
+          .update(prefix + branch + projectName)
+          .digest("hex")
+          .slice(0, 6)}`
+      : rawBranchSubdomain;
+
   return `https://${branchSubdomain}.stage.hash.ai`;
 };
 

--- a/site/src/pages/[shortname]/blocks/[block-slug].page.tsx
+++ b/site/src/pages/[shortname]/blocks/[block-slug].page.tsx
@@ -89,7 +89,7 @@ const generateSandboxBaseUrl = (): string => {
 
   const projectName = "blockprotocol";
   const prefix = isFork ? "git-fork-" : "git-";
-  const rawBranchSubdomain = `${projectName}-${prefix}-${branchSlug}`;
+  const rawBranchSubdomain = `${projectName}-${prefix}${branchSlug}`;
 
   const branchSubdomain =
     rawBranchSubdomain.length > 63

--- a/site/src/pages/[shortname]/blocks/[block-slug].page.tsx
+++ b/site/src/pages/[shortname]/blocks/[block-slug].page.tsx
@@ -84,11 +84,8 @@ const generateSandboxBaseUrl = (): string => {
     .toLowerCase()
     .replace(/\./g, "")
     .replace(/[^\w-]+/g, "-");
-  const branchPrefix = `blockprotocol-git-${slugifiedBranch}-hashintel`.slice(
-    0,
-    64,
-  );
-  return `https://${branchPrefix}.vercel.app`;
+  const branchPrefix = `blockprotocol-git-${slugifiedBranch}`.slice(0, 64);
+  return `https://${branchPrefix}.stage.hash.ai`;
 };
 
 const Bullet: VoidFunctionComponent = () => {

--- a/site/src/pages/[shortname]/blocks/[block-slug].page.tsx
+++ b/site/src/pages/[shortname]/blocks/[block-slug].page.tsx
@@ -80,12 +80,12 @@ const generateSandboxBaseUrl = (): string => {
   }
 
   // @see https://vercel.com/docs/concepts/deployments/automatic-urls
-  const slugifiedBranch = branch
+  const branchSlug = branch
     .toLowerCase()
     .replace(/\./g, "")
     .replace(/[^\w-]+/g, "-");
-  const branchPrefix = `blockprotocol-git-${slugifiedBranch}`.slice(0, 64);
-  return `https://${branchPrefix}.stage.hash.ai`;
+  const branchSubdomain = `blockprotocol-git-${branchSlug}`.slice(0, 63);
+  return `https://${branchSubdomain}.stage.hash.ai`;
 };
 
 const Bullet: VoidFunctionComponent = () => {


### PR DESCRIPTION
We changed Preview Deployment Suffix from `.vercel.app` to `.stage.hash.ai`, which [broke sandbox in preview releases](https://blockprotocol-1jo2v6kgs.stage.hash.ai/@alfie/blocks/github-pr-overview). This PR updates how we generate sandbox URLs, which fixed the issue.

- [Asana task](https://app.asana.com/0/1202542409311090/1202621858687201/f) (internal)
- [Slack thread](https://hashintel.slack.com/archives/C02LG39FJAU/p1658172223332219) (internal)
- [Vercel docs](https://vercel.com/docs/concepts/deployments/generated-urls#url-components) on URL format
- [Demo](https://blockprotocol-8udk0nx99.stage.hash.ai/@hash/blocks/code)  
  sandbox host = `blockprotocol-git-ak-fix-block-sandbox-url-in-preview-de-825d26.stage.hash.ai` (note the hash)
  
There is still a small chance that the new logic will be broken for short branch slugs (less than 64 characters). It is impossible to test that scenario now, so I will submit a follow-up PR if needed.

@teenoh and I plan to add Playwright tests this week, so this problem will be spotted quickly if it re-occurs.