### PR TITLE
Fix typo in changeset release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1.3.0
         with:
-          publish: yarn changesets publish
+          publish: yarn changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The changeset release action has a typo in it which means it does not work - see [here](https://github.com/blockprotocol/blockprotocol/runs/7541374647?check_suite_focus=true).