### PR TITLE
Do not require changeset markdowns in private packages

### DIFF
--- a/patches/@changesets+git+1.4.1.patch
+++ b/patches/@changesets+git+1.4.1.patch
@@ -1,0 +1,53 @@
+diff --git a/node_modules/@changesets/git/dist/git.cjs.dev.js b/node_modules/@changesets/git/dist/git.cjs.dev.js
+index 97ed365..c64789d 100644
+--- a/node_modules/@changesets/git/dist/git.cjs.dev.js
++++ b/node_modules/@changesets/git/dist/git.cjs.dev.js
+@@ -247,6 +247,10 @@ async function getChangedPackagesSinceRef({
+     const prevPkg = fileToPackage[fileName] || {
+       dir: ""
+     };
++
++    // Fixing "Some packages have been changed but no changesets were found" for private packages
++    if (pkg.packageJson.private) return;
++
+     if (pkg.dir.length > prevPkg.dir.length) fileToPackage[fileName] = pkg;
+   }));
+   return Object.values(fileToPackage) // filter, so that we have only unique packages
+diff --git a/node_modules/@changesets/git/dist/git.cjs.prod.js b/node_modules/@changesets/git/dist/git.cjs.prod.js
+index a3f7a4c..97e2799 100644
+--- a/node_modules/@changesets/git/dist/git.cjs.prod.js
++++ b/node_modules/@changesets/git/dist/git.cjs.prod.js
+@@ -139,6 +139,7 @@ async function getChangedChangesetFilesSinceRef({cwd: cwd, ref: ref}) {
+ }
+ 
+ async function getChangedPackagesSinceRef({cwd: cwd, ref: ref}) {
++  
+   const changedFiles = await getChangedFilesSince({
+     ref: ref,
+     cwd: cwd,
+@@ -151,6 +152,10 @@ async function getChangedPackagesSinceRef({cwd: cwd, ref: ref}) {
+       const prevPkg = fileToPackage[fileName] || {
+         dir: ""
+       };
++
++    // Fixing "Some packages have been changed but no changesets were found" for private packages
++    if (pkg.packageJson.private) return;
++
+       pkg.dir.length > prevPkg.dir.length && (fileToPackage[fileName] = pkg);
+     }));
+     var dir;
+diff --git a/node_modules/@changesets/git/dist/git.esm.js b/node_modules/@changesets/git/dist/git.esm.js
+index 9f25fb9..c58acc3 100644
+--- a/node_modules/@changesets/git/dist/git.esm.js
++++ b/node_modules/@changesets/git/dist/git.esm.js
+@@ -236,6 +236,10 @@ async function getChangedPackagesSinceRef({
+     const prevPkg = fileToPackage[fileName] || {
+       dir: ""
+     };
++
++    // Fixing "Some packages have been changed but no changesets were found" for private packages
++    if (pkg.packageJson.private) return;
++
+     if (pkg.dir.length > prevPkg.dir.length) fileToPackage[fileName] = pkg;
+   }));
+   return Object.values(fileToPackage) // filter, so that we have only unique packages


### PR DESCRIPTION
This patch follows #579 and is similar to #583. 

Now that we run `yarn changeset status` in pull requests, we get CI failures when a package is changed but a changeset file is missing (see [example run](https://github.com/blockprotocol/blockprotocol/runs/8260602543?check_suite_focus=true#step:5:1) for https://github.com/blockprotocol/blockprotocol/pull/584). This error is fixable by running `yarn changeset add --empty`, but doing so can be annoying each time.

This PR patches `@changesets/git` by ignoring private packages in `yarn changeset status`. When future PRs modify `@local/*` packages or `site`, CI should no longer fail. This can be tested locally by checking out this branch, then changing a file in a private package and finally running `yarn lint:changeset`. Changing publishable packages without creating `.changeset/*.md` will still exit with non-zero.

I might create an upstream issue later. If I do, I’ll post the link here.