### PR TITLE
Fix overflowing breadcrumbs issue on mobile

### DIFF
--- a/site/src/components/navbar/mobile-breadcrumbs.tsx
+++ b/site/src/components/navbar/mobile-breadcrumbs.tsx
@@ -18,9 +18,7 @@ export const MobileBreadcrumbs: FunctionComponent<MobileBreadcrumbsProps> = ({
 }) => {
   return (
     <Breadcrumbs
-      sx={{
-        marginTop: 2,
-      }}
+      sx={{ marginTop: 2 }}
       separator={
         <FontAwesomeIcon
           sx={{ fontSize: 14, color: ({ palette }) => palette.gray[40] }}
@@ -39,11 +37,17 @@ export const MobileBreadcrumbs: FunctionComponent<MobileBreadcrumbsProps> = ({
                   : item.href
                 : `#${item.anchor}`
             }
+            whiteSpace="normal"
           >
             {item.title}
           </Link>
         ) : (
-          <Typography key={item.title} variant="bpSmallCopy" color="inherit">
+          <Typography
+            key={item.title}
+            variant="bpSmallCopy"
+            color="inherit"
+            whiteSpace="normal"
+          >
             {item.title}
           </Typography>
         ),


### PR DESCRIPTION
## Purpose of this PR
On mobile devices, some of the long breadcrumbs are overflowing from screen, and that looks confusing. This PR enables line-breaks on mobile breadcrumbs, so it does not overflow.

## Demo
| Before   | After |
|----------|-------------|
| ![](https://user-images.githubusercontent.com/39553853/189288396-026e3f6d-b583-41fa-99ef-d4337063ee9d.png) |  ![](https://user-images.githubusercontent.com/39553853/189288400-c1a3cd60-9d44-478a-a0e0-d27f39ae19db.png) |

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202787635216896