### PR TITLE
Make codecov diff in PRs informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,6 @@ coverage:
       default:
         target: auto
         threshold: 1%
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
This PR should suppress CI failures when PR diff coverage is small:

<img width="487" alt="Screenshot 2022-08-31 at 17 17 29" src="https://user-images.githubusercontent.com/608862/187728507-7e320f91-dfb7-4bd7-8467-6d359e2a3fb4.png">

We can switch back to the default behavior when we are more committed to writing tests for new features. Getting used to ❌ makes it harder to pay attention to real issues.

- [codecov docs](https://docs.codecov.com/docs/common-recipe-list#set-non-blocking-status-checks)
- [Asana task](https://app.asana.com/0/0/1202886867026851) (internal)
