### PR TITLE
Pin esm.sh target

### DIFF
--- a/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
+++ b/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
@@ -58,7 +58,7 @@ const handler: NextApiHandler = async (req, res) => {
   for (const [packageName, packageVersion] of Object.entries(externals)) {
     externalUrlLookup[packageName] = `https://esm.sh/${hotfixPackageName(
       packageName,
-    )}@${packageVersion}`;
+    )}@${packageVersion}?target=es2021`;
   }
 
   const mockBlockDockInitialData = {
@@ -84,10 +84,10 @@ const handler: NextApiHandler = async (req, res) => {
       window.addEventListener("message", handleMessage);
     </script>
     <script type="module">
-      import React from "https://esm.sh/react@${reactVersion}"
-      import ReactDOM from "https://esm.sh/react-dom@${reactVersion}"
-      import { jsx as _jsx } from "https://esm.sh/react@${reactVersion}/jsx-runtime.js";
-      import { MockBlockDock } from "https://esm.sh/mock-block-dock@${mockBlockDockVersion}/dist/esm/index.js?deps=react@${reactVersion}";
+      import React from "https://esm.sh/react@${reactVersion}?target=es2021"
+      import ReactDOM from "https://esm.sh/react-dom@${reactVersion}?target=es2021"
+      import { jsx as _jsx } from "https://esm.sh/react@${reactVersion}/jsx-runtime.js?target=es2021";
+      import { MockBlockDock } from "https://esm.sh/mock-block-dock@${mockBlockDockVersion}/dist/esm/index.js?target=es2021&deps=react@${reactVersion}";
 
       const requireLookup = {
         "react-dom": ReactDOM,


### PR DESCRIPTION
Follows #618. Fixes block sandbox by avoiding duplicate react copies.

Recent deployments included these two requests in the network tab ([example](https://blockprotocol-2foqf4ppg.stage.hash.ai/@hash/blocks/code)):
https://esm.sh/stable/react@18.2.0/es2021/react.js
https://esm.sh/stable/react@18.2.0/es2022/react.js

This caused:

```
eact-dom.js:9 TypeError: Cannot read properties of null (reading 'useState')
    at n.useState (react.js:2:6785)
    at i (use-default-state.js:2:164)
    at P (use-mock-block-props.js:2:710)
    at W (mock-block-dock.js:2:1420)
    at Bi (react-dom.js:7:19481)
```

The error could happen because esm.sh cached `https://esm.sh/mock-block-dock@${mockBlockDockVersion}/dist/esm/index.js?deps=react@${reactVersion}` in a new browser (needing ES2022) and then loaded the result in an older browser (needing ES2021). So every time we publish a new version of MBD, sandbox availability is a gamble – it depends on the first browser used. Hope that [pinning the target](https://esm.sh/#esbuild-options) can fix this. ES2021 is supported by all evergreen browsers.