### PR TITLE
FAQ subsection titles appearing as slugs in sidebar

### DIFF
--- a/site/src/_pages/docs/4_faq.mdx
+++ b/site/src/_pages/docs/4_faq.mdx
@@ -191,7 +191,7 @@ We don’t prescribe canonical types for any _thing_, but do recommend that user
 
 </FAQ>
 
-<FAQ question="How does the Block Protocol relate to schema.org?">
+<FAQ question={<div>How does the Block Protocol relate to <i>schema.org</i>?</div>} anchor="how-does-the-block-protocol-relate-to-schema.org">
 
 [schema.org](https://schema.org) defines a collection of schemas for use in making the data on web pages machine-readable.
 
@@ -239,7 +239,7 @@ All schemas created on the Block Protocol website are currently public. In futur
 </InfoCardWrapper>
 </FAQ>
 
-<FAQ anchor="why-arent-the-default-schemaorg-definitions-sufficient" question={(<>Why aren’t the default <i>schema.org</i> definitions sufficient?</>)}>
+<FAQ question={<div>Why aren’t the default <i>schema.org</i> definitions sufficient?</div>} anchor="why-arent-the-default-schemaorg-definitions-sufficient">
 
 [schema.org](https://schema.org) provides a great base ontology for defining lots of types of ‘things’ out there in the world.
 

--- a/site/src/components/page-sidebar.tsx
+++ b/site/src/components/page-sidebar.tsx
@@ -23,6 +23,7 @@ import {
 
 import { SiteMapPage, SiteMapPageSection } from "../lib/sitemap";
 import { theme as themeImport } from "../theme";
+import { parseHTML } from "../util/html-utils";
 import { FontAwesomeIcon } from "./icons";
 import { Link } from "./link";
 import { DESKTOP_NAVBAR_HEIGHT, MOBILE_NAVBAR_HEIGHT } from "./navbar";
@@ -117,7 +118,7 @@ const SidebarPageSection: FunctionComponent<SidebarPageSectionProps> = ({
             ...highlightSection(isSectionSelected),
           })}
         >
-          {sectionTitle}
+          {parseHTML(sectionTitle)}
         </SidebarLink>
         {subSections && subSections.length > 0 ? (
           <IconButton


### PR DESCRIPTION
Questions with styles in the FAQ section were incorrectly displaying a slug in the sidebar (see `why-arent-the-default-schemaorg-definitions-sufficient`).

![image](https://user-images.githubusercontent.com/37453800/181373571-1cd3e262-5cf0-4cd1-89ec-0ed2afd0934d.png)

This PR fixes the parsing of FAQ sections in the docs to correctly handle anchors and HTML styled titles.

![image](https://user-images.githubusercontent.com/37453800/181374115-022103fe-4c4b-4987-a386-c99795598a5a.png)

[Task](https://app.asana.com/0/1200211978612931/1202579651285633/f)
