### PR TITLE
Improve TS Types of the Type System Package

### DIFF
--- a/crates/type-system/src/ontology/data_type/repr.rs
+++ b/crates/type-system/src/ontology/data_type/repr.rs
@@ -22,6 +22,7 @@ enum DataTypeTag {
 pub struct DataType {
     #[cfg_attr(target_arch = "wasm32", tsify(type = "'dataType'"))]
     kind: DataTypeTag,
+    #[cfg_attr(target_arch = "wasm32", tsify(type = "VersionedUri"))]
     #[serde(rename = "$id")]
     id: String,
     title: String,

--- a/crates/type-system/src/ontology/data_type/repr.rs
+++ b/crates/type-system/src/ontology/data_type/repr.rs
@@ -73,6 +73,7 @@ impl From<super::DataType> for DataType {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DataTypeReference {
+    #[cfg_attr(target_arch = "wasm32", tsify(type = "VersionedUri"))]
     #[serde(rename = "$ref")]
     uri: String,
 }

--- a/crates/type-system/src/ontology/entity_type/links/repr.rs
+++ b/crates/type-system/src/ontology/entity_type/links/repr.rs
@@ -17,7 +17,7 @@ pub struct Links {
         target_arch = "wasm32",
         tsify(
             optional,
-            type = "Record<VersionedUri, MaybeOrderedArray<OneOf<EntityTypeReference>>>"
+            type = "Record<VersionedUri, MaybeOrderedArray<MaybeOneOfEntityTypeReference>>"
         )
     )]
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]

--- a/crates/type-system/src/ontology/entity_type/links/repr.rs
+++ b/crates/type-system/src/ontology/entity_type/links/repr.rs
@@ -13,8 +13,16 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Links {
+    #[cfg_attr(
+        target_arch = "wasm32",
+        tsify(
+            optional,
+            type = "Record<VersionedUri, MaybeOrderedArray<OneOf<EntityTypeReference>>>"
+        )
+    )]
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     links: HashMap<String, MaybeOrderedArray<MaybeOneOfEntityTypeReference>>,
+    #[cfg_attr(target_arch = "wasm32", tsify(optional, type = "VersionedUri[]"))]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     required_links: Vec<String>,
 }

