### PR TITLE
Hotfix mock-block-dock

### DIFF
--- a/.changeset/rare-teachers-train.md
+++ b/.changeset/rare-teachers-train.md
@@ -1,0 +1,5 @@
+---
+"mock-block-dock": patch
+---
+
+Hide dashed border when `hideDebugToggle`is true

--- a/packages/mock-block-dock/src/mock-block-dock-ui.tsx
+++ b/packages/mock-block-dock/src/mock-block-dock-ui.tsx
@@ -11,8 +11,19 @@ export const MockBlockDockUi: FunctionComponent<{ children: ReactNode }> = ({
 }) => {
   const { setDebugMode, debugMode } = useMockBlockDockContext();
 
+  const childrenWithBorder = (
+    <div
+      style={{
+        border: "1px dashed rgb(0,0,0,0.1)",
+        marginTop: 30,
+      }}
+    >
+      {children}
+    </div>
+  );
+
   return debugMode ? (
-    <DebugView>{children}</DebugView>
+    <DebugView>{childrenWithBorder}</DebugView>
   ) : (
     <Box>
       <Box className={styles["mbd-debug-mode-toggle-header"]}>
@@ -25,7 +36,7 @@ export const MockBlockDockUi: FunctionComponent<{ children: ReactNode }> = ({
           <OffSwitch />
         </button>
       </Box>
-      {children}
+      {childrenWithBorder}
     </Box>
   );
 };

--- a/packages/mock-block-dock/src/mock-block-dock.tsx
+++ b/packages/mock-block-dock/src/mock-block-dock.tsx
@@ -187,31 +187,22 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps> = ({
     }
   }, [graphService, graphServiceCallbacks]);
 
-  const blockRendererWithBorder = (
-    <div
-      style={{
-        border: "1px dashed rgb(0,0,0,0.1)",
-        marginTop: 30,
-      }}
-    >
-      {graphService ? (
-        <BlockRenderer
-          customElement={
-            "customElement" in blockDefinition
-              ? blockDefinition.customElement
-              : undefined
-          }
-          html={"html" in blockDefinition ? blockDefinition.html : undefined}
-          properties={propsToInject}
-          ReactComponent={
-            "ReactComponent" in blockDefinition
-              ? blockDefinition.ReactComponent
-              : undefined
-          }
-        />
-      ) : null}
-    </div>
-  );
+  const blockRenderer = graphService ? (
+    <BlockRenderer
+      customElement={
+        "customElement" in blockDefinition
+          ? blockDefinition.customElement
+          : undefined
+      }
+      html={"html" in blockDefinition ? blockDefinition.html : undefined}
+      properties={propsToInject}
+      ReactComponent={
+        "ReactComponent" in blockDefinition
+          ? blockDefinition.ReactComponent
+          : undefined
+      }
+    />
+  ) : null;
 
   return (
     <MockBlockDockProvider
@@ -235,9 +226,9 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps> = ({
       <div ref={wrapperRef}>
         <Suspense>
           {hideDebugToggle && !debugMode ? (
-            blockRendererWithBorder
+            blockRenderer
           ) : (
-            <MockBlockDockUi>{blockRendererWithBorder}</MockBlockDockUi>
+            <MockBlockDockUi>{blockRenderer}</MockBlockDockUi>
           )}
         </Suspense>
       </div>

--- a/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
+++ b/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
@@ -87,7 +87,7 @@ const handler: NextApiHandler = async (req, res) => {
       import React from "https://esm.sh/react@${reactVersion}"
       import ReactDOM from "https://esm.sh/react-dom@${reactVersion}"
       import { jsx as _jsx } from "https://esm.sh/react@${reactVersion}/jsx-runtime.js";
-      import { MockBlockDock } from "https://esm.sh/mock-block-dock@${mockBlockDockVersion}?alias=lodash:lodash-es&deps=react@${reactVersion}"
+      import { MockBlockDock } from "https://esm.sh/mock-block-dock@${mockBlockDockVersion}/dist/esm/index.js";
 
       const requireLookup = {
         "react-dom": ReactDOM,

--- a/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
+++ b/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
@@ -87,7 +87,7 @@ const handler: NextApiHandler = async (req, res) => {
       import React from "https://esm.sh/react@${reactVersion}"
       import ReactDOM from "https://esm.sh/react-dom@${reactVersion}"
       import { jsx as _jsx } from "https://esm.sh/react@${reactVersion}/jsx-runtime.js";
-      import { MockBlockDock } from "https://esm.sh/mock-block-dock@${mockBlockDockVersion}/dist/esm/index.js";
+      import { MockBlockDock } from "https://esm.sh/mock-block-dock@${mockBlockDockVersion}/dist/esm/index.js?deps=react@${reactVersion}";
 
       const requireLookup = {
         "react-dom": ReactDOM,


### PR DESCRIPTION
Follows #611 

- Load ESM instead of CJS via esm.sh
- Hide dashed border when `hideDebugToggle`is true

[Asana task](https://app.asana.com/0/1200211978612931/1202449143008136/f) (internal)


## Before

<img width="488" alt="Screenshot 2022-09-16 at 14 28 05" src="https://user-images.githubusercontent.com/608862/190650277-5ef20360-8b3b-479f-82b7-c90b0a4e4f44.png">

## After

<img width="403" alt="Screenshot 2022-09-16 at 14 28 53" src="https://user-images.githubusercontent.com/608862/190650308-e7905629-b006-4d3f-a82c-c5bdbafea265.png">
