### PR TITLE
Fix login modal scroll in Webkit

### DIFF
--- a/site/src/components/modal/login-modal.tsx
+++ b/site/src/components/modal/login-modal.tsx
@@ -161,6 +161,7 @@ export const LoginModal: FunctionComponent<LoginModalProps> = ({
                 <SendLoginCodeScreen
                   initialEmail={email}
                   onLoginCodeSent={handleLoginCodeSent}
+                  disabled={!modalProps.open}
                   onClose={handleClose}
                 />
               ) : null}

--- a/site/src/components/screens/send-login-code-screen.tsx
+++ b/site/src/components/screens/send-login-code-screen.tsx
@@ -17,6 +17,7 @@ import { TextField } from "../text-field";
 import { VerificationCodeInfo } from "./verification-code-screen";
 
 type SendLoginCodeScreenProps = {
+  disabled?: boolean;
   initialEmail?: string;
   onLoginCodeSent: (params: {
     verificationCodeInfo: VerificationCodeInfo;
@@ -27,14 +28,14 @@ type SendLoginCodeScreenProps = {
 
 export const SendLoginCodeScreen: FunctionComponent<
   SendLoginCodeScreenProps
-> = ({ initialEmail, onLoginCodeSent, onClose }) => {
+> = ({ disabled, initialEmail, onLoginCodeSent, onClose }) => {
   const emailInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    if (emailInputRef.current) {
+    if (emailInputRef.current && !disabled) {
       emailInputRef.current.select();
     }
-  }, [emailInputRef]);
+  }, [emailInputRef, disabled]);
 
   const {
     emailValue,
@@ -118,6 +119,7 @@ export const SendLoginCodeScreen: FunctionComponent<
           placeholder="claude@example.com"
           variant="outlined"
           value={emailValue}
+          disabled={disabled}
           onChange={({ target }) => {
             if (apiErrorMessage) setApiErrorMessage(undefined);
             setEmailValue(target.value);

--- a/site/src/components/screens/send-login-code-screen.tsx
+++ b/site/src/components/screens/send-login-code-screen.tsx
@@ -33,7 +33,7 @@ export const SendLoginCodeScreen: FunctionComponent<
 
   useEffect(() => {
     if (emailInputRef.current && !disabled) {
-      emailInputRef.current.select();
+      emailInputRef.current.focus();
     }
   }, [emailInputRef, disabled]);
 

--- a/site/tests/integration/login-flow.test.ts
+++ b/site/tests/integration/login-flow.test.ts
@@ -121,7 +121,6 @@ test("login works for an existing user (via magic link)", async ({
 });
 
 test("login modal screen 1 correctly handles interactions", async ({
-  browserName,
   page,
   isMobile,
 }) => {
@@ -182,13 +181,6 @@ test("login modal screen 1 correctly handles interactions", async ({
 
   await loginModal.locator("text=Close").click();
   await expect(loginModal).toBeHidden();
-
-  // @todo Remove when Safari bug is fixed
-  // (main page scrolls down when modal is closed, navbar disappears)
-  test.skip(
-    browserName === "webkit",
-    "https://app.asana.com/0/1202542409311090/1202629133807661/f (internal)",
-  );
 
   await openLoginModal({ page, isMobile });
   await expect(loginModal).toBeVisible();


### PR DESCRIPTION
[Asana task](https://app.asana.com/0/1200211978612931/1202629133807661/f) (internal)

The bug was discovered while working on https://github.com/blockprotocol/blockprotocol/issues/452

We hide login modal with a fade-out effect. When we press close, _Email address_ field is unfocused and automatically focused again while the modal is fading. This causes an odd scroll jump in Webkit browsers (both in Playwright and on macOS / iOS).

https://user-images.githubusercontent.com/608862/181071370-436b55f5-9e3f-4161-b167-eb205a31b15c.mp4

Because scrolling the page down hides the top menu, `login-flow` test often fails for Safari and iPhone. It can pass, but only if the header menu is pressed very quickly, before it animates away.

This PR marks the email input field as disabled while the modal is being faded. This makes it non-focusable, which fixes the scrolling bug.

I tried reproducing the same bug for the second login screen (with the code) but could not. Hence, the fix is just for the first screen.
