### PR TITLE
Revert "Skip block properties test"

### DIFF
--- a/site/tests/universal/blockpage.test.ts
+++ b/site/tests/universal/blockpage.test.ts
@@ -13,8 +13,6 @@ test("Updating block properties should update block preview", async ({
   );
   test.slow(); // @todo Remove after re-engineering block sandbox
 
-  test.fail(); // @todo Re-enable as part of https://app.asana.com/0/1202839302145209/1202922733837187/f
-
   await page.goto("/hub");
 
   await expect(


### PR DESCRIPTION
Reverts blockprotocol/blockprotocol#569. No longer needed after #571 and #572