### PR TITLE
Fix incorrect link formatting

### DIFF
--- a/site/src/_pages/docs/3_spec/1_core-specification.mdx
+++ b/site/src/_pages/docs/3_spec/1_core-specification.mdx
@@ -231,7 +231,7 @@ As blocks may not sandboxed, messages to or from them must be scoped to their lo
 
 Blocks:
 
-- MUST send messages via dispatching a `[CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent)` named `"blockprotocolmessage"`, where the event matches the structure described in [message content](#message-content)
+- MUST send messages via dispatching a [`CustomEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent) named `"blockprotocolmessage"`, where the event matches the structure described in [message content](#message-content)
 - MUST dispatch events from an element located within the component, ideally the root, which MUST not change across the lifetime of the block instance
 - MUST listen for messages of type `"blockprotocolmessage"` sent from the embedder on the SAME ELEMENT from which they dispatch events
 


### PR DESCRIPTION
The markdown for a link in core specification is incorrect. This PR fixes that.