### PR TITLE
Use `React.lazy` in `mock-block-dock` to optimize MUI loading

### DIFF
--- a/.changeset/friendly-pumpkins-complain.md
+++ b/.changeset/friendly-pumpkins-complain.md
@@ -1,0 +1,5 @@
+---
+"mock-block-dock": patch
+---
+
+Use `React.lazy` in `mock-block-dock` to optimize MUI loading

--- a/packages/block-template-react/src/dev.tsx
+++ b/packages/block-template-react/src/dev.tsx
@@ -27,8 +27,7 @@ const DevApp = () => {
         properties: { name: "World" },
       }}
       blockInfo={packageJSON.blockprotocol}
-      debug
-      // debug // remove this to start with the debug UI minimised. You can also toggle it in the UI
+      debug // remove this to start with the debug UI minimised. You can also toggle it in the UI
       // hideDebugToggle <- uncomment this to disable the debug UI entirely
       // initialEntities={[]} <- customise the entities in the datastore (blockEntity is always added, if you provide it)
       // initialEntityTypes={[]} <- customise the entity types in the datastore

--- a/packages/block-template-react/src/dev.tsx
+++ b/packages/block-template-react/src/dev.tsx
@@ -27,7 +27,8 @@ const DevApp = () => {
         properties: { name: "World" },
       }}
       blockInfo={packageJSON.blockprotocol}
-      debug // remove this to start with the debug UI minimised. You can also toggle it in the UI
+      debug
+      // debug // remove this to start with the debug UI minimised. You can also toggle it in the UI
       // hideDebugToggle <- uncomment this to disable the debug UI entirely
       // initialEntities={[]} <- customise the entities in the datastore (blockEntity is always added, if you provide it)
       // initialEntityTypes={[]} <- customise the entity types in the datastore

--- a/packages/mock-block-dock/src/mock-block-dock-ui.tsx
+++ b/packages/mock-block-dock/src/mock-block-dock-ui.tsx
@@ -4,18 +4,13 @@ import { FunctionComponent, ReactNode } from "react";
 import styles from "./assets/debug-view-styles.module.css";
 import { DebugView } from "./debug-view";
 import { OffSwitch } from "./debug-view/icons";
+import { useMockBlockDockContext } from "./mock-block-dock-context";
 
