### PR TITLE
Fix base url in Axios requests

### DIFF
--- a/site/src/lib/api-client.ts
+++ b/site/src/lib/api-client.ts
@@ -40,7 +40,7 @@ import {
 } from "../pages/api/verify-email.api";
 import { FRONTEND_URL } from "./config";
 
-const BASE_URL = `${typeof window === "undefined" ? "" : FRONTEND_URL}/api/`;
+const BASE_URL = `${typeof window !== "undefined" ? "" : FRONTEND_URL}/api/`;
 
 const axiosClient = axios.create({
   baseURL: BASE_URL,


### PR DESCRIPTION
#556 included a change aimed at using relative API routes when running on the client, but instead set relative API routes when running on the server, breaking pages which made server-side calls to the API (e.g. https://blockprotocol.org/@hash).

This PR corrects the condition.