### PR TITLE
Configure `no-unused-vars`

### DIFF
--- a/packages/@local/eslint-config/index.js
+++ b/packages/@local/eslint-config/index.js
@@ -47,6 +47,14 @@ module.exports = {
     "no-nested-ternary": "off",
     "no-restricted-syntax": "off",
     camelcase: "off",
+    "no-unused-vars": [
+      "error",
+      {
+        args: "all", // check all args, not just those after-used
+        argsIgnorePattern: "^_+",
+        varsIgnorePattern: "^_+",
+      },
+    ],
     "default-param-last": "off", // using @typescript-eslint/default-param-last instead
     "no-await-in-loop": "off",
     "import/first": "error",

--- a/packages/@local/eslint-config/index.js
+++ b/packages/@local/eslint-config/index.js
@@ -412,8 +412,7 @@ module.exports = {
     {
       files: ["*.ts", "*.tsx"],
       rules: {
-        "no-unused-vars": "off",
-        // replaced by @typescript-eslint/no-unused-vars
+        "no-unused-vars": "off", // replaced by @typescript-eslint/no-unused-vars
         "@typescript-eslint/no-unused-vars": [
           "error",
           {


### PR DESCRIPTION
This PR syncs [`no-unused-vars`](https://eslint.org/docs/latest/rules/no-unused-vars) with [`@typescript-eslint/no-unused-vars`](https://typescript-eslint.io/rules/no-unused-vars/) which is [already configured](https://github.com/blockprotocol/blockprotocol/blob/35531b3601bf1e6f1446a25c24f70a3a04807434/packages/%40local/eslint-config/index.js#L404-L418). Syncing two rules helps us maintain the same code style both in js and ts files.

My personal preference is to keep the rule defaults, but I agree with the idea of consistency.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202861619533371