### PR TITLE
Remove template on VersionedUri

### DIFF
--- a/crates/type-system/src/ontology/uri/wasm.rs
+++ b/crates/type-system/src/ontology/uri/wasm.rs
@@ -8,10 +8,10 @@ use crate::{
     uri::{error::ParseVersionedUriError, VersionedUri},
 };
 
-// Generates the TypeScript alias: type VersionedUri = `${string}/v/${number}`
+// Generates the TypeScript alias: type VersionedUri = string
 #[derive(Tsify)]
 #[serde(rename = "VersionedUri")]
-pub struct VersionedUriPatch(#[tsify(type = "`${string}/v/${number}`")] String);
+pub struct VersionedUriPatch(String);
 
 #[wasm_bindgen(typescript_custom_section)]
 const PARSE_BASE_URI_DEF: &'static str = r#"

--- a/packages/@blockprotocol/type-system-node/dist/index.d.ts
+++ b/packages/@blockprotocol/type-system-node/dist/index.d.ts
@@ -80,7 +80,7 @@ export interface PropertyType extends OneOf<PropertyValues> {
     description?: string;
 }
 
-export type VersionedUri = `${string}/v/${number}`;
+export type VersionedUri = string;
 
 
 /**

--- a/packages/@blockprotocol/type-system-web/dist/index.d.ts
+++ b/packages/@blockprotocol/type-system-web/dist/index.d.ts
@@ -80,7 +80,7 @@ export interface PropertyType extends OneOf<PropertyValues> {
     description?: string;
 }
 
-export type VersionedUri = `${string}/v/${number}`;
+export type VersionedUri = string;
 
 
 /**


### PR DESCRIPTION
We had an experimental approach where we were constraining the type of `VersionedUri` a little bit further in TypeScript by using a template literal.

This provided some benefit but it also turns out that it makes the library harder to use when trying to convert between different interfaces, making it unergonomic where you have to destructure the object so you can call `isVersionedUri` even when the type has already been checked, due to coercion. 

This PR removes the template type. We might bring it back in the future, as the change is small and easy to reimplement