### PR TITLE
Allow setting entityId in examples object

### DIFF
--- a/.changeset/shiny-mice-protect.md
+++ b/.changeset/shiny-mice-protect.md
@@ -1,0 +1,5 @@
+---
+"mock-block-dock": patch
+---
+
+set minheight on debug header

--- a/packages/mock-block-dock/src/debug-view/header.tsx
+++ b/packages/mock-block-dock/src/debug-view/header.tsx
@@ -17,6 +17,7 @@ export const HEADER_HEIGHT = 50;
 
 const Container = styled(Box)(({ theme }) => ({
   height: HEADER_HEIGHT,
+  minHeight: HEADER_HEIGHT,
   position: "sticky",
   top: 0,
   zIndex: 2000,

--- a/site/src/components/pages/hub/block-data-container.tsx
+++ b/site/src/components/pages/hub/block-data-container.tsx
@@ -53,6 +53,9 @@ export const BlockDataContainer: FunctionComponent<BlockDataContainerProps> = ({
   const [readonly, setReadonly] = useState(false);
 
   const [text, setText] = useState("{}");
+  const [exampleEntityId, setExampleEntityId] = useState<string>(
+    `test-entity-${metadata.name}`,
+  );
 
   const previousBlockVariantsTab = useRef(-1);
   const propertiesToRemove = useRef<string[]>([]);
@@ -73,7 +76,15 @@ export const BlockDataContainer: FunctionComponent<BlockDataContainerProps> = ({
 
       // reset data source input when switching blocks
       if (example) {
-        setText(JSON.stringify(example, undefined, 2));
+        if (typeof example.entityId === "string") {
+          setExampleEntityId(example.entityId);
+          if (example.properties && typeof example.properties === "object") {
+            setText(JSON.stringify(example.properties, undefined, 2));
+          }
+        } else {
+          setText(JSON.stringify(example, undefined, 2));
+          setExampleEntityId(`test-entity-${metadata.name}`);
+        }
       } else {
         setText("{}");
       }
@@ -127,8 +138,7 @@ export const BlockDataContainer: FunctionComponent<BlockDataContainerProps> = ({
   /** used to recompute props and errors on dep changes (caching has no benefit here) */
   const [props, errors] = useMemo<[Entity<any> | undefined, string[]]>(() => {
     const result = {
-      accountId: `test-account-${metadata.name}`,
-      entityId: `test-entity-${metadata.name}`,
+      entityId: exampleEntityId,
       properties: {},
       readonly,
     };
@@ -149,7 +159,7 @@ export const BlockDataContainer: FunctionComponent<BlockDataContainerProps> = ({
       );
 
     return [result, errorMessages];
-  }, [text, schema, metadata.name, readonly]);
+  }, [exampleEntityId, text, schema, readonly]);
 
   return (
     <>


### PR DESCRIPTION
# What is this PR?

This does a couple of small things:

1. Allows users to specify the `entityId` in their example entity provided in `block-metadata.json["examples"]`. This is because blocks which rely on an `example-graph.json` which specifies _other_ entities, and _links_ from those other entities to the block example, rely on the block entity having a known `entityId`.

2. Adds a minheight to the MBD debug header, because it can become squashed if the block is very high

it originally added another loading indicator to the Hub, but it was too buggy