### PR TITLE
Add additional MIT LICENSE files to libs

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,4 @@
-The MIT License (MIT)
-=====================
+# The MIT License (MIT)
 
 Copyright © 2021–, HASH
 

--- a/crates/type-system/LICENSE.md
+++ b/crates/type-system/LICENSE.md
@@ -1,5 +1,4 @@
-The MIT License (MIT)
-=====================
+# The MIT License (MIT)
 
 Copyright © 2022–, HASH
 

--- a/packages/@blockprotocol/core/LICENSE.md
+++ b/packages/@blockprotocol/core/LICENSE.md
@@ -1,5 +1,4 @@
-The MIT License (MIT)
-=====================
+# The MIT License (MIT)
 
 Copyright © 2021–, HASH
 

--- a/packages/@blockprotocol/graph/LICENSE.md
+++ b/packages/@blockprotocol/graph/LICENSE.md
@@ -1,5 +1,4 @@
-The MIT License (MIT)
-=====================
+# The MIT License (MIT)
 
 Copyright © 2021–, HASH
 

--- a/packages/@blockprotocol/hook/LICENSE.md
+++ b/packages/@blockprotocol/hook/LICENSE.md
@@ -1,5 +1,4 @@
-The MIT License (MIT)
-=====================
+# The MIT License (MIT)
 
 Copyright © 2021–, HASH
 

--- a/packages/@blockprotocol/type-system-node/LICENSE.md
+++ b/packages/@blockprotocol/type-system-node/LICENSE.md
@@ -1,5 +1,4 @@
-The MIT License (MIT)
-=====================
+# The MIT License (MIT)
 
 Copyright © 2021–, HASH
 

--- a/packages/@blockprotocol/type-system-web/LICENSE.md
+++ b/packages/@blockprotocol/type-system-web/LICENSE.md
@@ -1,5 +1,4 @@
-The MIT License (MIT)
-=====================
+# The MIT License (MIT)
 
 Copyright © 2021–, HASH
 

--- a/packages/block-scripts/LICENSE.md
+++ b/packages/block-scripts/LICENSE.md
@@ -1,5 +1,4 @@
-The MIT License (MIT)
-=====================
+# The MIT License (MIT)
 
 Copyright © 2021–, HASH
 

--- a/packages/blockprotocol/LICENSE.md
+++ b/packages/blockprotocol/LICENSE.md
@@ -1,5 +1,4 @@
-The MIT License (MIT)
-=====================
+# The MIT License (MIT)
 
 Copyright © 2021–, HASH
 

--- a/packages/create-block-app/LICENSE.md
+++ b/packages/create-block-app/LICENSE.md
@@ -1,5 +1,4 @@
-The MIT License (MIT)
-=====================
+# The MIT License (MIT)
 
 Copyright © 2021–, HASH
 

--- a/packages/mock-block-dock/LICENSE.md
+++ b/packages/mock-block-dock/LICENSE.md
@@ -1,5 +1,4 @@
-The MIT License (MIT)
-=====================
+# The MIT License (MIT)
 
 Copyright © 2021–, HASH
 


### PR DESCRIPTION
# What this does

- Improves the formatting of our root LICENSE file (the underlying license remains unchanged)
- Adds explicit LICENSE files to each of our libs (crates/packages) to assist license compliance checkers in confirming the open-source status of BP components used as dependencies within external repos. Our 3x block templates have been excluded from this (to reduce cruft), but remain MIT-licensed per the top-level LICENSE file's terms.