### PR TITLE
Fix coverage stats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,10 @@ jobs:
 
       - name: Stop frontend ## Updates .nyc_output
         if: ${{ success() || failure() }}
-        run: yarn kill-port 3000
+        run: kill -2 $(lsof -t -i:3000)
+        ## TODO: Replace with kill-port when SIGINT is supported as an argument
+        ## https://github.com/tiaanduplessis/kill-port/issues/48
+        # run: yarn kill-port 3000
 
       - name: Generate coverage report
         if: ${{ success() || failure() }}

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,4 +1,5 @@
 {
+  "extends": "@istanbuljs/nyc-config-typescript",
   "all": true,
   "silent": true,
   "include": "site",

--- a/site/package.json
+++ b/site/package.json
@@ -30,6 +30,7 @@
     "@fortawesome/free-brands-svg-icons": "^6.0.0",
     "@fortawesome/free-regular-svg-icons": "^6.0.0",
     "@fortawesome/free-solid-svg-icons": "^6.0.0",
+    "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@mui/icons-material": "^5.3.1",
     "@mui/material": "^5.4.0",
     "@next/bundle-analyzer": "^12.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2397,6 +2397,13 @@
     js-yaml "^3.13.1"
     resolve-from "^5.0.0"
 
+"@istanbuljs/nyc-config-typescript@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-1.0.2.tgz#1f5235b28540a07219ae0dd42014912a0b19cf89"
+  integrity sha512-iKGIyMoyJuFnJRSVTZ78POIRvNnwZaWIf8vG4ZS3rQq58MMDrqEX2nnzx0R28V2X8JvmKYiqY9FP2hlJsm8A0w==
+  dependencies:
+    "@istanbuljs/schema" "^0.1.2"
+
 "@istanbuljs/schema@^0.1.2":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"


### PR DESCRIPTION
I was [documenting](https://app.asana.com/0/1200211978612931/1202644137081309/f) integration tests and noticed two issues with reported coverage. This PR fixes them.

- We used `npx kill-port 3000` in CI, which stopped `next start` with SIGKILL instead of SIGINT. Abrupt process termination meant that the runtime coverage was not reported. I have temporarily replaced `yarn kill-port` with `kill -2` (i.e. SIGKILL with SIGINT). We can switch back when https://github.com/tiaanduplessis/kill-port/issues/48 is closed upstream.
  
  ↑ this change **increased** reported code coverage

- We did not have `@istanbuljs/nyc-config-typescript` in `.nycrc.json`, which caused some source files to be missing from the list of all files. In particular, all `site/src/pages/api/**.ts` files were not included into the report. Adding `@istanbuljs/nyc-config-typescript` made the list of files more complete.

  ↑ this change **decreased** reported code coverage


Overall coverage has **decreased**, but this is expected.