### PR TITLE
Fix footer navigation bug

### DIFF
--- a/site/src/components/mdx/mdx-page-content.tsx
+++ b/site/src/components/mdx/mdx-page-content.tsx
@@ -1,5 +1,5 @@
 import Box, { BoxProps } from "@mui/material/Box";
-import _ from "lodash";
+import throttle from "lodash/throttle";
 import { useRouter } from "next/router";
 import { MDXRemote, MDXRemoteSerializeResult } from "next-mdx-remote";
 import { FunctionComponent, useEffect, useMemo, useRef, useState } from "react";
@@ -156,7 +156,7 @@ export const MdxPageContent: FunctionComponent<MdxPageContentProps> = ({
       }
     };
 
-    const throttledOnScroll = _.throttle(onScroll, 1000);
+    const throttledOnScroll = throttle(onScroll, 1000);
 
     window.addEventListener("scroll", throttledOnScroll);
 

--- a/site/src/components/mdx/mdx-page-content.tsx
+++ b/site/src/components/mdx/mdx-page-content.tsx
@@ -140,10 +140,6 @@ export const MdxPageContent: FunctionComponent<MdxPageContentProps> = ({
               ? `#${headingAtScrollPosition.anchor}`
               : ""
           }`,
-          undefined,
-          {
-            scroll: false,
-          },
         );
       }
     };

--- a/site/src/components/mdx/mdx-page-content.tsx
+++ b/site/src/components/mdx/mdx-page-content.tsx
@@ -143,7 +143,7 @@ export const MdxPageContent: FunctionComponent<MdxPageContentProps> = ({
       }
     };
 
-    window.addEventListener("scroll", onScroll);
+    setTimeout(() => window.addEventListener("scroll", onScroll), 500);
 
     return () => {
       window.removeEventListener("scroll", onScroll);

--- a/site/src/pages/_app.page.tsx
+++ b/site/src/pages/_app.page.tsx
@@ -58,18 +58,18 @@ const MyApp = ({
     void refetchUser();
   }, [refetchUser]);
 
-  const updatePreviousRoute = (url: string) => {
-    // routeChangeStart also runs on initial load,
-    // so this condition prevents the initial URL being added to sessionStorage
-    if (!document.location.href.includes(url)) {
-      sessionStorage.setItem("previousRoute", document.location.href);
-    }
-  };
-
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_VERCEL_ENV === "production") {
       TagManager.initialize({ gtmId: "GTM-5DRD4LS" });
     }
+
+    const updatePreviousRoute = (url: string) => {
+      // routeChangeStart also runs on initial load,
+      // so this condition prevents the initial URL being added to sessionStorage
+      if (document && !document.location.href.includes(url)) {
+        sessionStorage.setItem("previousRoute", document.location.href);
+      }
+    };
 
     Router.events.on("routeChangeStart", updatePreviousRoute);
 


### PR DESCRIPTION
This fixes the error in console that comes up when
- user navigates to any of the docs page from the footer of a `non-doc` page
- user tries to scroll fast on a long docs page (e.g /docs/developing-blocks)

We have 3 handlers in the docs page that affect scrolling and in some scenarios they might clash, leading to the error.
- Nextjs default scroll to top functionality
- An effect that updates the url as user scrolls down the page
- An effect that detects changes to the url and scrolls to the relevant section where possible. 

This PR fixes the issue by trying to prevent the clashes from happening

Before

https://user-images.githubusercontent.com/16928688/181187538-84cda03f-df1e-4e6a-adf5-5ad41b46d505.mov

After

https://user-images.githubusercontent.com/16928688/181187914-6cd6d1c6-c34b-4719-a18d-cfe8d942052a.mov

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202629493068301