### PR TITLE
Enable Turborepo remote cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: hashintel
+  TURBO_REMOTE_ONLY: true
+
 jobs:
   linting:
     name: Linting

--- a/turbo.json
+++ b/turbo.json
@@ -6,13 +6,13 @@
         "dist/**",
         ".next/**",
         "public/blocks/**",
-        "public/schemas/**",
-        "blocks-data.json",
-        "site-map.json"
+        "public/schemas/**"
       ],
       "dependsOn": ["codegen", "^build"]
     },
-    "codegen": {},
+    "codegen": {
+      "outputs": ["blocks-data.json", "site-map.json"]
+    },
     "lint:tsc": {
       "dependsOn": ["^build"],
       "outputs": []


### PR DESCRIPTION
This change should speed up CI by reusing Turborepo remote cache between builds. Unlike GitHub cache (which is pretty much monolithic), Turborepo cache is more granular and lets us read and write individual keys depending on the state of the packages.

[Docs](https://turborepo.org/docs/ci/github-actions) recommend setting two secrets: `TURBO_TOKEN` and `TURBO_TEAM`. I deviated from this a little and hardcoded `TURBO_TEAM`. Keeping `hashintel` in GitHub secrets will replace this string with `***` in CI output, which we don’t want. I had this in another project and had to remove a trivial string id from secrets to avoid confusion.

This change is an experiment. If we see issues with Turborepo cache, we'll roll this PR back. Otherwise, we’ll use new env vars to other jobs too. 