### PR TITLE
Clarify Discussion Process in RFC

### DIFF
--- a/rfcs/0000-template.md
+++ b/rfcs/0000-template.md
@@ -1,7 +1,7 @@
 - **Feature Name:** (fill me in with a unique ident such as `my-feature`, this should be used in the name of the file)
 - **Start Date:** (fill me in with today's date, YYYY-MM-DD)
 - **RFC PR:** [blockprotocol/blockprotocol#0000](https://github.com/blockprotocol/blockprotocol/pull/0000)
-- **RFC Discussion:** [blockprotocol/blockprotocol#0000](https://github.com/blockprotocol/blockprotocol/discussions/0000)
+- **RFC Discussion:** [blockprotocol/blockprotocol#0000](https://github.com/blockprotocol/blockprotocol/discussions/0000) (To be created **after** the RFC has been accepted and the PR is **merged**)
 
 # Summary
 


### PR DESCRIPTION
We have been opening discussions too early, and ideally we should be discussing _proposals_ on the PR themselves until they have been accepted and then merged. At which point we are to open a discussion to track **implementation**.