### PR TITLE
Use GitHub token in ‘Version Packages’ PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,3 @@
-## Using MACHINE_USER_TOKEN enables GitHub Workflows in ‘Version Packages’ PRs
-## https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
-
 name: Release
 on:
   push:
@@ -22,5 +19,4 @@ jobs:
         with:
           publish: yarn workspace @local/package-chores exe scripts/publish-to-npmjscom.ts
         env:
-          GITHUB_TOKEN: ${{ secrets.MACHINE_USER_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
[Slack thread](https://hashintel.slack.com/archives/C02LG39FJAU/p1666004405468329) (internal)

From [docs on triggering PR workflows](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs):

### current solution (introduced in https://github.com/blockprotocol/blockprotocol/pull/538)

> Use a repo scoped [Personal Access Token (PAT)](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) created on an account that has write access to the repository that pull requests are being created in. This is the standard workaround and [recommended by GitHub](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token). However, the PAT cannot be scoped to a specific repository so the token becomes a very sensitive secret. If this is a concern, the PAT can instead be created for a dedicated [machine account](https://docs.github.com/en/github/site-policy/github-terms-of-service#3-account-requirements) that has collaborator access to the repository. Also note that because the account that owns the PAT will be the creator of pull requests, that user account will be unable to perform actions such as request changes or approve the pull request.

### after this PR

> Use the default GITHUB_TOKEN and allow the action to create pull requests that have no checks enabled. Manually close pull requests and immediately reopen them. This will enable on: pull_request workflows to run and be added as checks. To prevent merging of pull requests without checks erroneously, use [branch protection rules](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests).

The new approach should save workflow time and thus speed up CI in other PRs. It also reduces the number of Vercel preview deployments:

<div align=center><img width="500" alt="Screenshot 2022-10-17 at 11 51 42" src="https://user-images.githubusercontent.com/608862/196183697-fb4e8b20-99a3-46f7-94a9-e6001826b563.png"></div>

As a result, new ‘Version Packages’ PRs and the releases will be done by **github-actions** ([example](https://github.com/blockprotocol/blockprotocol/releases/tag/mock-block-dock%400.0.21)) instead of **hashdotai** ([example](https://github.com/blockprotocol/blockprotocol/releases/tag/mock-block-dock%400.0.24)).
