### PR TITLE
Replace import assertion with `fs.readJsonSync`

### DIFF
--- a/site/src/lib/api/blocks/get.ts
+++ b/site/src/lib/api/blocks/get.ts
@@ -1,10 +1,11 @@
 import fs from "fs-extra";
+import path from "node:path";
 
 import { ExpandedBlockMetadata } from "../../blocks";
 import { getDbBlock, getDbBlocks } from "./db";
 
 const localBlocks = fs.readJsonSync(
-  "blocks-data.json",
+  path.resolve("blocks-data.json"),
 ) as ExpandedBlockMetadata[];
 
 export const getAllBlocks = async (): Promise<ExpandedBlockMetadata[]> => {

--- a/site/src/lib/api/blocks/get.ts
+++ b/site/src/lib/api/blocks/get.ts
@@ -1,6 +1,11 @@
-import localBlocks from "../../../../blocks-data.json" assert { type: "json" };
+import fs from "fs-extra";
+
 import { ExpandedBlockMetadata } from "../../blocks";
 import { getDbBlock, getDbBlocks } from "./db";
+
+const localBlocks = fs.readJsonSync(
+  "blocks-data.json",
+) as ExpandedBlockMetadata[];
 
 export const getAllBlocks = async (): Promise<ExpandedBlockMetadata[]> => {
   const allDbBlocks = await getDbBlocks({});


### PR DESCRIPTION
Fixes recent failures in Integration tests

- [slack thread](https://hashintel.slack.com/archives/C02LG39FJAU/p1661875861698159) (internal)
- [Asana task](https://app.asana.com/0/0/1202886867026837) (internal)
