### PR TITLE
Remove `hotfixExternals` (unused code)

### DIFF
--- a/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
+++ b/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
@@ -1,24 +1,7 @@
-import { JsonObject } from "@blockprotocol/core";
 import { NextApiHandler } from "next";
 
 import packageJson from "../../../../package.json";
 import { readBlockDataFromDisk, readBlocksFromDisk } from "../../../lib/blocks";
-
-/**
- * @todo remove after fixing
- * - https://blockprotocol.org/@jmackie/blocks/quote
- * - https://blockprotocol.org/@shinypb/blocks/emoji-trading-cards
- * - https://blockprotocol.org/@kickstartds/blocks/button
- */
-const hotfixExternals = (externals: JsonObject | undefined): JsonObject => {
-  return (
-    externals ?? {
-      react: packageJson.dependencies.react,
-      lodash: packageJson.dependencies.lodash,
-      twind: packageJson.dependencies.twind,
-    }
-  );
-};
 
 /**
  * @todo potentially remove after building blocks to ESM
@@ -62,16 +45,15 @@ const handler: NextApiHandler = async (req, res) => {
 
   const externalUrlLookup: Record<string, string> = {};
 
+  const externals = blockMetadata.externals ?? {};
   if (
-    Object.keys(blockMetadata.externals ?? {}).length > 0 &&
+    Object.keys(externals).length > 0 &&
     blockMetadata.blockType.entryPoint === "html"
   ) {
     throw new Error(
       "Block Protocol does not support externals with HTML blocks",
     );
   }
-
-  const externals = hotfixExternals(blockMetadata.externals);
 
   for (const [packageName, packageVersion] of Object.entries(externals)) {
     externalUrlLookup[packageName] = `https://esm.sh/${hotfixPackageName(


### PR DESCRIPTION
This PR removes unused code which I’ve accidentally discovered while preparing #477. The `hotfixExternals` function was needed to render the following blocks in conjunction with Þ v0.1:
- https://blockprotocol.org/@jmackie/blocks/quote
- https://blockprotocol.org/@shinypb/blocks/emoji-trading-cards
- https://blockprotocol.org/@kickstartds/blocks/button

The are incompatible with Þ v0.2 and are therefore not displayed on the website. Keeping the patch will make it more tricky to review new versions of these blocks or other blocks.