### PR TITLE
Add cd step to post-install instructions

### DIFF
--- a/.changeset/fast-ducks-scream.md
+++ b/.changeset/fast-ducks-scream.md
@@ -1,0 +1,5 @@
+---
+"create-block-app": patch
+---
+
+add cd step to post-install instructions

--- a/packages/create-block-app/create-block-app.js
+++ b/packages/create-block-app/create-block-app.js
@@ -157,7 +157,18 @@ const usage = commandLineUsage(helpSections);
     await fs.writeJson(blockMetadataPath, blockMetadata, { spaces: 2 });
   }
 
+  const chalk = (await import("chalk")).default;
+
   console.log(
-    `Your ${blockName} block is ready to code in ${resolvedBlockPath}.\nRun 'yarn install && yarn dev' to get started`,
+    chalk.bold("-".repeat(Math.min(process.stdout.columns ?? 48, 48))),
+  );
+  console.log(
+    `Your ${chalk.bold(blockName)} block is ready to code in ${chalk.bold(
+      resolvedBlockPath,
+    )}.\n` +
+      `Run ${chalk.blue(`cd ${resolvedBlockPath}`)} and then \n` +
+      `${chalk.blue("yarn install && yarn dev")} or ${chalk.blue(
+        "npm install && npm run dev",
+      )} to get started`,
   );
 })();

