### PR TITLE
Set codecov threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%


### PR DESCRIPTION
Our test coverage is a bit unstable because of some async code in `useEffect` calls. This triggers false codecov CI failures, e.g. https://github.com/blockprotocol/blockprotocol/pull/512#issuecomment-1220956812.


This PR eases Codecov threshold by changing it to 0 (default) to 1%. This can help us avoid some distraction while we investigate the underlying cause.

The most common source of flakines is `mdx-page-content.tsx`. The relationship between scrolling and `#anchors` is async and settles within 1.5...2 seconds. If Playwright (or a user) scrolls faster than that, some code is skipped. Other cases are similar in nature.