### PR TITLE
Fix Algolia workflow

### DIFF
--- a/.github/workflows/algolia-upload-index.yml
+++ b/.github/workflows/algolia-upload-index.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+      - uses: actions/checkout@v3
+
       - uses: ./.github/actions/warm-up-repo
 
       - name: Sync Algolia Index


### PR DESCRIPTION
Caused by #440. Example error: https://github.com/blockprotocol/blockprotocol/runs/7408512664?check_suite_focus=true#step:2:1

```
Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/blockprotocol/blockprotocol/.github/actions/warm-up-repo'.
Did you forget to run actions/checkout before running your local action?
```

I haven’t spotted this issue in the original PR because this workflow only runs for `main`.