### PR TITLE
Reduce Playwright test flakiness

### DIFF
--- a/apps/site/playwright.config.ts
+++ b/apps/site/playwright.config.ts
@@ -9,7 +9,7 @@ const ci = process.env.CI === "true";
 process.env.ISTANBUL_TEMP_DIR = "../../.nyc_output";
 
 const integrationTestsBaseConfig = {
-  retries: 1,
+  retries: 2,
   testMatch: "**/{integration,universal}/**",
 };
 
@@ -51,7 +51,7 @@ const config: PlaywrightTestConfig = {
     },
     {
       name: "e2e",
-      retries: 0,
+      retries: 1,
       testMatch: "**/{e2e,universal}/**",
       use: { ...devices["Desktop Chrome"] },
     },

--- a/apps/site/tests/integration/api-keys.test.ts
+++ b/apps/site/tests/integration/api-keys.test.ts
@@ -49,9 +49,9 @@ test("API key page should generate a valid key", async ({
   const apiKeyValue =
     (await page.locator('[data-testid="api-key-value"]').textContent()) ?? "";
 
-  await page.locator("text=Copy to Clipboard").click();
+  // ”Copy to Clipboard” does not work in Webkit on Linux
   if (browserName !== "webkit") {
-    // ”Copy to Clipboard” does not work in Webkit on Linux
+    await page.locator("text=Copy to Clipboard").click();
     await expect(page.locator("text=✓ Copied")).toBeVisible();
   }
   await page.locator("text=Go back").click();
@@ -94,9 +94,9 @@ test("API key page should generate a valid key", async ({
   expect(apiKeyValue).not.toEqual(apiKeyValue2);
   expect(publicKeyId).not.toEqual(publicKeyId2);
 
-  await page.locator("text=Copy to Clipboard").click();
+  // ”Copy to Clipboard” does not work in Webkit on Linux
   if (browserName !== "webkit") {
-    // ”Copy to Clipboard” does not work in Webkit on Linux
+    await page.locator("text=Copy to Clipboard").click();
     await expect(page.locator("text=✓ Copied")).toBeVisible();
   }
   await expect(page.locator("text=my first key regenerated")).toBeVisible();


### PR DESCRIPTION
This PR

- Increases the number of retries
- Skip pressing ‘Copy to Clipboard’ in Safari (may prevent internal hanging?)

Used Safari traces from https://github.com/blockprotocol/blockprotocol/actions/runs/3328626488

The test occasionally fails when pressing ‘Go back’ right after pressing ’Copy to Clibpoard’:

<img width="1520" alt="Screenshot 2022-10-26 at 18 32 31" src="https://user-images.githubusercontent.com/608862/198097820-7c39adb2-28d0-49bd-800c-83efc322ffa9.png">

This is how a successful click looks like (same run, just further up in the file):

<img width="1523" alt="Screenshot 2022-10-26 at 18 33 48" src="https://user-images.githubusercontent.com/608862/198098230-0e4d787f-d822-416a-b346-58c92bf7d10b.png">


If this PR’s diff does not reduce flakiness, I’ll try something else.