### PR TITLE
Fix bug in dock text comparison

### DIFF
--- a/.changeset/chilly-parents-kneel.md
+++ b/.changeset/chilly-parents-kneel.md
@@ -1,0 +1,5 @@
+---
+"mock-block-dock": patch
+---
+
+fix bug in comparing text

--- a/packages/mock-block-dock/src/hook-portals/text.tsx
+++ b/packages/mock-block-dock/src/hook-portals/text.tsx
@@ -4,7 +4,6 @@ import {
   useEffect,
   useMemo,
   useRef,
-  useState,
 } from "react";
 import {
   BaseEditor,
@@ -78,15 +77,40 @@ const isMaybeText = (value: unknown): value is MaybePlainOrRichText => {
   );
 };
 
+const serializeToPlaintext = (nodes: Descendant[]) => {
+  return nodes.map((n) => Node.string(n)).join("\n");
+};
+
 const generateComparableString = (text: MaybePlainOrRichText) =>
-  typeof text === "string" ? text : JSON.stringify(text);
+  typeof text === "string" ? text : serializeToPlaintext(text ?? []);
+
+/**
+ * Compare two texts to see if they differ either
+ * - in plain text (if at least one is a string), or
+ * - in text and/or formatting (if both are rich text)
+ */
+const isTextDifferent = (
+  first: MaybePlainOrRichText,
+  second: MaybePlainOrRichText,
+) => {
+  if (typeof first === "string") {
+    return first !== generateComparableString(second);
+  }
+  if (typeof second === "string") {
+    return second !== serializeToPlaintext(first ?? []);
+  }
+  // These are both rich text, so we don't convert them to plain text – we won't detect formatting differences
+  return JSON.stringify(first) !== JSON.stringify(second);
+};
 
 export const TextHookView = ({
   readonly = false,
   text = "",
   updateText,
 }: TextHookViewProps) => {
-  const [editor] = useState(() => withReact(createEditor()));
+  const editor = useMemo(() => {
+    return withReact(createEditor());
+  }, []);
 
   const renderLeaf = useCallback(
     (props: RenderLeafProps) => <Leaf {...props} />,
@@ -99,9 +123,9 @@ export const TextHookView = ({
     );
   }
 
-  const previousTextRef = useRef<string | null>(null);
+  const previousTextRef = useRef<MaybePlainOrRichText>(null);
   if (previousTextRef.current === null) {
-    previousTextRef.current = generateComparableString(text);
+    previousTextRef.current = text;
   }
 
   const nodesFromProps: Descendant[] = useMemo(
@@ -118,9 +142,8 @@ export const TextHookView = ({
   );
 
   useEffect(() => {
-    const comparableString = generateComparableString(text);
-    if (comparableString !== previousTextRef.current) {
-      previousTextRef.current = comparableString;
+    if (isTextDifferent(text, previousTextRef.current)) {
+      previousTextRef.current = text;
       resetNodes(editor, nodesFromProps);
     }
   }, [editor, nodesFromProps, text]);
@@ -156,7 +179,15 @@ export const TextHookView = ({
 
   return (
     <div style={{ border: "1px solid rgba(0,0,0,0.5)" }}>
-      <Slate editor={editor} onChange={onChange} value={nodesFromProps}>
+      <Slate
+        editor={editor}
+        onChange={(value) => {
+          if (isTextDifferent(value, text)) {
+            onChange(value);
+          }
+        }}
+        value={nodesFromProps}
+      >
         <Toolbar />
         <Editable
           style={{ padding: "12px" }}

--- a/packages/mock-block-dock/src/hook-portals/text.tsx
+++ b/packages/mock-block-dock/src/hook-portals/text.tsx
@@ -78,7 +78,7 @@ const isMaybeText = (value: unknown): value is MaybePlainOrRichText => {
 };
 
 const serializeToPlaintext = (nodes: Descendant[]) => {
-  return nodes.map((n) => Node.string(n)).join("\n");
+  return nodes.map((node) => Node.string(node)).join("\n");
 };
 
 const generateComparableString = (text: MaybePlainOrRichText) =>
@@ -99,7 +99,7 @@ const isTextDifferent = (
   if (typeof second === "string") {
     return second !== serializeToPlaintext(first ?? []);
   }
-  // These are both rich text, so we don't convert them to plain text – we won't detect formatting differences
+  // These are both rich text, so we don't convert them to plain text – we want to detect formatting differences
   return JSON.stringify(first) !== JSON.stringify(second);
 };
 
@@ -182,6 +182,10 @@ export const TextHookView = ({
       <Slate
         editor={editor}
         onChange={(value) => {
+          /**
+           * This is not just an optimization – updating Editor content from props (via the resetNodes function)
+           * also triggers onChange, and if external updates are coming quickly, this can cause a loop.
+           */
           if (isTextDifferent(value, text)) {
             onChange(value);
           }

--- a/packages/mock-block-dock/src/hook-portals/text/toolbar.tsx
+++ b/packages/mock-block-dock/src/hook-portals/text/toolbar.tsx
@@ -3,7 +3,12 @@ import { MarkButton } from "./mark-button";
 export const Toolbar = () => {
   return (
     <div
-      style={{ padding: "8px 12px", borderBottom: "1px solid rgba(0,0,0,0.1)" }}
+      contentEditable={false}
+      style={{
+        padding: "8px 12px",
+        borderBottom: "1px solid rgba(0,0,0,0.1)",
+        userSelect: "none", // @see https://github.com/ianstormtaylor/slate/issues/3421#issuecomment-573326794
+      }}
     >
       <MarkButton format="bold">
         <span>B</span>


### PR DESCRIPTION
This PR fixes a few bugs in mock-block-dock's hook service which only appear when updates to the property the block has called the hook service on are sent from outside the block, either very quickly or as plain text. This was noticed when trying out text blocks in the Hub and typing in the external editor.

Fixes as follows:
1. when a plain string is sent as an update to a property that is currently rich text, the string was not being properly compared to rich text in the block. This PR fixes comparing strings to rich text
2. when resetting the slate editor content in response to external updates, the `onChange` is triggered. This PR stops this sending an update back to the embedding application if the content is the same as the value from props – otherwise, if updates are coming fast, this can cause a loop when an external update comes in, and is then sent back out again while another external update is coming in.
3. fixes an issue in the Toolbar whereby Slate crashes if the user selects it and hits backspace

### Known issues

Sending external text updates very quickly can still cause some jankiness in the text updating – this will only happen in the Hub if someone types quickly into the JSON editor, and not when developing a block, so it's good enough for now. T[ask to fix this](https://app.asana.com/0/1201095311341924/1203225015178902/f) (internal).

### Next steps

Once this is merged and new mock-block-dock released, add back text blocks to the Hub – #697 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203225015178904