### PR TITLE
Add list of links to messages on graph spec page

### DIFF
--- a/site/src/components/service-message-list.tsx
+++ b/site/src/components/service-message-list.tsx
@@ -6,6 +6,7 @@ import { Box, Typography } from "@mui/material";
 import { Fragment, FunctionComponent } from "react";
 
 import { JsonSchema } from "../lib/json-schema";
+import { Link } from "./link";
 import { mdxComponents } from "./mdx/mdx-components";
 
 const DataType: FunctionComponent<{ propertySchema: JsonSchema }> = ({
@@ -100,6 +101,9 @@ const ServiceMessageData: FunctionComponent<{
   );
 };
 
+const generateServiceMessageAnchor = (messageName: string) =>
+  `message:${messageName}`;
+
 const ServiceMessage: FunctionComponent<{
   message: ServiceMessageDefinition;
 }> = ({ message }) => {
@@ -119,7 +123,7 @@ const ServiceMessage: FunctionComponent<{
   } = message;
 
   return (
-    <Box sx={{ mb: 4 }}>
+    <Box sx={{ mb: 4 }} id={generateServiceMessageAnchor(messageName)}>
       <MdxH5>
         <MdxCode>{messageName}</MdxCode>
       </MdxH5>
@@ -174,6 +178,21 @@ export const ServiceMessageList: FunctionComponent<{
 }> = ({ serviceDefinition }) => {
   return (
     <Box>
+      <Box>
+        {serviceDefinition.messages.map(({ messageName, source }) => (
+          <Typography key={messageName} mb={1}>
+            <Link
+              href={`#${generateServiceMessageAnchor(messageName)}`}
+              sx={{ fontWeight: 600 }}
+            >
+              {messageName}
+            </Link>
+            <Typography component="span" variant="bpSmallCopy" ml={1}>
+              [{source}]
+            </Typography>
+          </Typography>
+        ))}
+      </Box>
       {serviceDefinition.messages.map((message) => (
         <ServiceMessage key={message.messageName} message={message} />
       ))}


### PR DESCRIPTION
This PR adds a list of links to messages descriptions above the list of full message description, to make it easier to see at once the full list of messages, and go to the one of interest.

<img width="1418" alt="Screenshot 2022-09-13 at 17 56 59" src="https://user-images.githubusercontent.com/37743469/189962008-adad7814-3981-4a7d-baf5-2cb4f59e3499.png">
