### PR TITLE
Reconfigure Renovate (cover all dependencies)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,55 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+
   "automerge": true,
   "dependencyDashboard": true,
   "dependencyDashboardApproval": true,
-  "enabledManagers": ["github-actions", "npm"],
   "postUpdateOptions": ["yarnDedupeFewer"],
+  "rangeStrategy": "bump",
   "rebaseWhen": "conflicted",
   "packageRules": [
-    {
-      "matchManagers": ["npm"],
-      "rangeStrategy": "bump"
-    },
-    {
-      "enabled": false,
-      "matchDepTypes": ["dependencies", "peerDependencies"],
-      "matchManagers": ["npm"]
-    },
-    {
-      "enabled": true,
-      "matchManagers": ["npm"],
-      "matchPackagePatterns": [
-        "^axios$",
-        "^chalk$",
-        "^core-js$",
-        "^envalid$",
-        "^execa$",
-        "^lit$",
-        "^typescript$",
-        "^webpack$",
-        "^webpack-cli$",
-        "^webpack-dev-server$"
-      ]
-    },
-    {
-      "enabled": true,
-      "groupName": "Babel",
-      "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^@babel/", "^babel-", "^babel$"]
-    },
-    {
-      "enabled": true,
-      "groupName": "Changesets",
-      "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^@changesets/"]
-    },
-    {
-      "enabled": true,
-      "groupName": "Jest",
-      "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^@types/jest$", "^jest", "^ts-jest$"]
-    },
     {
       "enabled": true,
       "groupName": "ESLint",
@@ -57,22 +16,27 @@
       "matchPackagePatterns": [
         "^@types/eslint",
         "^@typescript-eslint/",
-        "^eslint-config-",
-        "^eslint-plugin-",
+        "^eslint-",
         "^eslint$"
       ]
     },
     {
       "enabled": true,
-      "groupName": "Playwright",
+      "groupName": "Jest",
       "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^@playwright/", "^playwright"]
+      "matchPackagePatterns": ["^@types/jest$", "^jest", "^ts-jest$", "^jest-"]
     },
     {
       "enabled": true,
-      "groupName": "Prettier",
+      "groupName": "Playwright",
       "matchManagers": ["npm"],
-      "matchPackagePatterns": ["^prettier"]
+      "matchPackagePatterns": ["^@playwright/", "^playwright$", "^playwright-"]
+    },
+    {
+      "enabled": true,
+      "groupName": "Jest",
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["^@types/jest$", "^jest", "^ts-jest$"]
     },
     {
       "enabled": true,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR extends the scope of Renovate, which now covers all dependencies in the repo. As before, new PRs are not created automatically and we need to approve them via Dependency dashboard (#788) first.
<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203312852763953/1203464390652052/f) _(internal)_
- https://github.com/hashintel/hash/pull/1535

## 🔍 What does this change?

I’ve removed some package rules as they are no longer needed. We extend from a preset named [`config:base`](https://docs.renovatebot.com/presets-config/#configbase) which in turn includes [monorepo presets](https://docs.renovatebot.com/presets-monorepo/). This means that dependencies within well-known monorepos are grouped together without us having to configure anything. For example, `next` is upgraded with `@next/bundle-analyzer` in a single PR. I’ve kept a few rules that span across multiple monorepos (e.g. everything related to ESLint or Jest), but we can revise this later.