### PR TITLE
Update Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,7 @@
   "prConcurrentLimit": 10,
   "enabledManagers": ["github-actions", "npm"],
   "rebaseWhen": "conflicted",
-  "schedule": ["every weekday before 5am"],
+  "schedule": ["monday before 5am", "thursday before 5am"],
   "packageRules": [
     {
       "matchManagers": ["npm"],
@@ -26,6 +26,7 @@
         "^envalid$",
         "^execa$",
         "^lit$",
+        "^webpack$",
         "^webpack-cli$",
         "^webpack-dev-server$"
       ]


### PR DESCRIPTION
## 🔍 What does this change?

- Mirror https://github.com/hashintel/hash/pull/1427: Dependency PRs are created on Monday and Thursday only (to reduce PR spam)

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Avoid version mismatch for webpack, like in https://github.com/blockprotocol/blockprotocol/pull/760


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203362004694922