### PR TITLE
Run `lint:tsc` via Turborepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint:lockfile-lint": "lockfile-lint --path yarn.lock --allowed-hosts registry.yarnpkg.com --allowed-schemes \"https:\"",
     "lint:markdownlint": "markdownlint \"**/*\"",
     "lint:prettier": "prettier --check --ignore-unknown \"**/*\"",
-    "lint:tsc": "yarn workspaces run lint:tsc",
+    "lint:tsc": "turbo run lint:tsc",
     "lint:yarn-deduplicate": "yarn-deduplicate --fail --list --strategy=fewer",
     "dev": "yarn workspace @blockprotocol/site dev",
     "dev:seed-db": "yarn workspace @blockprotocol/site dev:seed-db",

--- a/packages/block-template-html/package.json
+++ b/packages/block-template-html/package.json
@@ -20,7 +20,6 @@
   "scripts": {
     "build": "rimraf dist; cp -R src dist; cp block-metadata.json dist; cp block-schema.json dist; cp -R public dist;",
     "dev": "echo \"Serving at http://localhost:63212\"; http-server -p 63212 ./dev",
-    "lint:tsc": "echo \"Skipping: TypeScript not configured\"",
     "prepare": "rimraf ./dev/src; lnk -f ./src ./dev",
     "serve": "block-scripts serve"
   },

--- a/packages/create-block-app/package.json
+++ b/packages/create-block-app/package.json
@@ -20,9 +20,6 @@
     "url": "https://hash.ai"
   },
   "bin": "create-block-app.js",
-  "scripts": {
-    "lint:tsc": "echo \"Skipping: TypeScript not configured\""
-  },
   "dependencies": {
     "command-line-args": "^5.2.1",
     "command-line-usage": "^6.1.3",

--- a/scripts/packages/e2e-test-create-block-app.ts
+++ b/scripts/packages/e2e-test-create-block-app.ts
@@ -143,7 +143,15 @@ const script = async () => {
     logStepEnd();
     logStepStart("Linting");
 
-    await execa("npm", ["run", "lint:tsc"], execaOptionsInBlockDir);
+    const blockPackageJson = await fs.readJson(
+      path.resolve(resolvedBlockDirPath, "package.json"),
+    );
+
+    if (blockPackageJson.scripts["lint:tsc"]) {
+      await execa("npm", ["run", "lint:tsc"], execaOptionsInBlockDir);
+    } else {
+      console.log("Skipping (yarn lint:tsc is not configured)");
+    }
 
     logStepEnd();
     logStepStart("Build");

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,10 @@
       ],
       "dependsOn": ["codegen", "^build"]
     },
-    "codegen": {}
+    "codegen": {},
+    "lint:tsc": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    }
   }
 }


### PR DESCRIPTION
Extracted from #508 to keep PR scope focused. Continues https://github.com/blockprotocol/blockprotocol/pull/525.

- saves us from creating dummy `lint:tsc` in some existing and future packages (requirement of `yarn workspaces`)
- speeds up repeated calls to `yarn lint:tsc`:

```
 Tasks:    15 successful, 15 total
Cached:    15 cached, 15 total
  Time:    280ms >>> FULL TURBO
```