--- a/crates/type-system/src/ontology/entity_type/repr.rs
+++ b/crates/type-system/src/ontology/entity_type/repr.rs
@@ -23,6 +23,7 @@ enum EntityTypeTag {
 pub struct EntityType {
     #[cfg_attr(target_arch = "wasm32", tsify(type = "'entityType'"))]
     kind: EntityTypeTag,
+    #[cfg_attr(target_arch = "wasm32", tsify(type = "VersionedUri"))]
     #[serde(rename = "$id")]
     id: String,
     title: String,
@@ -32,10 +33,13 @@ pub struct EntityType {
     #[serde(flatten)]
     all_of: repr::AllOf<EntityTypeReference>,
     // TODO - Improve the typing of the values
-    #[cfg_attr(target_arch = "wasm32", tsify(type = "Record<BaseUri, any>"))]
+    #[cfg_attr(target_arch = "wasm32", tsify(optional, type = "Record<BaseUri, any>"))]
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     default: HashMap<String, serde_json::Value>,
-    #[cfg_attr(target_arch = "wasm32", tsify(type = "Record<BaseUri, any>[]"))]
+    #[cfg_attr(
+        target_arch = "wasm32",
+        tsify(optional, type = "Record<BaseUri, any>[]")
+    )]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     examples: Vec<HashMap<String, serde_json::Value>>,
     #[serde(flatten)]

--- a/crates/type-system/src/ontology/entity_type/repr.rs
+++ b/crates/type-system/src/ontology/entity_type/repr.rs
@@ -145,6 +145,7 @@ impl From<super::EntityType> for EntityType {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EntityTypeReference {
+    #[cfg_attr(target_arch = "wasm32", tsify(type = "VersionedUri"))]
     #[serde(rename = "$ref")]
     uri: String,
 }

--- a/crates/type-system/src/ontology/property_type/repr.rs
+++ b/crates/type-system/src/ontology/property_type/repr.rs
@@ -23,6 +23,7 @@ enum PropertyTypeTag {
 pub struct PropertyType {
     #[cfg_attr(target_arch = "wasm32", tsify(type = "'propertyType'"))]
     kind: PropertyTypeTag,
+    #[cfg_attr(target_arch = "wasm32", tsify(type = "VersionedUri"))]
     #[serde(rename = "$id")]
     id: String,
     title: String,

--- a/crates/type-system/src/ontology/property_type/repr.rs
+++ b/crates/type-system/src/ontology/property_type/repr.rs
@@ -67,6 +67,7 @@ impl From<super::PropertyType> for PropertyType {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PropertyTypeReference {
+    #[cfg_attr(target_arch = "wasm32", tsify(type = "VersionedUri"))]
     #[serde(rename = "$ref")]
     uri: String,
 }

--- a/crates/type-system/src/ontology/shared/all_of/repr.rs
+++ b/crates/type-system/src/ontology/shared/all_of/repr.rs
@@ -8,6 +8,7 @@ use crate::{repr, EntityTypeReference, ParseAllOfError};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AllOf<T> {
+    #[cfg_attr(target_arch = "wasm32", tsify(optional, type = "T[]"))]
     #[serde(
         rename = "allOf",
         default = "Vec::new",

--- a/crates/type-system/src/ontology/shared/object/repr.rs
+++ b/crates/type-system/src/ontology/shared/object/repr.rs
@@ -21,7 +21,9 @@ enum ObjectTypeTag {
 pub struct Object<T> {
     #[cfg_attr(target_arch = "wasm32", tsify(type = "'object'"))]
     r#type: ObjectTypeTag,
+    #[cfg_attr(target_arch = "wasm32", tsify(type = "Record<BaseUri, T>"))]
     properties: HashMap<String, T>,
+    #[cfg_attr(target_arch = "wasm32", tsify(optional, type = "BaseUri[]"))]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     required: Vec<String>,
 }

--- a/packages/@blockprotocol/type-system-node/dist/index.d.ts
+++ b/packages/@blockprotocol/type-system-node/dist/index.d.ts
@@ -6,8 +6,8 @@ export interface OneOf<T> {
 
 export interface Object<T> {
     type: 'object';
-    properties: Record<string, T>;
-    required?: string[];
+    properties: Record<BaseUri, T>;
+    required?: BaseUri[];
 }
 
 export type ValueOrArray<T> = T | Array<T>;
@@ -55,13 +55,13 @@ export type ParseDataTypeError = { reason: "InvalidVersionedUri"; inner: ParseVe
 
 export interface PropertyType extends OneOf<PropertyValues> {
     kind: 'propertyType';
-    $id: string;
+    $id: VersionedUri;
     title: string;
     description?: string;
 }
 
 export interface PropertyTypeReference {
-    $ref: string;
+    $ref: VersionedUri;
 }
 
 export type PropertyValues = DataTypeReference | Object<ValueOrArray<PropertyTypeReference>> | Array<OneOf<PropertyValues>>;
@@ -119,12 +119,12 @@ export type ParseVersionedUriError = { reason: "IncorrectFormatting" } | { reaso
 export type ParseBaseUriError = { reason: "MissingTrailingSlash" } | { reason: "UrlParseError"; inner: string } | { reason: "CannotBeABase" };
 
 export interface EntityTypeReference {
-    $ref: string;
+    $ref: VersionedUri;
 }
 
 export interface EntityType extends AllOf<EntityTypeReference>, Object<ValueOrArray<PropertyTypeReference>>, Links {
     kind: 'entityType';
-    $id: string;
+    $id: VersionedUri;
     title: string;
     description?: string;
     default?: Record<BaseUri, any>;
@@ -132,8 +132,8 @@ export interface EntityType extends AllOf<EntityTypeReference>, Object<ValueOrAr
 }
 
 export interface Links {
-    links?: Record<string, MaybeOrderedArray<MaybeOneOfEntityTypeReference>>;
-    requiredLinks?: string[];
+    links?: Record<VersionedUri, MaybeOrderedArray<OneOf<EntityTypeReference>>>;
+    requiredLinks?: VersionedUri[];
 }
 
 export interface MaybeOrderedArray<T> extends Array<T> {
@@ -157,12 +157,12 @@ export type ParseOneOfError = { reason: "EntityTypeReferenceError"; inner: Parse
 export type ParseEntityTypeError = { reason: "InvalidPropertyTypeObject"; inner: ParsePropertyTypeObjectError } | { reason: "InvalidAllOf"; inner: ParseAllOfError } | { reason: "InvalidLinks"; inner: ParseLinksError } | { reason: "InvalidDefaultKey"; inner: ParseBaseUriError } | { reason: "InvalidExamplesKey"; inner: ParseBaseUriError } | { reason: "InvalidVersionedUri"; inner: ParseVersionedUriError } | { reason: "InvalidJson"; inner: string };
 
 export interface DataTypeReference {
-    $ref: string;
+    $ref: VersionedUri;
 }
 
 export interface DataType extends Record<string, any> {
     kind: 'dataType';
-    $id: string;
+    $id: VersionedUri;
     title: string;
     description?: string;
     type: string;

--- a/packages/@blockprotocol/type-system-node/dist/index.d.ts
+++ b/packages/@blockprotocol/type-system-node/dist/index.d.ts
@@ -132,7 +132,7 @@ export interface EntityType extends AllOf<EntityTypeReference>, Object<ValueOrAr
 }
 
 export interface Links {
-    links?: Record<VersionedUri, MaybeOrderedArray<OneOf<EntityTypeReference>>>;
+    links?: Record<VersionedUri, MaybeOrderedArray<MaybeOneOfEntityTypeReference>>;
     requiredLinks?: VersionedUri[];
 }
 

--- a/packages/@blockprotocol/type-system-web/dist/index.d.ts
+++ b/packages/@blockprotocol/type-system-web/dist/index.d.ts
@@ -6,8 +6,8 @@ export interface OneOf<T> {
 
 export interface Object<T> {
     type: 'object';
-    properties: Record<string, T>;
-    required?: string[];
+    properties: Record<BaseUri, T>;
+    required?: BaseUri[];
 }
 
 export type ValueOrArray<T> = T | Array<T>;
@@ -55,13 +55,13 @@ export type ParseDataTypeError = { reason: "InvalidVersionedUri"; inner: ParseVe
 
 export interface PropertyType extends OneOf<PropertyValues> {
     kind: 'propertyType';
-    $id: string;
+    $id: VersionedUri;
     title: string;
     description?: string;
 }
 
 export interface PropertyTypeReference {
-    $ref: string;
+    $ref: VersionedUri;
 }
 
 export type PropertyValues = DataTypeReference | Object<ValueOrArray<PropertyTypeReference>> | Array<OneOf<PropertyValues>>;
@@ -119,12 +119,12 @@ export type ParseVersionedUriError = { reason: "IncorrectFormatting" } | { reaso
 export type ParseBaseUriError = { reason: "MissingTrailingSlash" } | { reason: "UrlParseError"; inner: string } | { reason: "CannotBeABase" };
 
 export interface EntityTypeReference {
-    $ref: string;
+    $ref: VersionedUri;
 }
 
 export interface EntityType extends AllOf<EntityTypeReference>, Object<ValueOrArray<PropertyTypeReference>>, Links {
     kind: 'entityType';
-    $id: string;
+    $id: VersionedUri;
     title: string;
     description?: string;
     default?: Record<BaseUri, any>;
@@ -132,8 +132,8 @@ export interface EntityType extends AllOf<EntityTypeReference>, Object<ValueOrAr
 }
 
 export interface Links {
-    links?: Record<string, MaybeOrderedArray<MaybeOneOfEntityTypeReference>>;
-    requiredLinks?: string[];
+    links?: Record<VersionedUri, MaybeOrderedArray<OneOf<EntityTypeReference>>>;
+    requiredLinks?: VersionedUri[];
 }
 
 export interface MaybeOrderedArray<T> extends Array<T> {
@@ -157,12 +157,12 @@ export type ParseOneOfError = { reason: "EntityTypeReferenceError"; inner: Parse
 export type ParseEntityTypeError = { reason: "InvalidPropertyTypeObject"; inner: ParsePropertyTypeObjectError } | { reason: "InvalidAllOf"; inner: ParseAllOfError } | { reason: "InvalidLinks"; inner: ParseLinksError } | { reason: "InvalidDefaultKey"; inner: ParseBaseUriError } | { reason: "InvalidExamplesKey"; inner: ParseBaseUriError } | { reason: "InvalidVersionedUri"; inner: ParseVersionedUriError } | { reason: "InvalidJson"; inner: string };
 
 export interface DataTypeReference {
-    $ref: string;
+    $ref: VersionedUri;
 }
 
 export interface DataType extends Record<string, any> {
     kind: 'dataType';
-    $id: string;
+    $id: VersionedUri;
     title: string;
     description?: string;
     type: string;

--- a/packages/@blockprotocol/type-system-web/dist/index.d.ts
+++ b/packages/@blockprotocol/type-system-web/dist/index.d.ts
@@ -132,7 +132,7 @@ export interface EntityType extends AllOf<EntityTypeReference>, Object<ValueOrAr
 }
 
 export interface Links {
-    links?: Record<VersionedUri, MaybeOrderedArray<OneOf<EntityTypeReference>>>;
+    links?: Record<VersionedUri, MaybeOrderedArray<MaybeOneOfEntityTypeReference>>;
     requiredLinks?: VersionedUri[];
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We had a number of spots in the Type System packages where non-ideal types were being used, strings instead of `VersionedUri` for example, and a few other things.

This PR generally improves the usabilities of the interfaces. 

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1201095311341924/1202981263631815/f) _(internal)_

## 🔍 What does this change?

- `DataTypeReference`, `PropertyTypeReference`, and `EntityTypeReference` now has `VersionedUri` instead of `string`
- The `links` object on `EntityType` has been much improved
- A lot of fields have been marked as optional when they were previously required
- `$id` in schemas are correctly typed as `VersionedUri`s
- `BaseUri` is used in more places where it should be
- Some other improvements, see the generated binding file

## 📜 Does this require a change to the docs?

- The TypeScript bindings act as the doc at the moment

## 🛡 What tests cover this?

- The Rust unit tests
- Node-variant of the Type System package integration tests

## ❓ How to test this?

1.  Run `cargo make test` from inside the crate
1.  Run `yarn test` from inside the node variant of the type-system package.
