### PR TITLE
Switch back to the latest `mockBlockDockVersion` in sandbox

### DIFF
--- a/scripts/packages/e2e-test-create-block-app.ts
+++ b/scripts/packages/e2e-test-create-block-app.ts
@@ -136,7 +136,7 @@ const script = async () => {
       },
     });
 
-    await waitOn({ resources: ["http://localhost:63212"], timeout: 20000 });
+    await waitOn({ resources: ["http://localhost:63212"], timeout: 30000 });
 
     await killProcessTree(devProcess.pid!, "SIGINT");
 

--- a/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
+++ b/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
@@ -38,9 +38,7 @@ const handler: NextApiHandler = async (req, res) => {
 
   const { exampleGraph } = await readBlockDataFromDisk(blockMetadata);
 
-  // @todo revert; context: https://hashintel.slack.com/archives/C02LG39FJAU/p1661170257710909
-  // const mockBlockDockVersion = packageJson.dependencies["mock-block-dock"];
-  const mockBlockDockVersion = "0.0.20";
+  const mockBlockDockVersion = packageJson.dependencies["mock-block-dock"];
 
   const reactVersion =
     blockMetadata.externals?.react ?? packageJson.dependencies.react;

--- a/site/tests/integration/blockpage.test.ts
+++ b/site/tests/integration/blockpage.test.ts
@@ -84,7 +84,9 @@ test("Block page should contain key elements", async ({
   if (browserName !== "webkit") {
     await expect(
       page.frameLocator("iframe[title='block']").locator("input"),
-    ).toBeVisible();
+    ).toBeVisible({
+      timeout: 30000, // @todo Remove after re-engineering block sandbox
+    });
     await expect(
       page.frameLocator("iframe[title='block']").locator("input"),
     ).toHaveValue(blockExample.caption!);

--- a/site/tests/integration/docs.test.ts
+++ b/site/tests/integration/docs.test.ts
@@ -16,7 +16,7 @@ test("Docs page should contain key elements and interactions should work", async
 
   await expect(page.locator('h1:has-text("Introduction")')).toBeVisible();
 
-  const sidebarSelector = page.locator(
+  const sidebarLocator = page.locator(
     isMobile ? "[data-testid='mobile-nav']" : "aside",
   );
 
@@ -24,7 +24,7 @@ test("Docs page should contain key elements and interactions should work", async
     await openMobileNav(page);
   }
 
-  await expect(sidebarSelector).toBeVisible();
+  await expect(sidebarLocator).toBeVisible();
 
   for (const [name, href] of [
     ["Introduction", "/docs"],
@@ -33,28 +33,28 @@ test("Docs page should contain key elements and interactions should work", async
     ["Specification", "/docs/spec"],
     ["FAQs", "/docs/faq"],
   ] as const) {
-    const item = sidebarSelector.locator(`a:has-text("${name}")`).first();
+    const item = sidebarLocator.locator(`a:has-text("${name}")`).first();
     await expect(item).toBeVisible();
     await expect(item).toHaveAttribute("href", href);
   }
 
   // confirm expand button works
-  await sidebarSelector
+  await sidebarLocator
     .locator(':has-text("Introduction") + button')
     .first()
     .click();
 
   await expect(
-    sidebarSelector.locator('a:has-text("Overview")').first(),
+    sidebarLocator.locator('a:has-text("Overview")').first(),
   ).not.toBeVisible();
 
-  await sidebarSelector
+  await sidebarLocator
     .locator(':has-text("Introduction") + button')
     .first()
     .click();
 
   await expect(
-    sidebarSelector.locator('a:has-text("Overview")').first(),
+    sidebarLocator.locator('a:has-text("Overview")').first(),
   ).toBeVisible();
 
   if (isMobile) {
@@ -72,7 +72,7 @@ test("Docs page should contain key elements and interactions should work", async
   }
 
   // navigate to spec page
-  await sidebarSelector.locator("a:has-text('Specification')").first().click();
+  await sidebarLocator.locator("a:has-text('Specification')").first().click();
 
   await expect(page).toHaveURL("/docs/spec");
 
@@ -117,7 +117,7 @@ test("Docs page should contain key elements and interactions should work", async
     await openMobileNav(page);
   }
 
-  await sidebarSelector.locator("a:has-text('FAQs')").click();
+  await sidebarLocator.locator("a:has-text('FAQs')").click();
 
   await expect(page.locator('h1:has-text("FAQs")')).toBeVisible();
 


### PR DESCRIPTION
Reverts blockprotocol/blockprotocol#515

We no longer need to pin MBD because the upstream issue is now resolved: https://github.com/ije/esm.sh/issues/406#issuecomment-1223330666

Extras: see comments