### PR TITLE
Fix block-template-html build script on Windows

### DIFF
--- a/.changeset/calm-buttons-sort.md
+++ b/.changeset/calm-buttons-sort.md
@@ -1,0 +1,5 @@
+---
+"block-template-html": patch
+---
+
+Fixed package scripts to run correctly on CMD

--- a/packages/block-template-html/package.json
+++ b/packages/block-template-html/package.json
@@ -18,10 +18,10 @@
     "url": "https://hash.ai"
   },
   "scripts": {
-    "build": "rimraf dist; cp -R src dist; cp block-metadata.json dist; cp block-schema.json dist; cp -R public dist;",
-    "dev": "echo \"Serving at http://localhost:63212\"; http-server -p 63212 ./dev",
+    "build": "rimraf dist && cp -R src dist && cp block-metadata.json dist && cp block-schema.json dist && cp -R public dist",
+    "dev": "echo \"Serving at http://localhost:63212\" && http-server -p 63212 ./dev",
     "format": "prettier \"**/*\" --write --ignore-unknown",
-    "prepare": "rimraf ./dev/src; lnk -f ./src ./dev",
+    "prepare": "rimraf ./dev/src && lnk -f ./src ./dev",
     "serve": "block-scripts serve"
   },
   "prettier": {


### PR DESCRIPTION
This PR fixes the build script on block-template-html on Windows.

Running yarn build on cmd was removing `block-metadata.json`, `block-schema.json`, `src/*` and `dev/*` because cmd doesn't recognize `;` as a chaining operator. Replaced the `;` operator with `&&`.

[Task](https://app.asana.com/0/1200211978612931/1202768723281652/f)