### PR TITLE
Implement integration tests for /api/blocks

### DIFF
--- a/site/tests/integration/api-keys.test.ts
+++ b/site/tests/integration/api-keys.test.ts
@@ -125,18 +125,31 @@ test("API key page should generate a valid key", async ({
   });
 
   const response3 = await request.get("/api/blocks", {
-    headers: { "x-api-key": apiKeyValue.replace(/\d{4}$/, "0000") },
+    headers: {
+      "x-api-key": "oops",
+    },
   });
   expect(response3.status()).toBe(401);
   expect(await response3.json()).toEqual({
-    errors: [{ msg: "API key has been revoked." }],
+    errors: [{ msg: "API key does not match the expected format." }],
   });
 
   const response4 = await request.get("/api/blocks", {
+    headers: {
+      "x-api-key":
+        "b10ck5.00000000000000000000000000000000.00000000-0000-0000-0000-000000000000",
+    },
+  });
+  expect(response4.status()).toBe(401);
+  expect(await response4.json()).toEqual({
+    errors: [{ msg: "Invalid API key." }],
+  });
+
+  const response5 = await request.get("/api/blocks", {
     headers: { "x-api-key": apiKeyValue2 },
   });
-  expect(response4.status()).toBe(200);
-  const blocks = await response4.json();
+  expect(response5.status()).toBe(200);
+  const blocks = await response5.json();
   expect(blocks.errors).toBeUndefined();
   expect(Array.isArray(blocks.results)).toBeTruthy();
   expect(blocks.results[0].author).not.toBeUndefined();

--- a/site/tests/integration/api-keys.test.ts
+++ b/site/tests/integration/api-keys.test.ts
@@ -117,9 +117,7 @@ test("API key page should generate a valid key", async ({
   });
 
   const response2 = await request.get("/api/blocks", {
-    headers: {
-      "x-api-key": apiKeyValue,
-    },
+    headers: { "x-api-key": apiKeyValue },
   });
   expect(response2.status()).toBe(401);
   expect(await response2.json()).toEqual({
@@ -127,9 +125,7 @@ test("API key page should generate a valid key", async ({
   });
 
   const response3 = await request.get("/api/blocks", {
-    headers: {
-      "x-api-key": apiKeyValue.replace(/\d{4}$/, "0000"),
-    },
+    headers: { "x-api-key": apiKeyValue.replace(/\d{4}$/, "0000") },
   });
   expect(response3.status()).toBe(401);
   expect(await response3.json()).toEqual({
@@ -137,9 +133,7 @@ test("API key page should generate a valid key", async ({
   });
 
   const response4 = await request.get("/api/blocks", {
-    headers: {
-      "x-api-key": apiKeyValue2,
-    },
+    headers: { "x-api-key": apiKeyValue2 },
   });
   expect(response4.status()).toBe(200);
   const blocks = await response4.json();

--- a/site/tests/integration/api-keys.test.ts
+++ b/site/tests/integration/api-keys.test.ts
@@ -125,9 +125,7 @@ test("API key page should generate a valid key", async ({
   });
 
   const response3 = await request.get("/api/blocks", {
-    headers: {
-      "x-api-key": "oops",
-    },
+    headers: { "x-api-key": "oops" },
   });
   expect(response3.status()).toBe(401);
   expect(await response3.json()).toEqual({


### PR DESCRIPTION
In scope:
- Check results of `/api/blocks` with various `x-api-header` values

Out of scope:
- Split one test into two: API key UI & API key endpoints (low priority)
- [Investigate why Þ/site/pages/api/*.api.ts are missing in coverage report](https://app.asana.com/0/1202538466812818/1202652337622582/f) (internal)
