### PR TITLE
Register webhook for npm-linked blocks

### DIFF
--- a/site/src/lib/blocks.ts
+++ b/site/src/lib/blocks.ts
@@ -15,6 +15,7 @@ import { FRONTEND_URL } from "./config";
  * Relative file URLs are rewritten to be absolute, and other fields are added
  */
 export type ExpandedBlockMetadata = BlockMetadata & {
+  author: string;
   createdAt?: string | null;
   // the block's URL on blockprotocol.org
   blockSitePath: string;

--- a/site/src/pages/api/README.md
+++ b/site/src/pages/api/README.md
@@ -2,6 +2,10 @@
 
 You should be aware of the following:
 
+## File name
+
+You must name your file `[something].api.ts` for it to be recognised as an API endpoint.
+
 ## Input validation, error formatting
 
 You can use `bodyValidator` to validate the request body.

--- a/site/src/pages/api/blocks/create.api.ts
+++ b/site/src/pages/api/blocks/create.api.ts
@@ -7,6 +7,7 @@ import {
   formatErrors,
   isErrorContainingCauseWithCode,
 } from "../../../util/api";
+import { revalidateMultiBlockPages } from "./shared";
 
 export type ApiBlockCreateRequest = {
   blockName: string;
@@ -40,6 +41,7 @@ export default createAuthenticatedHandler<
         npmPackageName,
         user,
       });
+      await revalidateMultiBlockPages(res, user.shortname!); // user is signed up and has shortname
       return res.status(200).json({ block });
     } catch (err) {
       const errIsError = err instanceof Error;

--- a/site/src/pages/api/blocks/npm-hook.api.ts
+++ b/site/src/pages/api/blocks/npm-hook.api.ts
@@ -1,0 +1,90 @@
+import crypto from "node:crypto";
+
+import { updateBlockFromNpm } from "../../../lib/api/blocks/npm";
+import { createBaseHandler } from "../../../lib/api/handler/base-handler";
+import { FRONTEND_URL } from "../../../lib/config";
+import { formatErrors } from "../../../util/api";
+import { revalidateMultiBlockPages } from "./shared";
+
+type PackageEventName =
+  | "star"
+  | "unstar"
+  | "publish"
+  | "unpublish"
+  | "owner"
+  | "owner-rm"
+  | "dist-tag"
+  | "dist-tag-rm"
+  | "deprecated"
+  | "undeprecated"
+  | "change";
+
+type PackageChangeObject = {
+  "dist-tag": string;
+  version: string;
+};
+
+/**
+ * @see https://github.com/npm/registry/blob/master/docs/hooks/hooks-payload.md
+ */
+type ApiNpmWebhookBody = {
+  change: PackageChangeObject;
+  event: `package:${PackageEventName}`;
+  hookOwner: { username: string };
+  name: string; // package name
+  payload: Record<string, unknown>; // API data on the package
+  time: string; // unix timestamp in ms
+  type: "package";
+  version: string;
+};
+
+type ApiWebhookResponse = "ok";
+
+export const npmWebhookEndpoint = `${FRONTEND_URL}/api/blocks/npm-hook`;
+export const npmWebhookSecret = process.env.NPM_WEBHOOK_SECRET;
+
+export default createBaseHandler<ApiNpmWebhookBody, ApiWebhookResponse>().post(
+  async (req, res) => {
+    if (!npmWebhookSecret) {
+      const errorMsg =
+        "No npm webhook secret in environment. Cannot process received webhook message.";
+      // eslint-disable-next-line no-console -- server-side, useful for debugging
+      console.error(errorMsg);
+      res.status(500).send(formatErrors({ msg: errorMsg }));
+      return;
+    }
+
+    const requestSignature = req.headers["x-npm-signature"];
+
+    const expected = crypto
+      .createHmac("sha256", npmWebhookSecret)
+      .update(req.body.toString())
+      .digest("hex");
+
+    if (requestSignature !== `sha256=${expected}`) {
+      const errorMsg = "Request signature does not match expectation.";
+      // eslint-disable-next-line no-console -- server-side, useful for debugging
+      console.error(errorMsg);
+      res.status(400).send(formatErrors({ msg: errorMsg }));
+      return;
+    }
+
+    const { event, name, change } = req.body;
+    if (event !== "package:publish" || change["dist-tag"] !== "latest") {
+      return;
+    }
+
+    try {
+      const { expandedMetadata } = await updateBlockFromNpm({
+        npmPackageName: name,
+        version: change.version,
+      });
+      await revalidateMultiBlockPages(res, expandedMetadata.author);
+      await res.revalidate(expandedMetadata.blockSitePath);
+      res.status(200).send("ok");
+    } catch (err) {
+      // eslint-disable-next-line no-console -- server-side, useful for debugging
+      console.error(`Could not update block from npm: ${err}`);
+    }
+  },
+);

--- a/site/src/pages/api/blocks/shared.ts
+++ b/site/src/pages/api/blocks/shared.ts
@@ -1,0 +1,10 @@
+import { NextApiResponse } from "next";
+
+export const revalidateMultiBlockPages = async (
+  res: NextApiResponse,
+  username: string,
+) => {
+  await res.revalidate("/");
+  await res.revalidate("/hub");
+  await res.revalidate(`/@${username}`);
+};


### PR DESCRIPTION
# What is this?

An attempt to register a hook with npm to inform `blockprotocol.org` of changes to specific packages, so that we can automatically update our metadata and files for npm-linked blocks.

It does not work because automation tokens cannot be used to call `npm hook add`, meaning that we cannot register hooks via the lambda (unless we disable 2FA).

Opening this PR to bank the work so far.