### PR TITLE
Skip block properties test

### DIFF
--- a/site/tests/universal/blockpage.test.ts
+++ b/site/tests/universal/blockpage.test.ts
@@ -13,6 +13,8 @@ test("Updating block properties should update block preview", async ({
   );
   test.slow(); // @todo Remove after re-engineering block sandbox
 
+  test.fail(); // @todo Re-enable as part of https://app.asana.com/0/1202839302145209/1202922733837187/f
+
   await page.goto("/hub");
 
   await expect(


### PR DESCRIPTION
Related to [Asana task](https://app.asana.com/0/1202839302145209/1202922733837187/f) (internal) / [Slack thread](https://hashintel.slack.com/archives/C02LG39FJAU/p1662396422497149) (internal)

Properly marking a failing test will keep CI green while we are fixing the bug. Keeping tests as is may lead to more bugs accidentally merged to `main`.