### PR TITLE
Include `timestamp` when messages are sent

### DIFF
--- a/.changeset/core-service-updates.md
+++ b/.changeset/core-service-updates.md
@@ -1,0 +1,5 @@
+---
+"@blockprotocol/core": patch
+---
+
+Include timestamp when messages are sent

--- a/packages/@blockprotocol/core/src/core-handler.ts
+++ b/packages/@blockprotocol/core/src/core-handler.ts
@@ -270,7 +270,6 @@ export abstract class CoreHandler {
           },
           requestId,
           sender: serviceHandler,
-          timestamp: new Date().toISOString(),
         });
       } catch (err) {
         throw new Error(

--- a/packages/@blockprotocol/core/src/core-handler.ts
+++ b/packages/@blockprotocol/core/src/core-handler.ts
@@ -200,6 +200,7 @@ export abstract class CoreHandler {
       respondedToBy: "respondedToBy" in args ? args.respondedToBy : undefined,
       service: sender.serviceName,
       source: this.sourceType,
+      timestamp: new Date().toISOString(),
     };
 
     const event = new CustomEvent(CoreHandler.customEventName, {
@@ -269,6 +270,7 @@ export abstract class CoreHandler {
           },
           requestId,
           sender: serviceHandler,
+          timestamp: new Date().toISOString(),
         });
       } catch (err) {
         throw new Error(

--- a/packages/@blockprotocol/core/src/service-handler.ts
+++ b/packages/@blockprotocol/core/src/service-handler.ts
@@ -112,7 +112,7 @@ export abstract class ServiceHandler {
   ) {
     this.checkIfDestroyed();
 
-    this.coreHandler.registerCallback({dd ch
+    this.coreHandler.registerCallback({
       callback,
       messageName,
       serviceName: this.serviceName,

--- a/packages/@blockprotocol/core/src/service-handler.ts
+++ b/packages/@blockprotocol/core/src/service-handler.ts
@@ -112,7 +112,7 @@ export abstract class ServiceHandler {
   ) {
     this.checkIfDestroyed();
 
-    this.coreHandler.registerCallback({
+    this.coreHandler.registerCallback({dd ch
       callback,
       messageName,
       serviceName: this.serviceName,

--- a/packages/@blockprotocol/core/src/types.ts
+++ b/packages/@blockprotocol/core/src/types.ts
@@ -149,6 +149,8 @@ export interface Message extends MessageContents {
   service: string;
   // the source of the message
   source: "block" | "embedder";
+  // when the message was sent
+  timestamp: string;
 }
 
 export type MessageCallback<


### PR DESCRIPTION
This PR ensures a timestamp is included when messages are sent. While implementing a logs viewer in https://github.com/blockprotocol/blockprotocol/pull/507, the logs were not displaying in the right order because the timestamp was being attached when the event was received as opposed to when it was dispatched. This ensures the right timestamp is set. 