### PR TITLE
Add Semgrep GitHub Action

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,22 @@
+name: Semgrep
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/semgrep.yml
+  schedule:
+    - cron: '0 0 * * 0'
+jobs:
+  semgrep:
+    name: Scan
+    runs-on: ubuntu-20.04
+    env:
+      SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+    container:
+      image: returntocorp/semgrep
+    if: (github.actor != 'dependabot[bot]')
+    steps:
+      - uses: actions/checkout@v3
+      - run: semgrep ci

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,5 +1,6 @@
 name: Semgrep
 on:
+  # Scan changed files in PRs (diff-aware scanning):
   pull_request: {}
   push:
     branches:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,25 +9,25 @@ on:
       - main
   # Schedule the CI job (this method uses cron syntax):
   schedule:
-    - cron: '30 0 1,15 * *' # scheduled for 00:30 UTC on both the 1st and 15th of the month
-    
+    - cron: "30 0 1,15 * *" # scheduled for 00:30 UTC on both the 1st and 15th of the month
+
 jobs:
   semgrep:
     name: Scan
-    
+
     # Change this in the event of future self-hosting of Action runner:
     runs-on: ubuntu-latest
-    
+
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
-      
+
     container:
       # A Docker image with Semgrep installed:
       image: returntocorp/semgrep
-      
+
     # Skip any PR created by dependabot to avoid permission issues:
     if: (github.actor != 'dependabot[bot]')
-    
+
     steps:
       - uses: actions/checkout@v3
       - run: semgrep ci

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - .github/workflows/semgrep.yml
   schedule:
     - cron: '0 0 * * 0'
 jobs:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -17,6 +17,7 @@ jobs:
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:
+      # A Docker image with Semgrep installed:
       image: returntocorp/semgrep
     if: (github.actor != 'dependabot[bot]')
     steps:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,4 +1,5 @@
 name: Semgrep
+
 on:
   # Scan changed files in PRs (diff-aware scanning):
   pull_request: {}
@@ -9,17 +10,24 @@ on:
   # Schedule the CI job (this method uses cron syntax):
   schedule:
     - cron: '30 0 1,15 * *' # scheduled for 00:30 UTC on both the 1st and 15th of the month
+    
 jobs:
   semgrep:
     name: Scan
+    
     # Change this in the event of future self-hosting of Action runner:
     runs-on: ubuntu-latest
+    
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
+      
     container:
       # A Docker image with Semgrep installed:
       image: returntocorp/semgrep
+      
+    # Skip any PR created by dependabot to avoid permission issues:
     if: (github.actor != 'dependabot[bot]')
+    
     steps:
       - uses: actions/checkout@v3
       - run: semgrep ci

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+  # Schedule the CI job (this method uses cron syntax):
   schedule:
     - cron: '0 0 * * 0'
 jobs:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -12,7 +12,8 @@ on:
 jobs:
   semgrep:
     name: Scan
-    runs-on: ubuntu-20.04
+    # Change this in the event of future self-hosting of Action runner:
+    runs-on: ubuntu-latest
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -8,7 +8,7 @@ on:
       - main
   # Schedule the CI job (this method uses cron syntax):
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: '30 0 1,15 * *' # scheduled for 00:30 UTC on both the 1st and 15th of the month
 jobs:
   semgrep:
     name: Scan

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -2,6 +2,7 @@ name: Semgrep
 on:
   # Scan changed files in PRs (diff-aware scanning):
   pull_request: {}
+  # Scan mainline branches and report all findings:
   push:
     branches:
       - main


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds a CI job for Semgrep scanning the repo on proposed merges into `main`, similar to that in use in [`@hashintel/hash`](https://github.com/hashintel/hash).

## Next steps

Once this has been reviewed and we're happy with it, we should update the [corresponding file](https://github.com/hashintel/hash/blob/main/.github/workflows/semgrep.yml) in `@hashintel/hash` to reflect our new understanding of best-practice here (minor modifications only expected).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203364310192415