### PR TITLE
Temporarily pin `mockBlockDockVersion` in sandbox

### DIFF
--- a/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
+++ b/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
@@ -38,7 +38,9 @@ const handler: NextApiHandler = async (req, res) => {
 
   const { exampleGraph } = await readBlockDataFromDisk(blockMetadata);
 
-  const mockBlockDockVersion = packageJson.dependencies["mock-block-dock"];
+  // @todo revert; context: https://hashintel.slack.com/archives/C02LG39FJAU/p1661170257710909
+  // const mockBlockDockVersion = packageJson.dependencies["mock-block-dock"];
+  const mockBlockDockVersion = "0.0.20";
 
   const reactVersion =
     blockMetadata.externals?.react ?? packageJson.dependencies.react;


### PR DESCRIPTION
Context:
- [Slack thread](https://hashintel.slack.com/archives/C02LG39FJAU/p1661170257710909) (internal)
- [Asana task](https://app.asana.com/0/1202787635216884/1202838684488401/f) (internal)
- Upstream issue: https://github.com/ije/esm.sh/issues/406