### PR TITLE
Improve Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,8 +3,8 @@
   "postUpdateOptions": ["yarnDedupeFewer"],
   "prConcurrentLimit": 10,
   "enabledManagers": ["github-actions", "npm"],
-  "rebaseWhen": "never",
-  "schedule": ["every weekday before 6am"],
+  "rebaseWhen": "conflicted",
+  "schedule": ["every weekday before 5am"],
   "packageRules": [
     {
       "enabled": false,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,43 +3,50 @@
   "postUpdateOptions": ["yarnDedupeFewer"],
   "prConcurrentLimit": 10,
   "enabledManagers": ["github-actions", "npm"],
+  "rebaseWhen": "never",
+  "schedule": ["every weekday before 6am"],
   "packageRules": [
     {
       "enabled": false,
       "matchManagers": ["npm"],
-      "matchPackagePatterns": [".*"]
-    },
-    {
-      "matchManagers": ["npm"],
-      "rangeStrategy": "bump"
+      "rangeStrategy": "bump",
+      "stabilityDays": 3
     },
     {
       "enabled": true,
-      "groupName": "changesets",
+      "matchManagers": ["npm"],
+      "matchFiles": ["package.json"]
+    },
+    {
+      "enabled": true,
+      "groupName": "Changesets",
       "matchManagers": ["npm"],
       "matchPackagePatterns": ["^@changesets/"]
     },
     {
+      "automerge": true,
       "enabled": true,
-      "groupName": "eslint",
+      "groupName": "ESLint",
       "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^@typescript-eslint/", "^eslint$"]
+      "matchPackagePatterns": [
+        "^@types/eslint",
+        "^@typescript-eslint/",
+        "^eslint-config-",
+        "^eslint-plugin-",
+        "^eslint$"
+      ]
     },
     {
       "enabled": true,
-      "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^eslint-config-", "^eslint-plugin-"]
-    },
-    {
-      "enabled": true,
-      "groupName": "playwright",
+      "groupName": "Playwright",
       "matchManagers": ["npm"],
       "matchPackagePatterns": ["^@playwright/", "^playwright"]
     },
     {
       "enabled": true,
+      "groupName": "Prettier",
       "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^typescript$", "^ts-node$"]
+      "matchPackagePatterns": ["^prettier"]
     }
   ]
 }


### PR DESCRIPTION
Follows #587 

## In scope

- Set [`stabilityDays`](https://docs.renovatebot.com/configuration-options/#stabilitydays) to 3

- Set [`rebaseWhen`](https://docs.renovatebot.com/configuration-options/#rebasewhen) to `conflicted`. When several PRs are open, each merge triggers update in all Renovate PRs and this clogs CI/CD. Reviews are discarded on rebasing because Renovate force-pushes. Instead of auto rebasing, we can try merging `main` into a PR branch manually just before we are ready to merge. We still want to rebase if there are conflicts (mostly in `yarn.lock`)

- Enable updates for all dependencies in root workspace (`"matchFiles": ["package.json"]`)

- Improve group names by using Title Case there. This can potentially help us distinguish between updates in Groups and updates in individual packages

- Move all ESLint dependencies into one group

- Set [`schedule`](https://docs.renovatebot.com/configuration-options/#schedule) to `"every weekday before 5am"` (before 8 am for Yusuf in winter)

- Enable [`automerge`](https://docs.renovatebot.com/configuration-options/#automerge) for ESLint dependencies as an experiment. Not sure it will work right away, but let’s see.

## Out of scope

- Add empty changeset in [`postUpgradeTasks`](https://docs.renovatebot.com/configuration-options/#postupgradetasks) (option only available in self-hosted Renovate instances)

-  Reduce concurrency to 10 (hopefully not needed with `rebaseWhen=conflicted`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203157179262065