### PR TITLE
Fix multiple re-renders bug in `mock-block-dock`

### DIFF
--- a/.changeset/mock-block-dock-fix.md
+++ b/.changeset/mock-block-dock-fix.md
@@ -1,0 +1,5 @@
+---
+mock-block-dock: patch
+---
+
+Fix bug introduced in 0.19 that comes up when `readonly` prop is undefined

--- a/.changeset/mock-block-dock-fix.md
+++ b/.changeset/mock-block-dock-fix.md
@@ -2,4 +2,4 @@
 mock-block-dock: patch
 ---
 
-Fix bug introduced in 0.19 that comes up when `readonly` prop is undefined
+Fix bug introduced in 0.0.19 that comes up when `readonly` prop is undefined

--- a/packages/mock-block-dock/src/mock-block-dock.tsx
+++ b/packages/mock-block-dock/src/mock-block-dock.tsx
@@ -90,7 +90,7 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps> = ({
   );
   const [debugReadonly, setDebugReadonly] = useState<boolean>(!!readonly);
   const wrapperRef = useRef<HTMLDivElement>(null);
-  const prevReadonly = useRef<boolean>(!!readonly);
+  const prevReadonly = useRef<boolean | undefined>(readonly);
 
   const propsToInject: BlockGraphProperties<any> = {
     graph: {
@@ -103,7 +103,7 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps> = ({
   };
 
   useEffect(() => {
-    prevReadonly.current = !!readonly;
+    prevReadonly.current = readonly;
   }, [readonly]);
 
   useEffect(() => {


### PR DESCRIPTION
A bug that was introduced in #488 where `mock-block-dock` has infinite re-renders when the `readonly` prop is undefined. This PR fixes that