### PR TITLE
Add entityId requirement to @blockprotocol/hook

### DIFF
--- a/.changeset/tricky-wolves-unite.md
+++ b/.changeset/tricky-wolves-unite.md
@@ -1,0 +1,5 @@
+---
+"@blockprotocol/hook": patch
+---
+
+add entityId to @blockprotocol/hook

--- a/packages/@blockprotocol/hook/README.md
+++ b/packages/@blockprotocol/hook/README.md
@@ -20,10 +20,11 @@ const handler = new HookBlockHandler({ element });
 
 handler.hook({
   data: {
-    blockId: "hookId",
-    node,
-    type: "text",
-    path: "$.text",
+    hookId: null, // the embedding application will provide a hookId in response to use in future messages
+    node, // a reference to the DOM node to render into
+    type: "text", // the type of hook
+    entityId: "entity1", // the id of the entity this hook will show/edit data for
+    path: "$.text", // the path in the entity's properties data will be taken from/saved to
   },
 });
 ```

--- a/packages/@blockprotocol/hook/src/react.ts
+++ b/packages/@blockprotocol/hook/src/react.ts
@@ -100,6 +100,7 @@ type Hook<T extends HTMLElement> = {
     service: HookBlockHandler | null;
     node: T;
     type: string;
+    entityId: string;
     path: string;
   };
 };
@@ -112,7 +113,8 @@ type Hook<T extends HTMLElement> = {
  *            embedding application is notified when the underlying DOM node
  *            inside the ref changes
  * @param type The type of hook – i.e, "text"
- * @param path The path to the data associated with the hook
+ * @param entityId The entityId of the entity on which to store data associated with the hook
+ * @param path The path in the entity's properties to the data associated with the hook
  * @param fallback A fallback to be called if the embedding application doesn't
  *                 implement the hook service, or doesn't implement this
  *                 specific type of hook. Return a function to "teardown" your
@@ -122,6 +124,7 @@ export const useHook = <T extends HTMLElement>(
   service: HookBlockHandler | null,
   ref: RefObject<T | null | void>,
   type: string,
+  entityId: string,
   path: string,
   fallback: (node: T) => void | (() => void),
 ) => {
@@ -178,6 +181,7 @@ export const useHook = <T extends HTMLElement>(
       existingHook &&
       existingHook.service === service &&
       existingHook.node === node &&
+      existingHook.entityId === entityId &&
       existingHook.path === path &&
       existingHook.type === type
     ) {
@@ -198,6 +202,7 @@ export const useHook = <T extends HTMLElement>(
       const reuseId =
         existingHook &&
         existingHook.service === service &&
+        existingHook.entityId === entityId &&
         existingHook.path === path &&
         existingHook.type === type;
 
@@ -206,6 +211,7 @@ export const useHook = <T extends HTMLElement>(
         params: {
           service,
           type,
+          entityId,
           path,
           node,
         },
@@ -229,6 +235,7 @@ export const useHook = <T extends HTMLElement>(
                 await service.hook({
                   data: {
                     hookId,
+                    entityId,
                     path,
                     type,
                     node: null,
@@ -256,6 +263,7 @@ export const useHook = <T extends HTMLElement>(
             .hook({
               data: {
                 hookId: hook.id,
+                entityId,
                 node,
                 type,
                 path,

--- a/packages/@blockprotocol/hook/src/types.ts
+++ b/packages/@blockprotocol/hook/src/types.ts
@@ -9,6 +9,7 @@ export type HookData = {
   type: string;
   path: string;
   hookId: string | null;
+  entityId: string;
 };
 
 export type BlockHookMessageCallbacks = {};


### PR DESCRIPTION
The hook service was first introduced without a requirement to specify an `entityId` to identify the entity hook data should be initalised from / saved to. The implicit assumption was that it was always the block entity that hooks should be dealing with – we want the service to handle hooks for _any_ entity.

This PR introduces an `entityId` field to the hook data specified in `@blockprotocol/hook`, so that users of the service are required to specify which entity a hook relates to.

There is follow-on implementation work to do to make this work in embedding applications (e.g. HASH - [task](https://app.asana.com/0/1202953520344821/1203093902519197/f)).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202809197795774