### PR TITLE
Fix handling json paths in mock-block-dock set

### DIFF
--- a/.changeset/dirty-cooks-exercise.md
+++ b/.changeset/dirty-cooks-exercise.md
@@ -1,0 +1,5 @@
+---
+"mock-block-dock": patch
+---
+
+bug fix in setting property via hook service

--- a/packages/mock-block-dock/dev/test-react-block.tsx
+++ b/packages/mock-block-dock/dev/test-react-block.tsx
@@ -21,7 +21,7 @@ export const TestReactBlock: BlockComponent<AppProps> = ({ graph }) => {
 
   const { hookService } = useHookBlockService(blockRef);
 
-  useHook(hookService, hookRef, "text", entityId, "description", () => {
+  useHook(hookService, hookRef, "text", entityId, "$.description", () => {
     throw new Error(
       "Fallback called – dock is not correctly handling text hook.",
     );

--- a/packages/mock-block-dock/src/util.ts
+++ b/packages/mock-block-dock/src/util.ts
@@ -47,6 +47,10 @@ export const set = (obj: {}, path: string | string[], value: unknown) => {
   let i;
 
   for (i = 0; i < keys.length - 1; i++) {
+    if (i === 0 && keys[i] === "$") {
+      // ignore leading json path identifier, if present
+      continue;
+    }
     // @ts-expect-error -- expected ‘No index signature with a parameter of type 'string' was found on type '{}'’
     currentObj = currentObj[keys[i]!];
   }


### PR DESCRIPTION
Fix a bug where mock-block-dock was not handling json paths correctly when deep setting entity properties.