### PR TITLE
Patch Changesets CLI

### DIFF
--- a/patches/@changesets+cli+2.25.0.patch
+++ b/patches/@changesets+cli+2.25.0.patch
@@ -1,0 +1,42 @@
+diff --git a/node_modules/@changesets/cli/dist/cli.cjs.dev.js b/node_modules/@changesets/cli/dist/cli.cjs.dev.js
+index e903107..1e7fc8e 100644
+--- a/node_modules/@changesets/cli/dist/cli.cjs.dev.js
++++ b/node_modules/@changesets/cli/dist/cli.cjs.dev.js
+@@ -1164,7 +1164,8 @@ async function getStatus(cwd, {
+     ref: sinceBranch || config.baseBranch
+   });
+ 
+-  if (changedPackages.length > 0 && changesets.length === 0) {
++  // Adding `false` prevents CI failures in Renovate PRs that immedeately follow ‘Version Packages’
++  if (false && changedPackages.length > 0 && changesets.length === 0) {
+     logger.error("Some packages have been changed but no changesets were found. Run `changeset add` to resolve this error.");
+     logger.error("If this change doesn't need a release, run `changeset add --empty`.");
+     process.exit(1);
+diff --git a/node_modules/@changesets/cli/dist/cli.cjs.prod.js b/node_modules/@changesets/cli/dist/cli.cjs.prod.js
+index fe411b2..9f748a0 100644
+--- a/node_modules/@changesets/cli/dist/cli.cjs.prod.js
++++ b/node_modules/@changesets/cli/dist/cli.cjs.prod.js
+@@ -625,7 +625,8 @@ async function getStatus(cwd, {sinceMaster: sinceMaster, since: since, verbose:
+   sinceMaster && (logger.warn("--sinceMaster is deprecated and will be removed in a future major version"), 
+   logger.warn("Use --since=master instead"));
+   const sinceBranch = void 0 === since ? sinceMaster ? "master" : void 0 : since, releasePlan = await getReleasePlan__default.default(cwd, sinceBranch, config), {changesets: changesets, releases: releases} = releasePlan;
+-  if ((await git.getChangedPackagesSinceRef({
++  // Adding `false` prevents CI failures in Renovate PRs that immedeately follow ‘Version Packages’
++  if (false && (await git.getChangedPackagesSinceRef({
+     cwd: cwd,
+     ref: sinceBranch || config.baseBranch
+   })).length > 0 && 0 === changesets.length && (logger.error("Some packages have been changed but no changesets were found. Run `changeset add` to resolve this error."), 
+diff --git a/node_modules/@changesets/cli/dist/cli.esm.js b/node_modules/@changesets/cli/dist/cli.esm.js
+index ffd9f1b..07acb23 100644
+--- a/node_modules/@changesets/cli/dist/cli.esm.js
++++ b/node_modules/@changesets/cli/dist/cli.esm.js
+@@ -1141,7 +1141,8 @@ async function getStatus(cwd, {
+     ref: sinceBranch || config.baseBranch
+   });
+ 
+-  if (changedPackages.length > 0 && changesets.length === 0) {
++  // Adding `false` prevents CI failures in Renovate PRs that immedeately follow ‘Version Packages’
++  if (false && changedPackages.length > 0 && changesets.length === 0) {
+     error("Some packages have been changed but no changesets were found. Run `changeset add` to resolve this error.");
+     error("If this change doesn't need a release, run `changeset add --empty`.");
+     process.exit(1);

--- a/patches/@changesets+cli+2.25.0.patch
+++ b/patches/@changesets+cli+2.25.0.patch
@@ -1,42 +1,42 @@
 diff --git a/node_modules/@changesets/cli/dist/cli.cjs.dev.js b/node_modules/@changesets/cli/dist/cli.cjs.dev.js
-index e903107..1e7fc8e 100644
+index e903107..eb48efb 100644
 --- a/node_modules/@changesets/cli/dist/cli.cjs.dev.js
 +++ b/node_modules/@changesets/cli/dist/cli.cjs.dev.js
-@@ -1164,7 +1164,8 @@ async function getStatus(cwd, {
-     ref: sinceBranch || config.baseBranch
-   });
- 
--  if (changedPackages.length > 0 && changesets.length === 0) {
-+  // Adding `false` prevents CI failures in Renovate PRs that immedeately follow ‘Version Packages’
-+  if (false && changedPackages.length > 0 && changesets.length === 0) {
+@@ -1167,7 +1167,8 @@ async function getStatus(cwd, {
+   if (changedPackages.length > 0 && changesets.length === 0) {
      logger.error("Some packages have been changed but no changesets were found. Run `changeset add` to resolve this error.");
      logger.error("If this change doesn't need a release, run `changeset add --empty`.");
-     process.exit(1);
+-    process.exit(1);
++    // Prevent CI failures in Renovate PRs that immedeately follow ‘Version Packages’
++    // process.exit(1);
+   }
+ 
+   if (output) {
 diff --git a/node_modules/@changesets/cli/dist/cli.cjs.prod.js b/node_modules/@changesets/cli/dist/cli.cjs.prod.js
-index fe411b2..9f748a0 100644
+index fe411b2..85aafb3 100644
 --- a/node_modules/@changesets/cli/dist/cli.cjs.prod.js
 +++ b/node_modules/@changesets/cli/dist/cli.cjs.prod.js
-@@ -625,7 +625,8 @@ async function getStatus(cwd, {sinceMaster: sinceMaster, since: since, verbose:
-   sinceMaster && (logger.warn("--sinceMaster is deprecated and will be removed in a future major version"), 
-   logger.warn("Use --since=master instead"));
-   const sinceBranch = void 0 === since ? sinceMaster ? "master" : void 0 : since, releasePlan = await getReleasePlan__default.default(cwd, sinceBranch, config), {changesets: changesets, releases: releases} = releasePlan;
--  if ((await git.getChangedPackagesSinceRef({
-+  // Adding `false` prevents CI failures in Renovate PRs that immedeately follow ‘Version Packages’
-+  if (false && (await git.getChangedPackagesSinceRef({
-     cwd: cwd,
+@@ -630,7 +630,8 @@ async function getStatus(cwd, {sinceMaster: sinceMaster, since: since, verbose:
      ref: sinceBranch || config.baseBranch
    })).length > 0 && 0 === changesets.length && (logger.error("Some packages have been changed but no changesets were found. Run `changeset add` to resolve this error."), 
+   logger.error("If this change doesn't need a release, run `changeset add --empty`."),
+-  process.exit(1)), output) return void await fs__default.default.writeFile(path__default.default.join(cwd, output), JSON.stringify(releasePlan, void 0, 2));
++  // Prevent CI failures in Renovate PRs that immedeately follow ‘Version Packages’
++  /* process.exit(1) */ false), output) return void await fs__default.default.writeFile(path__default.default.join(cwd, output), JSON.stringify(releasePlan, void 0, 2));
+   const print = verbose ? verbosePrint : SimplePrint;
+   return print("patch", releases), logger.log("---"), print("minor", releases), logger.log("---"), 
+   print("major", releases), releasePlan;
 diff --git a/node_modules/@changesets/cli/dist/cli.esm.js b/node_modules/@changesets/cli/dist/cli.esm.js
-index ffd9f1b..07acb23 100644
+index ffd9f1b..aa03f1c 100644
 --- a/node_modules/@changesets/cli/dist/cli.esm.js
 +++ b/node_modules/@changesets/cli/dist/cli.esm.js
-@@ -1141,7 +1141,8 @@ async function getStatus(cwd, {
-     ref: sinceBranch || config.baseBranch
-   });
- 
--  if (changedPackages.length > 0 && changesets.length === 0) {
-+  // Adding `false` prevents CI failures in Renovate PRs that immedeately follow ‘Version Packages’
-+  if (false && changedPackages.length > 0 && changesets.length === 0) {
+@@ -1144,7 +1144,8 @@ async function getStatus(cwd, {
+   if (changedPackages.length > 0 && changesets.length === 0) {
      error("Some packages have been changed but no changesets were found. Run `changeset add` to resolve this error.");
      error("If this change doesn't need a release, run `changeset add --empty`.");
-     process.exit(1);
+-    process.exit(1);
++    // Prevent CI failures in Renovate PRs that immedeately follow ‘Version Packages’
++    // process.exit(1);
+   }
+ 
+   if (output) {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR prevents CI failures in Renovate PRs that immediately follow ‘Version Packages’.
<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203007126736613/1203268787004289/f) _(internal)_


## 🔍 What does this change?

`yarn lint:changeset` (i.e. `yarn changeset status`) no longer fails when no changeset files are found. This avoids CI failures in Renovate PRs, e.g.:
https://github.com/blockprotocol/blockprotocol/actions/runs/3357688943/jobs/5563688194#step:5:1

## ⚠️ Known issues

Disabling the check means that in theory we can forget adding a Changesets entry in a valid case. However, it seems that [the existing check](https://github.com/changesets/changesets/blob/c1401716cf5ee839aaa02ea7ff8f23f8af8bf5b0/packages/cli/src/commands/status/index.ts#L46-L54) only works until the first changeset is added. For example, adding a changeset for package `a` in PR1 disables the check for package `b` in PR2, unless there has been a new release between PR1 and PR2.

## 📜 Does this require a change to the docs?

No

## 🐾 Next steps

Rebase and merge open Renvote PRs
- https://github.com/blockprotocol/blockprotocol/pull/727
- https://github.com/blockprotocol/blockprotocol/pull/728
- https://github.com/blockprotocol/blockprotocol/pull/729
- https://github.com/blockprotocol/blockprotocol/pull/730

## 🧪 How to test this?

Step 1

```
git switch renovate/react-18.x
yarn lint:changeset
```
↓
```
🦋  error Some packages have been changed but no changesets were found. Run `changeset add` to resolve this error.
🦋  error If this change doesn't need a release, run `changeset add --empty`.
```

Step 2
```sh
git checkout ak/patch-changesets-cli patches/@changesets+cli+2.25.0.patch
yarn lint:changeset
```
↓
```
🦋  error Some packages have been changed but no changesets were found. Run `changeset add` to resolve this error.
🦋  error If this change doesn't need a release, run `changeset add --empty`.
🦋  info NO packages to be bumped at patch
🦋  ---
🦋  info NO packages to be bumped at minor
🦋  ---
🦋  info NO packages to be bumped at major
```