### PR TITLE
Add integration tests for Dashboard and API key generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,7 @@ jobs:
         run: yarn nyc report --reporter=lcovonly --reporter=text
 
       - uses: codecov/codecov-action@v3
+        if: ${{ success() || failure() }}
         name: Upload coverage to https://app.codecov.io/gh/blockprotocol/blockprotocol
         with:
           fail_ci_if_error: true

--- a/patches/playwright-core+1.24.0.patch
+++ b/patches/playwright-core+1.24.0.patch
@@ -1,12 +1,14 @@
 diff --git a/node_modules/playwright-core/lib/server/fetch.js b/node_modules/playwright-core/lib/server/fetch.js
-index 13cd767..10178c0 100644
+index 13cd767..f9d42d2 100644
 --- a/node_modules/playwright-core/lib/server/fetch.js
 +++ b/node_modules/playwright-core/lib/server/fetch.js
-@@ -187,7 +187,7 @@ class APIRequestContext extends _instrumentation.SdkObject {
+@@ -187,7 +187,9 @@ class APIRequestContext extends _instrumentation.SdkObject {
        const cookie = parseCookie(header);
        if (!cookie) continue; // https://datatracker.ietf.org/doc/html/rfc6265#section-5.2.3
  
 -      if (!cookie.domain) cookie.domain = url.hostname;else (0, _utils.assert)(cookie.domain.startsWith('.'));
++      // This hack allows setting cookies in site/tests/shared/nav.ts → login
++      // To be removed in https://app.asana.com/0/1202542409311090/1202652337622563/f
 +      if (!cookie.domain) cookie.domain = url.hostname;else cookie.domain = cookie.domain.replace(/^./, '');
        if (!(0, _cookieStore.domainMatches)(url.hostname, cookie.domain)) continue; // https://datatracker.ietf.org/doc/html/rfc6265#section-5.2.4
  

--- a/patches/playwright-core+1.24.0.patch
+++ b/patches/playwright-core+1.24.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/playwright-core/lib/server/fetch.js b/node_modules/playwright-core/lib/server/fetch.js
+index 13cd767..10178c0 100644
+--- a/node_modules/playwright-core/lib/server/fetch.js
++++ b/node_modules/playwright-core/lib/server/fetch.js
+@@ -187,7 +187,7 @@ class APIRequestContext extends _instrumentation.SdkObject {
+       const cookie = parseCookie(header);
+       if (!cookie) continue; // https://datatracker.ietf.org/doc/html/rfc6265#section-5.2.3
+ 
+-      if (!cookie.domain) cookie.domain = url.hostname;else (0, _utils.assert)(cookie.domain.startsWith('.'));
++      if (!cookie.domain) cookie.domain = url.hostname;else cookie.domain = cookie.domain.replace(/^./, '');
+       if (!(0, _cookieStore.domainMatches)(url.hostname, cookie.domain)) continue; // https://datatracker.ietf.org/doc/html/rfc6265#section-5.2.4
+ 
+       if (!cookie.path || !cookie.path.startsWith('/')) cookie.path = defaultPath;

--- a/site/package.json
+++ b/site/package.json
@@ -91,7 +91,7 @@
   },
   "devDependencies": {
     "@babel/runtime": "^7.17.9",
-    "@playwright/test": "1.23.3",
+    "@playwright/test": "^1.24.0",
     "@types/busboy": "^1.3.0",
     "@types/cookie-signature": "^1.0.4",
     "@types/cors": "^2.8.12",
@@ -118,7 +118,7 @@
     "envalid": "7.2.2",
     "execa": "^5.1.1",
     "micromatch": "^4.0.4",
-    "playwright": "^1.23.3",
+    "playwright": "^1.24.0",
     "playwright-test-coverage": "^1.1.0",
     "rimraf": "^3.0.2",
     "ts-node": "10.8.0",

--- a/site/playwright.config.ts
+++ b/site/playwright.config.ts
@@ -17,7 +17,11 @@ const config: PlaywrightTestConfig = {
     {
       name: "integration-chrome",
       ...integrationTestsBaseConfig,
-      use: { ...devices["Desktop Chrome"] },
+      use: {
+        ...devices["Desktop Chrome"],
+        // https://github.com/microsoft/playwright/issues/13037#issuecomment-1184698467
+        contextOptions: { permissions: ["clipboard-read", "clipboard-write"] },
+      },
     },
     {
       name: "integration-firefox",
@@ -37,7 +41,11 @@ const config: PlaywrightTestConfig = {
     {
       name: "integration-pixel",
       ...integrationTestsBaseConfig,
-      use: { ...devices["Pixel 5"] },
+      use: {
+        ...devices["Pixel 5"],
+        // https://github.com/microsoft/playwright/issues/13037#issuecomment-1184698467
+        contextOptions: { permissions: ["clipboard-read", "clipboard-write"] },
+      },
     },
     {
       name: "smoke",

--- a/site/src/components/pages/dashboard/api-key-renderer.tsx
+++ b/site/src/components/pages/dashboard/api-key-renderer.tsx
@@ -75,6 +75,7 @@ export const ApiKeyRenderer: FunctionComponent<ApiKeyRendererProps> = ({
         }}
       >
         <Box
+          data-testid="api-key-value"
           sx={{
             overflowWrap: "anywhere",
             textAlign: "left",

--- a/site/tests/integration/api-key-generation.test.ts
+++ b/site/tests/integration/api-key-generation.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "playwright-test-coverage";
+
+import { resetDb } from "../shared/fixtures";
+import { login } from "../shared/nav";
+
+test("API key generation UI works", async ({ page, browserName }) => {
+  await resetDb();
+
+  await page.goto("/");
+
+  await login({ page });
+
+  await page.goto("/dashboard");
+
+  const tableWithKeys = page.locator("text=Public ID");
+  const keyNameInput = page.locator('[placeholder="Key Name"]');
+
+  await page.locator('a:has-text("Generate your API key")').click();
+  await expect(page).toHaveURL("/settings/api-keys");
+
+  await expect(
+    page.locator("text=These keys allow you to access the block protocol"),
+  ).toBeVisible();
+  await expect(page.locator("text=Learn More").first()).toHaveAttribute(
+    "href",
+    "/docs/embedding-blocks#discovering-blocks",
+  );
+  await expect(tableWithKeys).not.toBeVisible();
+
+  await page.locator("text=Create new key").click();
+
+  await keyNameInput.click();
+  await keyNameInput.press("Enter");
+
+  await keyNameInput.fill("oops");
+  await page.locator("text=Cancel").click();
+
+  await page.locator("text=Create new key").click();
+  await expect(keyNameInput).toHaveValue("");
+
+  await keyNameInput.click();
+  await keyNameInput.fill("my first key");
+  await page.locator("text=Create Key").click();
+
+  const apiKeyValue =
+    (await page.locator('[data-testid="api-key-value"]').textContent()) ?? "";
+
+  await page.locator("text=Copy to Clipboard").click();
+  await expect(page.locator("text=✓ Copied")).toBeVisible();
+  await page.locator("text=Go back").click();
+
+  expect(apiKeyValue).toMatch(
+    /^b10ck5\.\w{32}\.\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/,
+  );
+  const publicKeyId = apiKeyValue?.match(/\w{32}/)?.[0] ?? "";
+
+  // https://github.com/microsoft/playwright/issues/13037
+  if (browserName === "chromium") {
+    const copiedApiKey = await page.evaluate(() =>
+      navigator.clipboard.readText(),
+    );
+    expect(copiedApiKey).toEqual(apiKeyValue);
+  }
+
+  await expect(tableWithKeys).toBeVisible();
+  await expect(page.locator("text=my first key")).toBeVisible();
+  await expect(page.locator(`text=${publicKeyId}`)).toBeVisible();
+  await page.locator("text=Regenerate API Key").click();
+
+  await expect(page.locator("text=Regenerate my first key")).toBeVisible();
+  await expect(
+    page.locator("text=Regenerating the my first key key will invalidate it."),
+  ).toBeVisible();
+
+  await page.locator("text=Cancel").click();
+  await expect(page.locator("text=Regenerate my first key")).not.toBeVisible();
+
+  await page.locator("text=Regenerate API Key").click();
+  await expect(page.locator("text=Regenerate my first key")).toBeVisible();
+
+  await page.locator("text=Regenerate key").click();
+
+  const apiKeyValue2 =
+    (await page.locator('[data-testid="api-key-value"]').textContent()) ?? "";
+  const publicKeyId2 = apiKeyValue2?.match(/\w{32}/)?.[0] ?? "";
+
+  expect(apiKeyValue).not.toEqual(apiKeyValue2);
+  expect(publicKeyId).not.toEqual(publicKeyId2);
+
+  await page.locator("text=Copy to Clipboard").click();
+  await expect(page.locator("text=✓ Copied")).toBeVisible();
+
+  await expect(page.locator("text=my first key regenerated")).toBeVisible();
+  await page.locator("text=Go back").click();
+
+  await expect(page.locator(`text=${publicKeyId2}`)).toBeVisible();
+  await expect(page.locator(`text=${publicKeyId}`)).not.toBeVisible();
+});

--- a/site/tests/integration/api-key-generation.test.ts
+++ b/site/tests/integration/api-key-generation.test.ts
@@ -92,7 +92,6 @@ test("API key page should generate and show a key", async ({
 
   await page.locator("text=Copy to Clipboard").click();
   await expect(page.locator("text=✓ Copied")).toBeVisible();
-
   await expect(page.locator("text=my first key regenerated")).toBeVisible();
   await page.locator("text=Go back").click();
 

--- a/site/tests/integration/api-key-generation.test.ts
+++ b/site/tests/integration/api-key-generation.test.ts
@@ -49,7 +49,10 @@ test("API key page should generate and show a key", async ({
     (await page.locator('[data-testid="api-key-value"]').textContent()) ?? "";
 
   await page.locator("text=Copy to Clipboard").click();
-  await expect(page.locator("text=✓ Copied")).toBeVisible();
+  if (browserName !== "webkit") {
+    // ”Copy to Clipboard” does not work in Webkit on Linux
+    await expect(page.locator("text=✓ Copied")).toBeVisible();
+  }
   await page.locator("text=Go back").click();
 
   expect(apiKeyValue).toMatch(
@@ -91,7 +94,10 @@ test("API key page should generate and show a key", async ({
   expect(publicKeyId).not.toEqual(publicKeyId2);
 
   await page.locator("text=Copy to Clipboard").click();
-  await expect(page.locator("text=✓ Copied")).toBeVisible();
+  if (browserName !== "webkit") {
+    // ”Copy to Clipboard” does not work in Webkit on Linux
+    await expect(page.locator("text=✓ Copied")).toBeVisible();
+  }
   await expect(page.locator("text=my first key regenerated")).toBeVisible();
   await page.locator("text=Go back").click();
 

--- a/site/tests/integration/api-key-generation.test.ts
+++ b/site/tests/integration/api-key-generation.test.ts
@@ -3,7 +3,10 @@ import { expect, test } from "playwright-test-coverage";
 import { resetDb } from "../shared/fixtures";
 import { login } from "../shared/nav";
 
-test("API key generation UI works", async ({ page, browserName }) => {
+test("API key page should generate and show a key", async ({
+  page,
+  browserName,
+}) => {
   await resetDb();
 
   await page.goto("/");

--- a/site/tests/integration/dashboard.test.ts
+++ b/site/tests/integration/dashboard.test.ts
@@ -4,11 +4,12 @@ import { resetDb } from "../shared/fixtures";
 import { login } from "../shared/nav";
 
 test("dashboard page should not be accessible to guests", async ({ page }) => {
-  await page.goto("/dashboard");
-
-  await page.waitForNavigation({
-    url: (url) => url.pathname === "/login",
-  });
+  await Promise.all([
+    page.goto("/dashboard"),
+    page.waitForNavigation({
+      url: (url) => url.pathname === "/login",
+    }),
+  ]);
 });
 
 test("dashboard page should contain key elements", async ({ page }) => {

--- a/site/tests/integration/dashboard.test.ts
+++ b/site/tests/integration/dashboard.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "playwright-test-coverage";
+
+import { resetDb } from "../shared/fixtures";
+import { login } from "../shared/nav";
+
+test("dashboard page should not be accessible to guests", async ({ page }) => {
+  await page.goto("/dashboard");
+
+  await page.waitForNavigation({
+    url: (url) => url.pathname === "/login",
+  });
+});
+
+test("dashboard page should contain key elements", async ({ page }) => {
+  await resetDb();
+
+  await page.goto("/");
+  await login({ page });
+  await page.goto("/dashboard");
+
+  await expect(page.locator("text=Welcome Back, Alice!")).toBeVisible();
+
+  for (const [text, url] of [
+    [
+      "Read our quick start guide to building blocks",
+      "/docs/developing-blocks",
+    ],
+    ["Test out blocks in the playground", "/hub"],
+    ["Create a Schema", null],
+    ["Generate your API key", "/settings/api-keys"],
+    ["View your public profile", "/@alice"],
+  ] as const) {
+    const card = page.locator(
+      url ? `a:has-text('${text}')` : `button:has-text('${text}')`,
+    );
+    await expect(card).toBeVisible();
+    expect(await card.getAttribute("href")).toEqual(url);
+  }
+
+  await page.locator('[aria-label="settings-tabs"] >> text=API Keys').click();
+  await expect(page).toHaveURL("/settings/api-keys");
+
+  await page.locator('[aria-label="settings-tabs"] >> text=Dashboard').click();
+  await expect(page).toHaveURL("/dashboard");
+});

--- a/site/tests/integration/login-flow.test.ts
+++ b/site/tests/integration/login-flow.test.ts
@@ -205,9 +205,10 @@ test("Login page redirects logged in users to home page", async ({ page }) => {
   await login({ page });
   expect(page.url()).toMatch(/\/docs$/);
 
-  await page.goto("/login");
-
-  await page.waitForNavigation({
-    url: (url) => url.pathname === "/",
-  });
+  await Promise.all([
+    page.goto("/login"),
+    page.waitForNavigation({
+      url: (url) => url.pathname === "/",
+    }),
+  ]);
 });

--- a/site/tests/integration/login-flow.test.ts
+++ b/site/tests/integration/login-flow.test.ts
@@ -200,7 +200,15 @@ test.skip("login modal screen 2 correctly handles interactions", () => {
   // @todo write after finishing signup flow
 });
 
-test("Login page redirects logged in users to home page", async ({ page }) => {
+test("Login page redirects logged in users to home page", async ({
+  browserName,
+  page,
+}) => {
+  test.skip(
+    browserName === "webkit",
+    "https://app.asana.com/0/1202538466812818/1202652337622563/f",
+  );
+
   await page.goto("/docs");
   await login({ page });
   expect(page.url()).toMatch(/\/docs$/);

--- a/site/tests/integration/login-flow.test.ts
+++ b/site/tests/integration/login-flow.test.ts
@@ -39,9 +39,8 @@ test("login works for an existing user (via verification code)", async ({
 
   const accountDropdownButton = page.locator(accountDropdownButtonSelector);
   await expect(accountDropdownButton).toBeVisible();
-
-  await accountDropdownButton.click();
   await expect(accountDropdownButton).toHaveText("A");
+  await accountDropdownButton.click();
 
   const accountDropdownPopover = page.locator(
     '[data-testid="account-dropdown-popover"]',
@@ -114,8 +113,9 @@ test("login works for an existing user (via magic link)", async ({
   await expect(accountDropdownPopover).toContainText("Alice@alice");
   await accountDropdownPopover.locator(`span:has-text("Log Out")`).click();
 
+  // If we are able to open login modal, are logged out
   await openLoginModal({ page, isMobile });
-
+  // Same for another page (after a reload)
   await page2.reload();
   await openLoginModal({ page: page2, isMobile });
 });

--- a/site/tests/shared/fixtures.ts
+++ b/site/tests/shared/fixtures.ts
@@ -1,0 +1,5 @@
+import execa from "execa";
+
+export const resetDb = async () => {
+  await execa("yarn", ["exe", "scripts/seed-db.ts"]);
+};

--- a/site/tests/shared/nav.ts
+++ b/site/tests/shared/nav.ts
@@ -37,6 +37,7 @@ export const login = async ({
   email?: string;
   page: Page;
 }) => {
+  await page.waitForLoadState("networkidle");
   const response1 = await page.request.post("/api/send-login-code", {
     data: { email },
     failOnStatusCode: true,

--- a/site/tests/shared/nav.ts
+++ b/site/tests/shared/nav.ts
@@ -55,6 +55,7 @@ export const login = async ({
   });
 
   await page.reload();
+  await page.waitForLoadState("networkidle");
 
   await expect(
     page.locator('[data-testid="account-dropdown-button"]'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2759,13 +2759,13 @@
     node-gyp "^8.2.0"
     read-package-json-fast "^2.0.1"
 
-"@playwright/test@1.23.3":
-  version "1.23.3"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.23.3.tgz#7f9dd982f2b1a5edbe9e58fedf7bb2691d6309b4"
-  integrity sha512-kR4vo2UGHC84DGqE6EwvAeaehj3xCAK6LoC1P1eu6ZGdC79rlqRKf8cFDx6q6c9T8MQSL1O9eOlup0BpwqNF0w==
+"@playwright/test@^1.24.0":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.24.0.tgz#bef07eddeebba21358ab15e9b0b7a79df0479b76"
+  integrity sha512-sZLH2N6aWN9TtG+vMjNSomSfX0dSVHwWE+GhHQPV+ZeGcuZ/6CgMCGFuGjobgq/hNF9ZkuVOjeyoceZ0owKnHQ==
   dependencies:
     "@types/node" "*"
-    playwright-core "1.23.3"
+    playwright-core "1.24.0"
 
 "@polka/url@^1.0.0-next.20":
   version "1.0.0-next.21"
@@ -9634,22 +9634,22 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright-core@1.23.3:
-  version "1.23.3"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.23.3.tgz#f27ad80fbf0ba9b53d142d94f052b010eaa0527b"
-  integrity sha512-x35yzsXDyo0BIXYimLnUFNyb42c//NadUNH6IPGOteZm96oTGA1kn4Hq6qJTI1/f9wEc1F9O1DsznXIgXMil7A==
+playwright-core@1.24.0:
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.24.0.tgz#ece821ceaf241bb7206329b1242b0cf6c1c60bdb"
+  integrity sha512-BkDWdVsoEEC8m2glQlfNu1EN2qvjBsLIg5bD0wjrfwv9zVHktIsp80yYFObAcWreLNYhfRP4PlXE04lr5R4DFQ==
 
 playwright-test-coverage@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/playwright-test-coverage/-/playwright-test-coverage-1.1.0.tgz#acd6896d1bdb7e5db146e602baef3d02f79e8d2b"
   integrity sha512-j/rk7TIwKYv+ps3KJX+FaL1kFqbB7vafQRGRVGBa2ORhqcd6XQslZLGvW6LpXqh3FY3x+WyWj+RHAVzpWktWCg==
 
-playwright@^1.23.3:
-  version "1.23.3"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.23.3.tgz#67bf7e80de30a464e34b88aab02a694cbf2c59d0"
-  integrity sha512-4uPqXU1PBTBnNhqIyuz+WmvjlMNrt+Rje8lwBf3RpUP9UCjP8G41qrr/vDUbMoHhQaUfdWeDuZAkPUxAv5Ag8g==
+playwright@^1.24.0:
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.24.0.tgz#b1599b992bad4221e87b19a430817316fef644db"
+  integrity sha512-oA9HzuYhskm9iEm9DeiWoLuJps+yzZ35zwR0EHhGFUd9ikUVMN5NqNAORvq+JesgoMlEu4IUdKK9jigFWm7olA==
   dependencies:
-    playwright-core "1.23.3"
+    playwright-core "1.24.0"
 
 pluralize@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION
In scope
- Dashboard page accessibility for guests and logged in users
- Dashboard page key elements and links
- API key page key elements
- API key page key generation
- API key page key re-generation
- API key page key modal edge cases
- Reusable API-based login flow that skips UI (to be used in tests)
- Playwright 1.24

Out of scope
- Type generation from the dashboard