### PR TITLE
Fix ISTANBUL_TEMP_DIR

### DIFF
--- a/apps/site/playwright.config.ts
+++ b/apps/site/playwright.config.ts
@@ -6,7 +6,7 @@ import { devices } from "@playwright/test";
 const ci = process.env.CI === "true";
 
 // https://github.com/anishkny/playwright-test-coverage#options
-process.env.ISTANBUL_TEMP_DIR = "../.nyc_output";
+process.env.ISTANBUL_TEMP_DIR = "../../.nyc_output";
 
 const integrationTestsBaseConfig = {
   retries: 1,


### PR DESCRIPTION
Follows #609. Makes sure we collect coverage not only from `yarn workspace @apps/site build` but also during `yarn workspace @apps/site start`. Restores original test coverage levels (≈60% 📉 ≈40% 📈 ≈60%).

#609 was reporting 0% coverage no matter what I tried, see details in https://github.com/blockprotocol/blockprotocol/pull/609#discussion_r989567128.