-export interface MockBlockDockUiProps {
-  debugMode: boolean;
-  onDebugModeChange: (debugMode: boolean) => void;
-  children: ReactNode;
-}
-
-export const MockBlockDockUi: FunctionComponent<MockBlockDockUiProps> = ({
-  debugMode,
-  onDebugModeChange,
+export const MockBlockDockUi: FunctionComponent<{ children: ReactNode }> = ({
   children,
 }) => {
+  const { setDebugMode, debugMode } = useMockBlockDockContext();
+
   return debugMode ? (
     <DebugView>{children}</DebugView>
   ) : (
@@ -24,7 +19,7 @@ export const MockBlockDockUi: FunctionComponent<MockBlockDockUiProps> = ({
         <button
           className={styles["mbd-debug-mode-toggle"]}
           type="button"
-          onClick={() => onDebugModeChange(true)}
+          onClick={() => setDebugMode(true)}
         >
           Preview Mode
           <OffSwitch />

--- a/packages/mock-block-dock/src/mock-block-dock-ui.tsx
+++ b/packages/mock-block-dock/src/mock-block-dock-ui.tsx
@@ -1,0 +1,36 @@
+import { Box } from "@mui/material";
+import { FunctionComponent, ReactNode } from "react";
+
+import styles from "./assets/debug-view-styles.module.css";
+import { DebugView } from "./debug-view";
+import { OffSwitch } from "./debug-view/icons";
+
+export interface MockBlockDockUiProps {
+  debugMode: boolean;
+  onDebugModeChange: (debugMode: boolean) => void;
+  children: ReactNode;
+}
+
+export const MockBlockDockUi: FunctionComponent<MockBlockDockUiProps> = ({
+  debugMode,
+  onDebugModeChange,
+  children,
+}) => {
+  return debugMode ? (
+    <DebugView>{children}</DebugView>
+  ) : (
+    <Box>
+      <Box className={styles["mbd-debug-mode-toggle-header"]}>
+        <button
+          className={styles["mbd-debug-mode-toggle"]}
+          type="button"
+          onClick={() => onDebugModeChange(true)}
+        >
+          Preview Mode
+          <OffSwitch />
+        </button>
+      </Box>
+      {children}
+    </Box>
+  );
+};

--- a/packages/mock-block-dock/src/mock-block-dock.tsx
+++ b/packages/mock-block-dock/src/mock-block-dock.tsx
@@ -186,17 +186,12 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps> = ({
     }
   }, [graphService, graphServiceCallbacks]);
 
-  const wrappedBlockRenderer = (
+  const blockRendererWithBorder = (
     <div
-      ref={wrapperRef}
-      style={
-        debugMode
-          ? {
-              border: "1px dashed rgb(0,0,0,0.1)",
-              marginTop: 30,
-            }
-          : {}
-      }
+      style={{
+        border: "1px dashed rgb(0,0,0,0.1)",
+        marginTop: 30,
+      }}
     >
       {graphService ? (
         <BlockRenderer
@@ -236,13 +231,15 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps> = ({
       setEntityIdOfEntityForBlock={setEntityIdOfEntityForBlock}
       updateEntity={graphServiceCallbacks.updateEntity}
     >
-      <Suspense>
-        {hideDebugToggle && !debugMode ? (
-          wrappedBlockRenderer
-        ) : (
-          <MockBlockDockUi>{wrappedBlockRenderer}</MockBlockDockUi>
-        )}
-      </Suspense>
+      <div ref={wrapperRef}>
+        <Suspense>
+          {hideDebugToggle && !debugMode ? (
+            blockRendererWithBorder
+          ) : (
+            <MockBlockDockUi>{blockRendererWithBorder}</MockBlockDockUi>
+          )}
+        </Suspense>
+      </div>
     </MockBlockDockProvider>
   );
 };

--- a/packages/mock-block-dock/src/mock-block-dock.tsx
+++ b/packages/mock-block-dock/src/mock-block-dock.tsx
@@ -240,12 +240,7 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps> = ({
         {hideDebugToggle && !debugMode ? (
           wrappedBlockRenderer
         ) : (
-          <MockBlockDockUi
-            debugMode={debugMode}
-            onDebugModeChange={() => setDebugMode(true)}
-          >
-            {wrappedBlockRenderer}
-          </MockBlockDockUi>
+          <MockBlockDockUi>{wrappedBlockRenderer}</MockBlockDockUi>
         )}
       </Suspense>
     </MockBlockDockProvider>

--- a/packages/mock-block-dock/src/mock-block-dock.tsx
+++ b/packages/mock-block-dock/src/mock-block-dock.tsx
@@ -7,17 +7,24 @@ import {
   LinkedAggregationDefinition,
 } from "@blockprotocol/graph";
 import { useGraphEmbedderService } from "@blockprotocol/graph/react";
-import { Box } from "@mui/material";
-import { ComponentType, FunctionComponent, useEffect, useRef } from "react";
+import {
+  ComponentType,
+  FunctionComponent,
+  lazy,
+  Suspense,
+  useEffect,
+  useRef,
+} from "react";
 
-import styles from "./assets/debug-view-styles.module.css";
 import { BlockRenderer } from "./block-renderer";
-import { DebugView } from "./debug-view";
-import { OffSwitch } from "./debug-view/icons";
 import { MockBlockDockProvider } from "./mock-block-dock-context";
 import { useDefaultState } from "./use-default-state";
 import { useMockBlockProps } from "./use-mock-block-props";
 import { useSendGraphValue } from "./use-send-graph-value";
+
+const MockBlockDockUi = lazy(async () => ({
+  default: (await import("./mock-block-dock-ui")).MockBlockDockUi,
+}));
 
 type BlockDefinition =
   | { ReactComponent: ComponentType<any> }
@@ -59,16 +66,16 @@ type MockBlockDockProps = {
  * It provides the functionality specified in the Block Protocol, and mock data which can be customized via props.
  * See README.md for usage instructions.
  * @param blockDefinition the source for the block and any additional metadata required
- * @param [blockEntity] the starting properties for the block entity
- * @param [blockInfo] metadata about the block
- * @param [blockSchema] the schema for the block entity
- * @param [debug = false] display debugging information
- * @param [hideDebugToggle = false] hide the ability to toggle the debug UI
- * @param [initialEntities] the entities to include in the data store (NOT the block entity, which is always provided)
- * @param [initialEntityTypes] the entity types to include in the data store (NOT the block's type, which is always provided)
- * @param [initialLinks] the links to include in the data store
- * @param [initialLinkedAggregations] The linkedAggregation DEFINITIONS to include in the data store (results will be resolved automatically)
- * @param [readonly = false] whether the block should display in readonly mode or not
+ * @param blockDefinition.blockEntity the starting properties for the block entity
+ * @param blockDefinition.blockInfo metadata about the block
+ * @param blockDefinition.blockSchema the schema for the block entity
+ * @param blockDefinition.debug `= false` display debugging information
+ * @param blockDefinition.hideDebugToggle `= false` hide the ability to toggle the debug UI
+ * @param blockDefinition.initialEntities the entities to include in the data store (NOT the block entity, which is always provided)
+ * @param blockDefinition.initialEntityTypes the entity types to include in the data store (NOT the block's type, which is always provided)
+ * @param blockDefinition.initialLinks the links to include in the data store
+ * @param blockDefinition.initialLinkedAggregations The linkedAggregation DEFINITIONS to include in the data store (results will be resolved automatically)
+ * @param blockDefinition.readonly `= false` whether the block should display in readonly mode or not
  */
 export const MockBlockDock: FunctionComponent<MockBlockDockProps> = ({
   blockDefinition,
@@ -179,7 +186,7 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps> = ({
     }
   }, [graphService, graphServiceCallbacks]);
 
-  const Component = (
+  const wrappedBlockRenderer = (
     <div
       ref={wrapperRef}
       style={
@@ -229,25 +236,18 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps> = ({
       setEntityIdOfEntityForBlock={setEntityIdOfEntityForBlock}
       updateEntity={graphServiceCallbacks.updateEntity}
     >
-      {!debugMode ? (
-        <Box>
-          {!hideDebugToggle && (
-            <Box className={styles["mbd-debug-mode-toggle-header"]}>
-              <button
-                className={styles["mbd-debug-mode-toggle"]}
-                type="button"
-                onClick={() => setDebugMode(true)}
-              >
-                Preview Mode
-                <OffSwitch />
-              </button>
-            </Box>
-          )}
-          {Component}
-        </Box>
-      ) : (
-        <DebugView>{Component}</DebugView>
-      )}
+      <Suspense>
+        {hideDebugToggle && !debugMode ? (
+          wrappedBlockRenderer
+        ) : (
+          <MockBlockDockUi
+            debugMode={debugMode}
+            onDebugModeChange={() => setDebugMode(true)}
+          >
+            {wrappedBlockRenderer}
+          </MockBlockDockUi>
+        )}
+      </Suspense>
     </MockBlockDockProvider>
   );
 };

--- a/packages/mock-block-dock/src/mock-block-dock.tsx
+++ b/packages/mock-block-dock/src/mock-block-dock.tsx
@@ -65,6 +65,7 @@ type MockBlockDockProps = {
  * A component which acts as a mock embedding application for Block Protocol blocks.
  * It provides the functionality specified in the Block Protocol, and mock data which can be customized via props.
  * See README.md for usage instructions.
+ * @param props component props
  * @param props.blockDefinition the source for the block and any additional metadata required
  * @param [props.blockEntity] the starting properties for the block entity
  * @param [props.blockInfo] metadata about the block

--- a/packages/mock-block-dock/src/mock-block-dock.tsx
+++ b/packages/mock-block-dock/src/mock-block-dock.tsx
@@ -65,17 +65,17 @@ type MockBlockDockProps = {
  * A component which acts as a mock embedding application for Block Protocol blocks.
  * It provides the functionality specified in the Block Protocol, and mock data which can be customized via props.
  * See README.md for usage instructions.
- * @param blockDefinition the source for the block and any additional metadata required
- * @param blockDefinition.blockEntity the starting properties for the block entity
- * @param blockDefinition.blockInfo metadata about the block
- * @param blockDefinition.blockSchema the schema for the block entity
- * @param blockDefinition.debug `= false` display debugging information
- * @param blockDefinition.hideDebugToggle `= false` hide the ability to toggle the debug UI
- * @param blockDefinition.initialEntities the entities to include in the data store (NOT the block entity, which is always provided)
- * @param blockDefinition.initialEntityTypes the entity types to include in the data store (NOT the block's type, which is always provided)
- * @param blockDefinition.initialLinks the links to include in the data store
- * @param blockDefinition.initialLinkedAggregations The linkedAggregation DEFINITIONS to include in the data store (results will be resolved automatically)
- * @param blockDefinition.readonly `= false` whether the block should display in readonly mode or not
+ * @param props.blockDefinition the source for the block and any additional metadata required
+ * @param [props.blockEntity] the starting properties for the block entity
+ * @param [props.blockInfo] metadata about the block
+ * @param [props.blockSchema] the schema for the block entity
+ * @param [props.debug=false] display debugging information
+ * @param [props.hideDebugToggle=false] hide the ability to toggle the debug UI
+ * @param [props.initialEntities] the entities to include in the data store (NOT the block entity, which is always provided)
+ * @param [props.initialEntityTypes] the entity types to include in the data store (NOT the block's type, which is always provided)
+ * @param [props.initialLinks] the links to include in the data store
+ * @param [props.initialLinkedAggregations] The linkedAggregation DEFINITIONS to include in the data store (results will be resolved automatically)
+ * @param [props.readonly=false] whether the block should display in readonly mode or not
  */
 export const MockBlockDock: FunctionComponent<MockBlockDockProps> = ({
   blockDefinition,


### PR DESCRIPTION
The goal of this PR is to optimize sandbox performance. The changes cannot be tested in full until we've released the package on `esm.sh`. Manual smoke-testing testing can be done locally by following these steps:

1. Build MBD  
   ```sh
   cd packages/mock-block-dock
   yarn build
   ```

2. Launch React template   
   ```sh
   cd packages/block-template-react
   yarn dev
   ```

3. Replace `debug` with `hideDebugToggle` in `packages/block-template-react/src/dev.tsx` 

4. Confirm that MBD at http://localhost:63212/ still works

---

- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202449143008136