### PR TITLE
Parallelize integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,7 @@ jobs:
           path: |
             ${{ env.BLOCK_DIR_PATH }}
             !${{ env.BLOCK_DIR_PATH }}/node_modules/**
+          retention-days: 14
 
   site-integration-tests:
     name: "Site integration tests"
@@ -321,11 +322,12 @@ jobs:
         with:
           name: site-integration-tests-playwright-report-${{ matrix.project }}
           path: site/playwright-report
+          retention-days: 14
 
       - name: Upload artifact playwright-var
         uses: actions/upload-artifact@v3
         if: ${{ success() || failure() }}
         with:
           name: site-integration-tests-var-${{ matrix.project }}
-          path: |
-            var
+          path: var
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,7 @@ jobs:
 
       - uses: ./.github/actions/warm-up-repo
         with:
-          playwright-deps: ${{ ((matrix.device == 'iphone' || matrix.device == 'safari' && 'webkit') || (matrix.device == 'firefox' && 'firefox') || 'chrome' }}
+          playwright-deps: ${{ (matrix.device == 'iphone' || matrix.device == 'safari' && 'webkit') || (matrix.device == 'firefox' && 'firefox') || 'chrome' }}
 
       - name: Create temp files and folders
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,12 +233,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        project:
-          - integration-chrome
-          - integration-firefox
-          - integration-iphone
-          - integration-pixel
-          - integration-safari
+        device:
+          - chrome
+          - firefox
+          - iphone
+          - pixel
+          - safari
     steps:
       - uses: actions/checkout@v3
 
@@ -287,7 +287,7 @@ jobs:
 
       - name: Run Playwright tests
         if: ${{ success() || failure() }}
-        run: yarn workspace @blockprotocol/site playwright test --project=${{ matrix.project }}
+        run: yarn workspace @blockprotocol/site playwright test --project=integration-${{ matrix.device }}
 
       - name: Stop frontend ## Updates .nyc_output
         if: ${{ success() || failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
           docker stop verdaccio
 
       - name: Upload block folder as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ success() || failure() }}
         with:
           name: ${{ env.BLOCK_NAME }}
@@ -230,6 +230,14 @@ jobs:
   site-integration-tests:
     name: "Site integration tests"
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project:
+          - integration-chrome
+          - integration-firefox
+          - integration-iphone
+          - integration-pixel
+          - integration-safari
     steps:
       - uses: actions/checkout@v3
 
@@ -278,7 +286,7 @@ jobs:
 
       - name: Run Playwright tests
         if: ${{ success() || failure() }}
-        run: yarn workspace @blockprotocol/site playwright test --project=integration-chrome --project=integration-firefox --project=integration-safari --project=integration-iphone --project=integration-pixel
+        run: yarn workspace @blockprotocol/site playwright test --project=${{ matrix.project }}
 
       - name: Stop frontend ## Updates .nyc_output
         if: ${{ success() || failure() }}
@@ -296,7 +304,7 @@ jobs:
         name: Upload coverage to https://app.codecov.io/gh/blockprotocol/blockprotocol
         with:
           fail_ci_if_error: true
-          flags: site-integration
+          flags: site-integration-${{ matrix.project }}
           files: coverage/lcov.info
 
       - name: Show DB logs
@@ -309,15 +317,15 @@ jobs:
 
       - name: Upload artifact playwright-report
         if: ${{ success() || failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
-          name: site-integration-tests-playwright-report
+          name: site-integration-tests-playwright-report-${{ matrix.project }}
           path: site/playwright-report
 
       - name: Upload artifact playwright-var
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ success() || failure() }}
         with:
-          name: site-integration-tests-var
+          name: site-integration-tests-var-${{ matrix.project }}
           path: |
             var

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,7 @@ jobs:
         name: Upload coverage to https://app.codecov.io/gh/blockprotocol/blockprotocol
         with:
           fail_ci_if_error: true
-          flags: site-integration-${{ matrix.project }}
+          flags: site-integration-${{ matrix.device }}
           files: coverage/lcov.info
 
       - name: Show DB logs
@@ -320,7 +320,7 @@ jobs:
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v3
         with:
-          name: site-integration-tests-playwright-report-${{ matrix.project }}
+          name: site-integration-tests-playwright-report-${{ matrix.device }}
           path: site/playwright-report
           retention-days: 14
 
@@ -328,6 +328,6 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ success() || failure() }}
         with:
-          name: site-integration-tests-var-${{ matrix.project }}
+          name: site-integration-tests-var-${{ matrix.device }}
           path: var
           retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,7 @@ jobs:
     name: "Site integration tests"
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         device:
           - chrome
@@ -252,7 +253,7 @@ jobs:
 
       - uses: ./.github/actions/warm-up-repo
         with:
-          playwright-deps: ${{ (matrix.device == 'iphone' || matrix.device == 'safari' && 'webkit') || (matrix.device == 'firefox' && 'firefox') || 'chrome' }}
+          playwright-deps: ${{ ((matrix.device == 'iphone' || matrix.device == 'safari') && 'webkit') || (matrix.device == 'firefox' && 'firefox') || 'chrome' }}
 
       - name: Create temp files and folders
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,7 @@ jobs:
 
       - uses: ./.github/actions/warm-up-repo
         with:
-          playwright-deps: ${{ (matrix.device == 'iphone' || matrix.device == 'safari') && 'webkit' || (matrix.device == 'firefox') && 'firefox' || 'chrome' }}
+          playwright-deps: ${{ ((matrix.device == 'iphone' || matrix.device == 'safari' && 'webkit') || (matrix.device == 'firefox' && 'firefox') || 'chrome' }}
 
       - name: Create temp files and folders
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,7 @@ jobs:
 
       - uses: ./.github/actions/warm-up-repo
         with:
-          playwright-deps: chrome firefox webkit
+          playwright-deps: ${{ (matrix.device == 'iphone' || matrix.device == 'safari') && 'webkit' || (matrix.device == 'firefox') && 'firefox' || 'chrome' }}
 
       - name: Create temp files and folders
         run: |


### PR DESCRIPTION
When working on #565, I had to wait for 23-25 minutes to see if Integration test were failing. We’ve been slowly adding more and more tests since their introduction in https://github.com/blockprotocol/blockprotocol/issues/434, which has contributed to the overall performance of the pipeline.

This PR splits ‘Site integration tests’ into five jobs, one per device (browser). Doing so drops CI wait time to ≈7-9 minutes,which reduces feedback cycle and thus improves DX.

Current approach does not share `next build`, so the app is bundled five times instead of one. This is not ideal, but still quicker than having a separate build job that propagates an artifact to five downstream Playwright jobs. A two-stage setup would require us to have an extra call to `warm-up-repo` (`yarn install`), thus adding ≈2 minutes to the total CI duration. We may revisit the trade-offs after upgrading to Yarn 3 with its [focus](https://yarnpkg.com/cli/workspaces/focus) feature.

In addition to splitting the CI job, I have also changed artifact retention policy. Files are now deleted after 14 days instead of 90, which I believe is the default. When a lot of tests fail, Playwright report may be up to 0.5G in size, which is not great for billing. Even if we don’t pay for storage because the repo is open-source, it is extremely unlikely that we’ll ever download CI artifacts after 2 weeks. They can be always regenerated by re-running CI, if needed.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202970955514130