### PR TITLE
Stop DB in Site integration tests CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,10 @@ jobs:
         ## https://github.com/tiaanduplessis/kill-port/issues/48
         # run: yarn kill-port 3000
 
+      - name: Stop DB
+        if: ${{ success() || failure() }}
+        run: docker-compose -f apps/site/docker-compose.dev.yml down
+
       - name: Generate coverage report
         if: ${{ success() || failure() }}
         run: yarn nyc report --reporter=lcovonly --reporter=text
@@ -323,10 +327,6 @@ jobs:
           files: coverage/lcov.info
           flags: site-integration-${{ matrix.device }}
           token: ${{ secrets.CODECOV_TOKEN }} ## not required for public repos, can be removed when https://github.com/codecov/codecov-action/issues/837 is resolved
-
-      - name: Stop DB
-        if: ${{ success() || failure() }}
-        run: docker-compose -f docker-compose.dev.yml down
 
       - name: Show DB logs
         if: ${{ success() || failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,6 +324,10 @@ jobs:
           flags: site-integration-${{ matrix.device }}
           token: ${{ secrets.CODECOV_TOKEN }} ## not required for public repos, can be removed when https://github.com/codecov/codecov-action/issues/837 is resolved
 
+      - name: Stop DB
+        if: ${{ success() || failure() }}
+        run: docker-compose -f docker-compose.dev.yml down
+
       - name: Show DB logs
         if: ${{ success() || failure() }}
         run: cat var/logs/db.log


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR supplements https://github.com/blockprotocol/blockprotocol/issues/715. Stopping the DB should prevent changes in `var` while this folder is being uploaded as an artifact. This should reduce the probability of hanged (and therefore cancelled) Playwright jobs, which are now compulsory for PR merging.


<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- https://github.com/actions/upload-artifact/issues/358
- [Recent failure example](https://github.com/blockprotocol/blockprotocol/actions/runs/3489080330/jobs/5838721922)