--- a/packages/create-block-app/create-block-app.js
+++ b/packages/create-block-app/create-block-app.js
@@ -171,7 +171,7 @@ const usage = commandLineUsage(helpSections);
   );
   console.log(
     `Your ${chalk.bold(blockName)} block is ready to code in ${chalk.bold(
-      escapedPath,
+      resolvedBlockPath,
     )}\n` +
       `Run ${chalk.blue(`cd ${escapedPath}`)} and then \n` +
       `${chalk.blue("yarn install && yarn dev")} or ${chalk.blue(

--- a/packages/create-block-app/create-block-app.js
+++ b/packages/create-block-app/create-block-app.js
@@ -159,14 +159,20 @@ const usage = commandLineUsage(helpSections);
 
   const chalk = (await import("chalk")).default;
 
+  const relativeBlockPath = path.relative(process.cwd(), resolvedBlockPath);
+
+  const escapedPath = !/[^%+,-./:=@_0-9A-Za-z]/.test(relativeBlockPath)
+    ? relativeBlockPath
+    : `'${relativeBlockPath.replace(/'/g, `'"'`)}'`;
+
   console.log(
     chalk.bold("-".repeat(Math.min(process.stdout.columns ?? 48, 48))),
   );
   console.log(
     `Your ${chalk.bold(blockName)} block is ready to code in ${chalk.bold(
-      resolvedBlockPath,
-    )}.\n` +
-      `Run ${chalk.blue(`cd ${resolvedBlockPath}`)} and then \n` +
+      escapedPath,
+    )}\n` +
+      `Run ${chalk.blue(`cd ${escapedPath}`)} and then \n` +
       `${chalk.blue("yarn install && yarn dev")} or ${chalk.blue(
         "npm install && npm run dev",
       )} to get started`,

--- a/packages/create-block-app/package.json
+++ b/packages/create-block-app/package.json
@@ -21,6 +21,7 @@
   },
   "bin": "create-block-app.js",
   "dependencies": {
+    "chalk": "5.0.1",
     "command-line-args": "^5.2.1",
     "command-line-usage": "^6.1.3",
     "fs-extra": "^10.1.0",

--- a/site/src/_pages/docs/1_developing-blocks.mdx
+++ b/site/src/_pages/docs/1_developing-blocks.mdx
@@ -41,7 +41,7 @@ Bear in mind that a block schema will not be automatically generated as part of 
 1.  Move to a folder where you want to create your block.
 1.  Run `npx create-block-app@latest your-block-name --template template`.
 1.  Switch to your new folder: `cd [your-block-name]`.
-1.  Run `yarn install && yarn dev`.
+1.  Run `yarn install && yarn dev` or `npm install && npm run dev`.
 1.  Open [http://localhost:63212](http://localhost:63212/) in your browser to see your block.
 
 ## The development environment
@@ -50,10 +50,10 @@ The `create-block-app` package provides everything you need to develop a block.
 
 - `src/app.tsx` or `src/app.ts` contains your block’s code.
   - You can include dependencies in your block but bear in mind that the more dependencies you add, the bigger your block’s download size will be. Common dependencies which you can reasonably expect an embedding application to provide (e.g. React) can be defined as `peerDependencies` in `package.json`.
-- `yarn dev` will run your block in development mode, serving it locally with hot reloading at [http://localhost:63212](http://localhost:63212).
+- `yarn dev` or `npm run dev` will run your block in development mode, serving it locally with hot reloading at [http://localhost:63212](http://localhost:63212).
   - This uses the file at `src/dev.tsx` to render your block within a mock embedding application called `MockBlockDock`.
   - By default, dev mode will also show you the properties that are being passed to your block and the contents of the mock datastore. Remove `debug` from `MockBlockDock` to turn this off.
-- `yarn build` will:
+- `yarn build` or `npm run build` will:
   - Bundle the component into a single source file (without any dependencies listed as `peerDependencies`).
   - Generate a JSON schema from the `BlockEntityProperties` type representing the data interface with the block. If your block folder contains `block-schema.json`, this custom schema will be used instead.
   - Generate a `block-metadata.json` file which:
@@ -170,21 +170,21 @@ You can also review the messages defined in the graph specification [here](/docs
 To load your block into HASH:
 
 1.  Visit the [HASH repo](https://github.com/hashintel/hash/tree/main/packages/hash) and follow the instructions to run HASH locally.
-1.  In your block’s directory, run `yarn dev`. This will serve your block locally at a localhost URL in development mode and will reload if you make changes to your source code. Alternatively, you can run `yarn build && yarn serve` to test a production build of your block which will not automatically rebuild if you make changes to the source code.
+1.  In your block’s directory, run `yarn dev` or `npm run dev`. This will serve your block locally at a localhost URL in development mode and will reload if you make changes to your source code. Alternatively, you can run `yarn build && yarn serve` to test a production build of your block which will not automatically rebuild if you make changes to the source code.
 1.  Copy that localhost URL to your clipboard.
 1.  In HASH, create or navigate to a Page.
 1.  Find the […] menu button on the left of a block in the Page (you should see this button under the title on a new page).
 1.  Open that menu and paste the block’s localhost URL into the “Load block from URL…” input field and click "Load block".
 
-If you’re running your block in dev mode (`yarn dev`) and you make changes to the source code, your block will rebuild and HASH should automatically refresh the page. If you’re running your block in production mode, you will need to run `yarn build` from your block folder and reload your block manually in HASH by repeating steps 5-6 again.
+If you’re running your block in dev mode (`yarn dev` or `npm run dev`) and you make changes to the source code, your block will rebuild and HASH should automatically refresh the page. If you’re running your block in production mode, you will need to run `yarn build` from your block folder and reload your block manually in HASH by repeating steps 5-6 again.
 
 ## Build
 
-Once you’ve finished writing your block, run `yarn build`.
+Once you’ve finished writing your block, run `yarn build` or `npm run build`.
 
 This will produce a compiled version of your code in the `dist` folder, along with metadata files describing your block (`block-metadata.json`), and the data it accepts (`block-schema.json`).
 
-It is worth updating the `blockprotocol` object in `package.json` to include your own `icon`, `image`, and `examples` for your block. These will automatically be included in the `block-metadata.json` produced after running `yarn build`.
+It is worth updating the `blockprotocol` object in `package.json` to include your own `icon`, `image`, and `examples` for your block. These will automatically be included in the `block-metadata.json` produced after running `yarn build` or `npm run build`.
 
 You now have a block package that you can provide to apps to use, by **publishing it on the Block Hub**.
 


### PR DESCRIPTION
After creating a block, we tell users they can run 'yarn install && yarn dev' to get started.

Actually they'll need to change into the block dir first. This PR adds that step to the instructions, and a bit of colour.

<img width="716" alt="Screenshot 2022-09-13 at 17 39 01" src="https://user-images.githubusercontent.com/37743469/189958360-5ecb42ff-8c1a-4645-b0de-a9bd556fe4a7.png">
