### PR TITLE
Switch Playwright tests to ESM

### DIFF
--- a/apps/site/tests/integration/accountpage.test.ts
+++ b/apps/site/tests/integration/accountpage.test.ts
@@ -1,9 +1,7 @@
 import { expect, test } from "playwright-test-coverage";
 
-import blocksData from "../../blocks-data.json";
-import type { ExpandedBlockMetadata } from "../../src/lib/blocks";
-import { resetDb } from "../shared/fixtures";
-import { login } from "../shared/nav";
+import { getBlocksData, resetDb } from "../shared/fixtures.js";
+import { login } from "../shared/nav.js";
 
 test.beforeEach(async () => {
   await resetDb();
@@ -82,7 +80,7 @@ test("key elements should be present when user views their account page", async 
   await expect(page.locator("text=Create a schema")).toBeVisible();
 });
 
-const codeBlockMetadata = (blocksData as ExpandedBlockMetadata[]).find(
+const codeBlockMetadata = (await getBlocksData()).find(
   ({ pathWithNamespace }) => pathWithNamespace === "@hash/code",
 );
 

--- a/apps/site/tests/integration/api-keys.test.ts
+++ b/apps/site/tests/integration/api-keys.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "playwright-test-coverage";
 
-import { resetDb } from "../shared/fixtures";
-import { login } from "../shared/nav";
+import { resetDb } from "../shared/fixtures.js";
+import { login } from "../shared/nav.js";
 
 test("API key page should generate a valid key", async ({
   page,

--- a/apps/site/tests/integration/block-publish-npm.test.ts
+++ b/apps/site/tests/integration/block-publish-npm.test.ts
@@ -1,9 +1,9 @@
-import { Page } from "playwright";
+import type { Page } from "playwright";
 import { expect, test } from "playwright-test-coverage";
 
-import { publishBlock } from "../shared/blocks";
-import { resetDb } from "../shared/fixtures";
-import { login } from "../shared/nav";
+import { publishBlock } from "../shared/blocks.js";
+import { resetDb } from "../shared/fixtures.js";
+import { login } from "../shared/nav.js";
 
 const fillBlockDetails = async (
   page: Page,

--- a/apps/site/tests/integration/blockpage.test.ts
+++ b/apps/site/tests/integration/blockpage.test.ts
@@ -1,15 +1,14 @@
 import { expect, test } from "playwright-test-coverage";
 
-import blocksData from "../../blocks-data.json";
-import type { ExpandedBlockMetadata } from "../../src/lib/blocks";
+import { getBlocksData } from "../shared/fixtures.js";
 
-const typedBlocksData = blocksData as ExpandedBlockMetadata[];
+const blocksData = await getBlocksData();
 
-const codeBlock = typedBlocksData.find(
+const codeBlock = blocksData.find(
   ({ pathWithNamespace }) => pathWithNamespace === "@hash/code",
 );
 
-const unsupportedBlock = typedBlocksData.find(
+const unsupportedBlock = blocksData.find(
   ({ pathWithNamespace }) => pathWithNamespace === "@hash/embed",
 );
 

--- a/apps/site/tests/integration/dashboard.test.ts
+++ b/apps/site/tests/integration/dashboard.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "playwright-test-coverage";
 
-import { resetDb } from "../shared/fixtures";
-import { login } from "../shared/nav";
+import { resetDb } from "../shared/fixtures.js";
+import { login } from "../shared/nav.js";
 
 test("dashboard page should not be accessible to guests", async ({ page }) => {
   await Promise.all([

--- a/apps/site/tests/integration/docs.test.ts
+++ b/apps/site/tests/integration/docs.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "playwright-test-coverage";
 
-import { closeMobileNav, openMobileNav } from "../shared/nav";
+import { closeMobileNav, openMobileNav } from "../shared/nav.js";
 
 test("Docs page should contain key elements and interactions should work", async ({
   page,

--- a/apps/site/tests/integration/hubpage.test.ts
+++ b/apps/site/tests/integration/hubpage.test.ts
@@ -1,9 +1,8 @@
 import { expect, test } from "playwright-test-coverage";
 
-import blocksData from "../../blocks-data.json";
-import type { ExpandedBlockMetadata } from "../../src/lib/blocks";
+import { getBlocksData } from "../shared/fixtures.js";
 
-const codeBlockMetadata = (blocksData as ExpandedBlockMetadata[]).find(
+const codeBlockMetadata = (await getBlocksData()).find(
   ({ pathWithNamespace }) => pathWithNamespace === "@hash/code",
 );
 

--- a/apps/site/tests/integration/login-flow.test.ts
+++ b/apps/site/tests/integration/login-flow.test.ts
@@ -1,9 +1,9 @@
-import { Page } from "playwright";
+import type { Page } from "playwright";
 import { expect, test } from "playwright-test-coverage";
 
-import { readValueFromRecentDummyEmail } from "../shared/dummy-emails";
-import { resetDb } from "../shared/fixtures";
-import { login, openLoginModal, openMobileNav } from "../shared/nav";
+import { readValueFromRecentDummyEmail } from "../shared/dummy-emails.js";
+import { resetDb } from "../shared/fixtures.js";
+import { login, openLoginModal, openMobileNav } from "../shared/nav.js";
 
 const emailInputSelector = '[placeholder="claude\\@example\\.com"]';
 const loginButtonSelector = "button[type=submit]:has-text('Log In')";

--- a/apps/site/tests/integration/schema-creation.test.ts
+++ b/apps/site/tests/integration/schema-creation.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "playwright-test-coverage";
 
-import { resetDb } from "../shared/fixtures";
-import { login } from "../shared/nav";
-import { createSchema } from "../shared/schemas";
+import { resetDb } from "../shared/fixtures.js";
+import { login } from "../shared/nav.js";
+import { createSchema } from "../shared/schemas.js";
 
 test("user should be able to create schema", async ({ page }) => {
   await resetDb();

--- a/apps/site/tests/integration/schemapage.test.ts
+++ b/apps/site/tests/integration/schemapage.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "playwright-test-coverage";
 
-import { resetDb } from "../shared/fixtures";
-import { login } from "../shared/nav";
-import { createSchema } from "../shared/schemas";
+import { resetDb } from "../shared/fixtures.js";
+import { login } from "../shared/nav.js";
+import { createSchema } from "../shared/schemas.js";
 
 test.beforeEach(async () => {
   await resetDb();

--- a/apps/site/tests/integration/sign-up-flow.ts
+++ b/apps/site/tests/integration/sign-up-flow.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "playwright-test-coverage";
 
-import { readValueFromRecentDummyEmail } from "../shared/dummy-emails";
-import { resetDb } from "../shared/fixtures";
-import { login, openMobileNav } from "../shared/nav";
+import { readValueFromRecentDummyEmail } from "../shared/dummy-emails.js";
+import { resetDb } from "../shared/fixtures.js";
+import { login, openMobileNav } from "../shared/nav.js";
 
 test("sign up flow works", async ({ browserName, isMobile, page }) => {
   await resetDb();

--- a/apps/site/tests/package.json
+++ b/apps/site/tests/package.json
@@ -1,3 +1,0 @@
-{
-  "type": "commonjs"
-}

--- a/apps/site/tests/shared/fixtures.ts
+++ b/apps/site/tests/shared/fixtures.ts
@@ -1,7 +1,7 @@
 import execa from "execa";
 import fs from "fs-extra";
 
-import type { ExpandedBlockMetadata } from "../../../src/lib/blocks.js";
+import type { ExpandedBlockMetadata } from "../../src/lib/blocks.js";
 
 export const resetDb = async () => {
   await execa("yarn", ["exe", "scripts/seed-db.js"]);

--- a/apps/site/tests/shared/fixtures.ts
+++ b/apps/site/tests/shared/fixtures.ts
@@ -1,5 +1,12 @@
 import execa from "execa";
+import fs from "fs-extra";
+
+import type { ExpandedBlockMetadata } from "../../../src/lib/blocks.js";
 
 export const resetDb = async () => {
-  await execa("yarn", ["exe", "scripts/seed-db.ts"]);
+  await execa("yarn", ["exe", "scripts/seed-db.js"]);
+};
+
+export const getBlocksData = async (): Promise<ExpandedBlockMetadata[]> => {
+  return await fs.readJson("./blocks-data.json");
 };

--- a/apps/site/tests/shared/nav.ts
+++ b/apps/site/tests/shared/nav.ts
@@ -1,7 +1,7 @@
 import type { Locator, Page } from "playwright";
 import { expect } from "playwright-test-coverage";
 
-import { readValueFromRecentDummyEmail } from "./dummy-emails";
+import { readValueFromRecentDummyEmail } from "./dummy-emails.js";
 
 export const openMobileNav = async (page: Page) => {
   await page.locator("[data-testid='mobile-nav-trigger']").click();

--- a/apps/site/tests/universal/page-header.test.ts
+++ b/apps/site/tests/universal/page-header.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "playwright-test-coverage";
 
-import { openLoginModal, openMobileNav } from "../shared/nav";
+import { openLoginModal, openMobileNav } from "../shared/nav.js";
 
 test("page header navigation works", async ({
   page,

--- a/packages/@blockprotocol/graph/.eslintrc.cjs
+++ b/packages/@blockprotocol/graph/.eslintrc.cjs
@@ -1,9 +1,4 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
-  rules: {
-    // import plugin does not support .js file extensions in .ts files, which ESM TS projects require
-    // https://github.com/import-js/eslint-plugin-import/issues/2446
-    "import/no-unresolved": "off",
-  },
 };

--- a/packages/@blockprotocol/hook/.eslintrc.cjs
+++ b/packages/@blockprotocol/hook/.eslintrc.cjs
@@ -1,9 +1,4 @@
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
   ...require("@local/eslint-config/generate-workspace-config.cjs")(__dirname),
-  rules: {
-    // import plugin does not support .js file extensions in .ts files, which ESM TS projects require
-    // https://github.com/import-js/eslint-plugin-import/issues/2446
-    "import/no-unresolved": "off",
-  },
 };

--- a/packages/@local/eslint-config/generate-workspace-config.cjs
+++ b/packages/@local/eslint-config/generate-workspace-config.cjs
@@ -10,4 +10,12 @@ module.exports = (workspaceDirPath) => ({
     tsconfigRootDir: ".",
     project: `${workspaceDirPath}/tsconfig.json`,
   },
+  settings: {
+    "import/resolver": {
+      typescript: {
+        alwaysTryTypes: true,
+        project: `${__dirname}/tsconfig.json`,
+      },
+    },
+  },
 });

--- a/packages/@local/eslint-config/package.json
+++ b/packages/@local/eslint-config/package.json
@@ -16,6 +16,7 @@
     "eslint": "8.26.0",
     "eslint-config-airbnb": "19.0.4",
     "eslint-config-prettier": "8.5.0",
+    "eslint-import-resolver-typescript": "3.5.2",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jest": "27.1.3",
     "eslint-plugin-jsx-a11y": "6.6.1",

--- a/packages/block-template-react/src/app.tsx
+++ b/packages/block-template-react/src/app.tsx
@@ -1,5 +1,5 @@
 import {
-  BlockComponent,
+  type BlockComponent,
   useGraphBlockService,
 } from "@blockprotocol/graph/react";
 import { useRef } from "react";

--- a/packages/mock-block-dock/dev/dev-app.tsx
+++ b/packages/mock-block-dock/dev/dev-app.tsx
@@ -4,7 +4,6 @@ import { createRoot } from "react-dom/client";
 
 import { MockBlockDock } from "../src";
 import { TestCustomElementBlock } from "./test-custom-element-block";
-// eslint-disable-next-line import/no-unresolved
 import testBlockString from "./test-html-block/block.html?raw";
 import { TestReactBlock } from "./test-react-block";
 

--- a/packages/mock-block-dock/dev/test-react-block.tsx
+++ b/packages/mock-block-dock/dev/test-react-block.tsx
@@ -1,5 +1,5 @@
 import {
-  BlockComponent,
+  type BlockComponent,
   useGraphBlockService,
 } from "@blockprotocol/graph/react";
 import { useHook, useHookBlockService } from "@blockprotocol/hook/react";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3105,7 +3105,7 @@
     node-gyp "^8.2.0"
     read-package-json-fast "^2.0.1"
 
-"@pkgr/utils@^2.3.0", "@pkgr/utils@^2.3.1":
+"@pkgr/utils@^2.3.1":
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/@pkgr/utils/-/utils-2.3.1.tgz#0a9b06ffddee364d6642b3cd562ca76f55b34a03"
   integrity sha512-wfzX8kc1PMyUILA+1Z/EqoE4UCXGy0iRGMhPwdfae1+f0OXlLqCk+By+aMzgJBzR9AzS4CDizioG6Ss1gvAFJw==
@@ -8060,17 +8060,10 @@ is-ci@^3.0.1:
   dependencies:
     ci-info "^3.2.0"
 
-is-core-module@^2.10.0:
+is-core-module@^2.10.0, is-core-module@^2.2.0, is-core-module@^2.8.1, is-core-module@^2.9.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
   integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
-  dependencies:
-    has "^1.0.3"
-
-is-core-module@^2.2.0, is-core-module@^2.8.1, is-core-module@^2.9.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
-  integrity sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==
   dependencies:
     has "^1.0.3"
 
@@ -13183,15 +13176,7 @@ svgo@^2.0.3:
     picocolors "^1.0.0"
     stable "^0.1.8"
 
-synckit@^0.8.1:
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.8.3.tgz#f36ca23fb7cbcf2b2b78c9e553ce6764dc6aa415"
-  integrity sha512-1goXnDYNJlKwCM37f5MTzRwo+8SqutgVtg2d37D6YnHHT4E3IhQMRfKiGdfTZU7LBlI6T8inCQUxnMBFHrbqWw==
-  dependencies:
-    "@pkgr/utils" "^2.3.0"
-    tslib "^2.4.0"
-
-synckit@^0.8.4:
+synckit@^0.8.1, synckit@^0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.8.4.tgz#0e6b392b73fafdafcde56692e3352500261d64ec"
   integrity sha512-Dn2ZkzMdSX827QbowGbU/4yjWuvNaCoScLLoMo/yKbu+P4GBR6cRGKZH27k6a9bRzdqcyd1DE96pQtQ6uNkmyw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3105,7 +3105,7 @@
     node-gyp "^8.2.0"
     read-package-json-fast "^2.0.1"
 
-"@pkgr/utils@^2.3.0":
+"@pkgr/utils@^2.3.0", "@pkgr/utils@^2.3.1":
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/@pkgr/utils/-/utils-2.3.1.tgz#0a9b06ffddee364d6642b3cd562ca76f55b34a03"
   integrity sha512-wfzX8kc1PMyUILA+1Z/EqoE4UCXGy0iRGMhPwdfae1+f0OXlLqCk+By+aMzgJBzR9AzS4CDizioG6Ss1gvAFJw==
@@ -6435,6 +6435,19 @@ eslint-import-resolver-node@^0.3.6:
     debug "^3.2.7"
     resolve "^1.20.0"
 
+eslint-import-resolver-typescript@3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.5.2.tgz#9431acded7d898fd94591a08ea9eec3514c7de91"
+  integrity sha512-zX4ebnnyXiykjhcBvKIf5TNvt8K7yX6bllTRZ14MiurKPjDpCAZujlszTdB8pcNXhZcOf+god4s9SjQa5GnytQ==
+  dependencies:
+    debug "^4.3.4"
+    enhanced-resolve "^5.10.0"
+    get-tsconfig "^4.2.0"
+    globby "^13.1.2"
+    is-core-module "^2.10.0"
+    is-glob "^4.0.3"
+    synckit "^0.8.4"
+
 eslint-module-utils@^2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.7.4.tgz#4f3e41116aaf13a20792261e61d3a2e7e0583974"
@@ -7303,6 +7316,11 @@ get-symbol-description@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
+get-tsconfig@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.2.0.tgz#ff368dd7104dab47bf923404eb93838245c66543"
+  integrity sha512-X8u8fREiYOE6S8hLbq99PeykTDoLVnxvF4DjWKJmz9xy2nNRdUcV8ZN9tniJFeKyTU3qnC9lL8n4Chd6LmVKHg==
+
 git-hooks-list@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/git-hooks-list/-/git-hooks-list-1.0.3.tgz#be5baaf78203ce342f2f844a9d2b03dba1b45156"
@@ -8041,6 +8059,13 @@ is-ci@^3.0.1:
   integrity sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==
   dependencies:
     ci-info "^3.2.0"
+
+is-core-module@^2.10.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
+  integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
+  dependencies:
+    has "^1.0.3"
 
 is-core-module@^2.2.0, is-core-module@^2.8.1, is-core-module@^2.9.0:
   version "2.10.0"
@@ -13164,6 +13189,14 @@ synckit@^0.8.1:
   integrity sha512-1goXnDYNJlKwCM37f5MTzRwo+8SqutgVtg2d37D6YnHHT4E3IhQMRfKiGdfTZU7LBlI6T8inCQUxnMBFHrbqWw==
   dependencies:
     "@pkgr/utils" "^2.3.0"
+    tslib "^2.4.0"
+
+synckit@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.8.4.tgz#0e6b392b73fafdafcde56692e3352500261d64ec"
+  integrity sha512-Dn2ZkzMdSX827QbowGbU/4yjWuvNaCoScLLoMo/yKbu+P4GBR6cRGKZH27k6a9bRzdqcyd1DE96pQtQ6uNkmyw==
+  dependencies:
+    "@pkgr/utils" "^2.3.1"
     tslib "^2.4.0"
 
 table-layout@^1.0.2:


### PR DESCRIPTION
Removes `apps/site/tests/package.json` (with `"type": "commonjs"`), unblocks dependency updates such as [`execa@6`](https://github.com/sindresorhus/execa/releases/tag/v6.0.0) (which is needed in https://github.com/blockprotocol/blockprotocol/pull/703 / [internal Asana task](https://app.asana.com/0/1203007126736610/1203225227202716/f))

[Playwright docs on ESM](https://playwright.dev/docs/test-typescript#typescript-with-esm)

CJS to ESM conversion can be expanded to the entire `@apps/site` package in #709.

Also fixes `import/no-unresolved` for ESM imports by adding `"eslint-import-resolver-typescript"`. This can improve linting in other ESM-only packages in the future (`block-scripts` etc.).