### PR TITLE
Add `--report-unused-disable-directives` to `lint:eslint`

### DIFF
--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -14,7 +14,7 @@
     "exe": "node --unhandled-rejections=strict --experimental-loader ts-node/esm/transpile-only --es-module-specifier-resolution=node --require=@local/script-resources/suppress-experimental-warnings.cjs --require dotenv-flow/config",
     "fix:eslint": "eslint --fix .",
     "generate-blockmetadata-schema": "typescript-json-schema ../../packages/@blockprotocol/core/dist/esm/types.d.ts BlockMetadata --required true --out public/schemas/block-metadata.json",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "start": "yarn exe scripts/start.ts"
   },

--- a/crates/type-system/package.json
+++ b/crates/type-system/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/@blockprotocol/core/package.json
+++ b/packages/@blockprotocol/core/package.json
@@ -33,7 +33,7 @@
     "build:esm": "tsc --skipLibCheck --project tsconfig.build.esm.json",
     "clean": "rimraf ./dist/",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/@blockprotocol/graph/package.json
+++ b/packages/@blockprotocol/graph/package.json
@@ -52,7 +52,7 @@
     "build": "yarn clean && tsc --skipLibCheck",
     "clean": "rimraf ./dist/",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/@blockprotocol/hook/package.json
+++ b/packages/@blockprotocol/hook/package.json
@@ -48,7 +48,7 @@
     "build": "yarn clean && tsc --skipLibCheck",
     "clean": "rimraf ./dist/",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/@blockprotocol/type-system/package.json
+++ b/packages/@blockprotocol/type-system/package.json
@@ -44,7 +44,7 @@
     "clean": "rimraf ./dist/",
     "compressed-size": "yarn build && find dist -iname '*.js' -exec npx terser@latest --compress --mangle --output {} -- {} \\;",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "optimize": "wasm-opt -Os wasm/type-system_bg.wasm -o tmp.wasm && mv tmp.wasm wasm/type-system_bg.wasm",
     "prepublishOnly": "yarn build:wasm && yarn test && yarn optimize && yarn build:bundle",

--- a/packages/@local/eslint-config/package.json
+++ b/packages/@local/eslint-config/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/@local/package-chores/package.json
+++ b/packages/@local/package-chores/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "exe": "node --unhandled-rejections=strict --experimental-loader ts-node/esm/transpile-only --es-module-specifier-resolution=node --require=@local/script-resources/suppress-experimental-warnings.cjs --require dotenv-flow/config",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/@local/script-resources/package.json
+++ b/packages/@local/script-resources/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/block-scripts/package.json
+++ b/packages/block-scripts/package.json
@@ -21,7 +21,7 @@
   "bin": "./bin.js",
   "scripts": {
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/block-template-custom-element/package.json
+++ b/packages/block-template-custom-element/package.json
@@ -22,7 +22,7 @@
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
     "format": "prettier --write --ignore-unknown .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "prepublishOnly": "PACKAGE_DIR=$(pwd) yarn workspace @local/package-chores exe scripts/cleanup-before-publishing.ts",
     "serve": "block-scripts serve"

--- a/packages/block-template-html/package.json
+++ b/packages/block-template-html/package.json
@@ -22,7 +22,7 @@
     "dev": "echo \"Serving at http://localhost:63212\" && http-server -p 63212 ./dev",
     "fix:eslint": "eslint --fix .",
     "format": "prettier --write --ignore-unknown .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "prepare": "rimraf ./dev/src && lnk -f ./src ./dev",
     "prepublishOnly": "PACKAGE_DIR=$(pwd) yarn workspace @local/package-chores exe scripts/cleanup-before-publishing.ts",
     "serve": "block-scripts serve"

--- a/packages/block-template-react/package.json
+++ b/packages/block-template-react/package.json
@@ -22,7 +22,7 @@
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
     "format": "prettier --write --ignore-unknown .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "prepublishOnly": "PACKAGE_DIR=$(pwd) yarn workspace @local/package-chores exe scripts/cleanup-before-publishing.ts",
     "serve": "block-scripts serve"

--- a/packages/blockprotocol/package.json
+++ b/packages/blockprotocol/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "dev": "BLOCK_PROTOCOL_SITE_HOST=http://localhost:3000 node cli.js",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/create-block-app/package.json
+++ b/packages/create-block-app/package.json
@@ -22,7 +22,7 @@
   "bin": "create-block-app.js",
   "scripts": {
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint ."
+    "lint:eslint": "eslint --report-unused-disable-directives ."
   },
   "dependencies": {
     "chalk": "5.1.2",

--- a/packages/mock-block-dock/package.json
+++ b/packages/mock-block-dock/package.json
@@ -32,7 +32,7 @@
     "codegen": "node -p \"'export const MOCK_BLOCK_DOCK_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
     "dev": "concurrently -n webpack,webpack-dev-server -c green,cyan \"yarn build:dev --watch\" \"yarn run-dev-server\"",
     "fix:eslint": "eslint --fix .",
-    "lint:eslint": "eslint .",
+    "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "run-dev-server": "cross-env NODE_ENV=development webpack-dev-server --config dev/webpack.config.js"
   },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR makes sure that `yarn lint:eslint` does not exits with 0 if there are unused ESLint disable comments left in the codebase. These comments should be automatically removed on save because we have `reportUnusedDisableDirectives: true`  [in our base ESLint config](https://github.com/blockprotocol/blockprotocol/blob/e5a1e7df730596b0e93e420703ca70cdee314c58/packages/%40local/eslint-config/index.js#L5). However, when we do bulk-edits, unused directives may remain as warnings and not fail the CI.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203363157432081/1203452982053233/f) (internal)
<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

## 🐾 Next steps

If there is support for ``reportUnusedDisableDirectives: "error"`` [upstream](https://github.com/eslint/eslint/issues/15466#issuecomment-1339759506), we can remove the CLI option.

## 🛡 What tests cover this?

I tested the option manually by adding `// eslint-disable-next-line` in a random place. `yarn fix:eslint` worked equally with and without the CLI option so I only added it for `lint:eslint`.
