### PR TITLE
Add blockprotocol changeset for @types/react bump

### DIFF
--- a/.changeset/blockprotocol-react-types.md
+++ b/.changeset/blockprotocol-react-types.md
@@ -1,0 +1,5 @@
+---
+"blockprotocol": patch
+---
+
+upgrade @types/react dependency


### PR DESCRIPTION
We upgraded the `@types/react` dependency in `blockprotocol` in #426, but didn't publish a new version of `blockprotocol`. This is leading to type mismatches in https://github.com/hashintel/hash

This PR adds a changeset for `blockprotocol` so we can publish a new version.