### PR TITLE
Run Changesets as linter

### DIFF
--- a/.changeset/hello.md
+++ b/.changeset/hello.md
@@ -1,5 +1,0 @@
----
-oops: major
----
-
-testing

--- a/.changeset/hello.md
+++ b/.changeset/hello.md
@@ -1,0 +1,5 @@
+---
+oops: major
+---
+
+testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run yarn lint:changeset
         if: ${{ success() || failure() }}
         run: |
-          git pull -f origin main:main ## https://github.com/changesets/changesets/issues/517#issuecomment-884778604
+          git pull --force --no-tags origin main:main ## https://github.com/changesets/changesets/issues/517#issuecomment-884778604
           if ! yarn lint:changeset; then
             echo ''
             echo ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,19 @@ jobs:
 
       - uses: ./.github/actions/warm-up-repo
 
+      - name: Run yarn lint:changeset
+        if: ${{ success() || failure() }}
+        run: |
+          if ! yarn lint:changeset; then
+            echo ''
+            echo ''
+            echo 'ℹ️ ℹ️ ℹ️'
+            echo 'Please fix the above errors locally for the check to pass.'
+            echo 'If you don’t see them, try merging target branch into yours.'
+            echo 'ℹ️ ℹ️ ℹ️'
+            exit 1
+          fi
+
       - name: Run yarn lint:dependency-version-consistency
         if: ${{ success() || failure() }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - uses: ./.github/actions/warm-up-repo
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,15 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1000 ## Needed for Changesets to find `main` branch
 
       - uses: ./.github/actions/warm-up-repo
 
       - name: Run yarn lint:changeset
         if: ${{ success() || failure() }}
         run: |
+          git pull -f origin main:main ## https://github.com/changesets/changesets/issues/517#issuecomment-884778604
           if ! yarn lint:changeset; then
             echo ''
             echo ''
@@ -151,8 +154,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
 
       - uses: ./.github/actions/warm-up-repo
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 1000 ## Needed for Changesets to find `main` branch
+          fetch-depth: 0 ## Needed for Changesets to find `main` branch
 
       - uses: ./.github/actions/warm-up-repo
 
       - name: Run yarn lint:changeset
         if: ${{ success() || failure() }}
         run: |
-          git pull --force --no-tags origin main:main ## https://github.com/changesets/changesets/issues/517#issuecomment-884778604
+          git pull --force --no-tags origin main:main ## https://github.com/changesets/changesets/issues/517
           if ! yarn lint:changeset; then
             echo ''
             echo ''

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "fix:yarn-deduplicate": "yarn install && yarn-deduplicate --strategy=fewer && yarn install",
     "lint": "npm-run-all --continue-on-error \"lint:*\"",
     "@todo.2": "Remove the ignore argument below once react-block-loader is upgraded to 0.2 spec",
+    "lint:changeset": "changeset status",
     "lint:dependency-version-consistency": "check-dependency-version-consistency .",
     "lint:eslint": "eslint \"**/*\"",
     "lint:lockfile-lint": "lockfile-lint --path yarn.lock --allowed-hosts registry.yarnpkg.com --allowed-schemes \"https:\"",


### PR DESCRIPTION
When working on #577, I made a typo in `.chaneset/config.json` but noticed that CI was still passing. This meant that potential issues with [Changesets](https://github.com/changesets/changesets) could remain hidden until merge, thus causing delays in development.

This PR configures `changeset status` as a new linter (`yarn lint:changeset`). [Adding a malformed changeset markdown](https://github.com/blockprotocol/blockprotocol/pull/579/commits/df3236e121e8d4f71642d6bd2c0d4a438caa7a26) makes [CI fail](https://github.com/blockprotocol/blockprotocol/runs/8227047971?check_suite_focus=true#step:4:37), as expected. The same should also happen if `.changeset/config.json` gets broken in future at any point.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202922733837199