### PR TITLE
Add the `Subgraph` types

### DIFF
--- a/packages/@blockprotocol/graph/src/custom-element.ts
+++ b/packages/@blockprotocol/graph/src/custom-element.ts
@@ -69,14 +69,17 @@ export abstract class BlockElementBase<
       throw new Error(
         "Cannot update self: no 'blockEntity' on 'graph' object passed to block",
       );
-    } else if (!this.graph.blockEntity.metadata.entityId) {
+    } else if (!this.graph.blockEntity.metadata) {
       throw new Error(
-        "Cannot update self: no 'entityId' on graph.blockEntity.metadata passed to block",
+        "Cannot update self: no 'metadata' on graph.blockEntity passed to block",
       );
     }
 
     return this.graphService.updateEntity({
-      data: { entityId: this.graph.blockEntity.metadata.entityId, properties },
+      data: {
+        entityId: this.graph.blockEntity.metadata.editionId.baseId,
+        properties,
+      },
     });
   }
 }

--- a/packages/@blockprotocol/graph/src/types.ts
+++ b/packages/@blockprotocol/graph/src/types.ts
@@ -1,6 +1,6 @@
 export * from "./types/block-graph";
 export * from "./types/entity";
-export * from "./types/entity-type";
 export * from "./types/file";
 export * from "./types/link";
 export * from "./types/linked-aggregation";
+export * from "./types/ontology";

--- a/packages/@blockprotocol/graph/src/types/block-graph.ts
+++ b/packages/@blockprotocol/graph/src/types/block-graph.ts
@@ -10,11 +10,6 @@ import {
   GetEntityData,
   UpdateEntityData,
 } from "./entity";
-import {
-  AggregateEntityTypesData,
-  EntityType,
-  GetEntityTypeData,
-} from "./entity-type";
 import { UploadFileData, UploadFileReturn } from "./file";
 import {
   CreateLinkData,
@@ -32,6 +27,11 @@ import {
   LinkedAggregationDefinition,
   UpdateLinkedAggregationData,
 } from "./linked-aggregation";
+import {
+  AggregateEntityTypesData,
+  EntityType,
+  GetEntityTypeData,
+} from "./ontology/entity-type";
 
 export type LinkedAggregations = LinkedAggregation[];
 export type LinkedEntities = Entity[];

--- a/packages/@blockprotocol/graph/src/types/entity.ts
+++ b/packages/@blockprotocol/graph/src/types/entity.ts
@@ -1,7 +1,7 @@
 import { JsonValue } from "@blockprotocol/core";
 import { BaseUri, VersionedUri } from "@blockprotocol/type-system/slim";
 
-import { CreateLinkData, EntityType } from "../types";
+import { CreateLinkData, EntityType, isOntologyTypeEditionId } from "../types";
 
 /** @todo - Consider branding these */
 /** @todo - Add documentation for these if we keep them */
@@ -10,6 +10,21 @@ export type EntityVersion = string;
 export type EntityEditionId = {
   baseId: EntityId;
   versionId: EntityVersion;
+};
+
+export const isEntityEditionId = (
+  editionId: unknown,
+): editionId is EntityEditionId => {
+  return (
+    editionId != null &&
+    typeof editionId === "object" &&
+    "baseId" in editionId &&
+    "versionId" in editionId &&
+    /** @todo - is it fine to just check that versionId is string, maybe timestamp if we want to lock it into being a
+     *    timestamp?
+     */
+    !isOntologyTypeEditionId(editionId)
+  );
 };
 
 /**

--- a/packages/@blockprotocol/graph/src/types/entity.ts
+++ b/packages/@blockprotocol/graph/src/types/entity.ts
@@ -3,8 +3,14 @@ import { BaseUri, VersionedUri } from "@blockprotocol/type-system/slim";
 
 import { CreateLinkData, EntityType } from "../types";
 
-/** @todo - Consider branding this */
+/** @todo - Consider branding these */
+/** @todo - Add documentation for these if we keep them */
 export type EntityId = string;
+export type EntityVersion = string;
+export type EntityEditionId = {
+  baseId: EntityId;
+  versionId: EntityVersion;
+};
 
 /**
  * Entity Properties are JSON objects with `BaseUri`s as keys, _except_ when there is a Data Type of primitive type
@@ -16,7 +22,7 @@ export type EntityPropertiesObject = {
 };
 
 export type EntityMetadata = {
-  entityId: EntityId;
+  editionId: EntityEditionId;
   entityTypeId: VersionedUri;
 };
 

--- a/packages/@blockprotocol/graph/src/types/ontology.ts
+++ b/packages/@blockprotocol/graph/src/types/ontology.ts
@@ -1,4 +1,5 @@
 import { BaseUri } from "@blockprotocol/type-system/dist/cjs-slim/index-slim";
+import { validateBaseUri } from "@blockprotocol/type-system/wasm/type-system";
 
 export * from "./ontology/entity-type";
 /** @todo - Add documentation */
@@ -11,4 +12,19 @@ export * from "./ontology/entity-type";
 export type OntologyTypeEditionId = {
   baseId: BaseUri;
   versionId: number;
+};
+
+export const isOntologyTypeEditionId = (
+  editionId: unknown,
+): editionId is OntologyTypeEditionId => {
+  return (
+    editionId != null &&
+    typeof editionId === "object" &&
+    "baseId" in editionId &&
+    typeof editionId.baseId === "string" &&
+    /** @todo - This means we need to have initialized the type system */
+    validateBaseUri(editionId.baseId).type === "Ok" &&
+    "versionId" in editionId &&
+    typeof editionId.versionId === "number"
+  );
 };

--- a/packages/@blockprotocol/graph/src/types/ontology.ts
+++ b/packages/@blockprotocol/graph/src/types/ontology.ts
@@ -1,1 +1,14 @@
+import { BaseUri } from "@blockprotocol/type-system/dist/cjs-slim/index-slim";
+
 export * from "./ontology/entity-type";
+/** @todo - Add documentation */
+/**
+ *  @todo - Do we want to introduce "ontology" into code? Alternatives:
+ *    * `TypeEditionId` - "type" is so ambiguous in languages and tends to clash with protected keywords
+ *    * `TypeSystemElementId` - This is about as wordy as below, and is an element of the ontology the same as an element
+ *      of the type system? Not sure the type system == ontology, it's more like the type system describes the ontology.
+ */
+export type OntologyTypeEditionId = {
+  baseId: BaseUri;
+  versionId: number;
+};

--- a/packages/@blockprotocol/graph/src/types/ontology.ts
+++ b/packages/@blockprotocol/graph/src/types/ontology.ts
@@ -1,0 +1,1 @@
+export * from "./ontology/entity-type";

--- a/packages/@blockprotocol/graph/src/types/ontology/data-type.ts
+++ b/packages/@blockprotocol/graph/src/types/ontology/data-type.ts
@@ -1,0 +1,14 @@
+import { DataType } from "@blockprotocol/type-system/slim";
+
+import { OntologyElementMetadata } from "./metadata";
+
+/**
+ * @todo - Should we re-export this? Should the type-system package be an implementation detail of the graph service?
+ *   Or should consumers import it directly? Also raises the question of if we should be re-exporting the functions.
+ */
+export type { DataType };
+
+export type DataTypeWithMetadata = {
+  schema: DataType;
+  metadata: OntologyElementMetadata;
+};

--- a/packages/@blockprotocol/graph/src/types/ontology/entity-type.ts
+++ b/packages/@blockprotocol/graph/src/types/ontology/entity-type.ts
@@ -1,6 +1,6 @@
 import { EntityType, VersionedUri } from "@blockprotocol/type-system/slim";
 
-import { AggregateOperationInput } from "./entity";
+import { AggregateOperationInput } from "../entity";
 
 export type { EntityType };
 

--- a/packages/@blockprotocol/graph/src/types/ontology/entity-type.ts
+++ b/packages/@blockprotocol/graph/src/types/ontology/entity-type.ts
@@ -1,8 +1,18 @@
 import { EntityType, VersionedUri } from "@blockprotocol/type-system/slim";
 
 import { AggregateOperationInput } from "../entity";
+import { OntologyElementMetadata } from "./metadata";
 
+/**
+ * @todo - Should we re-export this? Should the type-system package be an implementation detail of the graph service?
+ *   Or should consumers import it directly? Also raises the question of if we should be re-exporting the functions.
+ */
 export type { EntityType };
+
+export type EntityTypeWithMetadata = {
+  schema: EntityType;
+  metadata: OntologyElementMetadata;
+};
 
 export type AggregateEntityTypesData = {
   // @todo mention in spec or remove

--- a/packages/@blockprotocol/graph/src/types/ontology/metadata.ts
+++ b/packages/@blockprotocol/graph/src/types/ontology/metadata.ts
@@ -1,0 +1,6 @@
+import { OntologyTypeEditionId } from "../ontology";
+
+export interface OntologyElementMetadata {
+  editionId: OntologyTypeEditionId;
+  ownedById: string;
+}

--- a/packages/@blockprotocol/graph/src/types/ontology/property-type.ts
+++ b/packages/@blockprotocol/graph/src/types/ontology/property-type.ts
@@ -1,0 +1,14 @@
+import { PropertyType } from "@blockprotocol/type-system/slim";
+
+import { OntologyElementMetadata } from "./metadata";
+
+/**
+ * @todo - Should we re-export this? Should the type-system package be an implementation detail of the graph service?
+ *   Or should consumers import it directly? Also raises the question of if we should be re-exporting the functions.
+ */
+export type { PropertyType };
+
+export type PropertyTypeWithMetadata = {
+  schema: PropertyType;
+  metadata: OntologyElementMetadata;
+};

--- a/packages/@blockprotocol/graph/src/types/subgraph.ts
+++ b/packages/@blockprotocol/graph/src/types/subgraph.ts
@@ -1,0 +1,26 @@
+import { Entity, EntityEditionId } from "./entity";
+import { OntologyTypeEditionId } from "./ontology";
+import { EntityTypeWithMetadata } from "./ontology/entity-type";
+import { Edges } from "./subgraph/edges";
+import { GraphResolveDepths } from "./subgraph/graph-resolve-depths";
+import { Vertices } from "./subgraph/vertices";
+
+export type SubgraphRootTypes = {
+  entityType: {
+    editionId: OntologyTypeEditionId;
+    element: EntityTypeWithMetadata;
+  };
+  entity: {
+    editionId: EntityEditionId;
+    element: Entity;
+  };
+};
+
+export type SubgraphRootType = SubgraphRootTypes[keyof SubgraphRootTypes];
+
+export type Subgraph<RootType extends SubgraphRootType = SubgraphRootType> = {
+  roots: RootType["editionId"][];
+  vertices: Vertices;
+  edges: Edges;
+  depths: GraphResolveDepths;
+};

--- a/packages/@blockprotocol/graph/src/types/subgraph/edges.ts
+++ b/packages/@blockprotocol/graph/src/types/subgraph/edges.ts
@@ -1,9 +1,17 @@
+import { BaseUri } from "@blockprotocol/type-system/slim";
+
 import { EntityId } from "../entity";
-import { KnowledgeGraphOutwardEdge } from "./edges/outward-edge";
+import {
+  KnowledgeGraphOutwardEdge,
+  OntologyOutwardEdge,
+} from "./edges/outward-edge";
 import { Timestamp } from "./time";
 
-/** @todo - Add ontology edges here */
 export type Edges = {
+  [_: BaseUri]: {
+    [_: number]: OntologyOutwardEdge[];
+  };
+} & {
   [_: EntityId]: {
     [_: Timestamp]: KnowledgeGraphOutwardEdge[];
   };

--- a/packages/@blockprotocol/graph/src/types/subgraph/edges.ts
+++ b/packages/@blockprotocol/graph/src/types/subgraph/edges.ts
@@ -1,0 +1,10 @@
+import { EntityId } from "../entity";
+import { KnowledgeGraphOutwardEdge } from "./edges/outward-edge";
+import { Timestamp } from "./time";
+
+/** @todo - Add ontology edges here */
+export type Edges = {
+  [_: EntityId]: {
+    [_: Timestamp]: KnowledgeGraphOutwardEdge[];
+  };
+};

--- a/packages/@blockprotocol/graph/src/types/subgraph/edges/kind.ts
+++ b/packages/@blockprotocol/graph/src/types/subgraph/edges/kind.ts
@@ -1,14 +1,36 @@
-/** @todo - Add the Ontology type edge kinds */
+const ONTOLOGY_EDGE_KINDS = [
+  "INHERITS_FROM",
+  "CONSTRAINS_VALUES_ON",
+  "CONSTRAINS_PROPERTIES_ON",
+  "CONSTRAINS_LINKS_ON",
+  "CONSTRAINS_LINK_DESTINATIONS_ON",
+] as const;
 
 const KNOWLEDGE_GRAPH_EDGE_KIND = [
   "HAS_LEFT_ENTITY",
   "HAS_RIGHT_ENTITY",
 ] as const;
 
+const SHARED_EDGE_KIND = ["IS_OF_TYPE"] as const;
+
+export type OntologyEdgeKind = typeof ONTOLOGY_EDGE_KINDS[number];
+
 export type KnowledgeGraphEdgeKind = typeof KNOWLEDGE_GRAPH_EDGE_KIND[number];
+
+export type SharedEdgeKind = typeof SHARED_EDGE_KIND[number];
+
+// -------------------------------- Type Guards --------------------------------
+
+export const isOntologyEdgeKind = (kind: string): kind is OntologyEdgeKind => {
+  return (ONTOLOGY_EDGE_KINDS as ReadonlyArray<string>).includes(kind);
+};
 
 export const isKnowledgeGraphEdgeKind = (
   kind: string,
 ): kind is KnowledgeGraphEdgeKind => {
   return (KNOWLEDGE_GRAPH_EDGE_KIND as ReadonlyArray<string>).includes(kind);
+};
+
+export const isSharedEdgeKind = (kind: string): kind is SharedEdgeKind => {
+  return (SHARED_EDGE_KIND as ReadonlyArray<string>).includes(kind);
 };

--- a/packages/@blockprotocol/graph/src/types/subgraph/edges/kind.ts
+++ b/packages/@blockprotocol/graph/src/types/subgraph/edges/kind.ts
@@ -1,0 +1,14 @@
+/** @todo - Add the Ontology type edge kinds */
+
+const KNOWLEDGE_GRAPH_EDGE_KIND = [
+  "HAS_LEFT_ENTITY",
+  "HAS_RIGHT_ENTITY",
+] as const;
+
+export type KnowledgeGraphEdgeKind = typeof KNOWLEDGE_GRAPH_EDGE_KIND[number];
+
+export const isKnowledgeGraphEdgeKind = (
+  kind: string,
+): kind is KnowledgeGraphEdgeKind => {
+  return (KNOWLEDGE_GRAPH_EDGE_KIND as ReadonlyArray<string>).includes(kind);
+};

--- a/packages/@blockprotocol/graph/src/types/subgraph/edges/outward-edge.ts
+++ b/packages/@blockprotocol/graph/src/types/subgraph/edges/outward-edge.ts
@@ -1,6 +1,14 @@
-import { EntityId } from "../../entity";
+import { EntityEditionId, EntityId, isEntityEditionId } from "../../entity";
+import { isOntologyTypeEditionId, OntologyTypeEditionId } from "../../ontology";
 import { Timestamp } from "../time";
-import { isKnowledgeGraphEdgeKind, KnowledgeGraphEdgeKind } from "./kind";
+import {
+  isKnowledgeGraphEdgeKind,
+  isOntologyEdgeKind,
+  isSharedEdgeKind,
+  KnowledgeGraphEdgeKind,
+  OntologyEdgeKind,
+  SharedEdgeKind,
+} from "./kind";
 
 /**
  * A "partial" definition of an edge which is complete when joined with the missing left-endpoint (usually the source
@@ -12,20 +20,38 @@ type GenericOutwardEdge<K, E> = {
   rightEndpoint: E;
 };
 
-/** @todo - Add the Ontology outward edges */
-export type KnowledgeGraphOutwardEdge = GenericOutwardEdge<
-  KnowledgeGraphEdgeKind,
-  {
-    baseId: EntityId;
-    timestamp: Timestamp;
-  }
->;
+export type OntologyOutwardEdge =
+  | GenericOutwardEdge<OntologyEdgeKind, OntologyTypeEditionId>
+  | GenericOutwardEdge<SharedEdgeKind, EntityEditionId>;
 
-/** @todo - Add the Ontology outward edges */
-export type OutwardEdge = KnowledgeGraphOutwardEdge;
+export type KnowledgeGraphOutwardEdge =
+  | GenericOutwardEdge<
+      KnowledgeGraphEdgeKind,
+      {
+        baseId: EntityId;
+        timestamp: Timestamp;
+      }
+    >
+  | GenericOutwardEdge<SharedEdgeKind, OntologyTypeEditionId>;
+
+export type OutwardEdge = OntologyOutwardEdge | KnowledgeGraphOutwardEdge;
+
+// -------------------------------- Type Guards --------------------------------
+
+export const isOntologyOutwardEdge = (
+  edge: OutwardEdge,
+): edge is OntologyOutwardEdge => {
+  return (
+    isOntologyEdgeKind(edge.kind) ||
+    (isSharedEdgeKind(edge.kind) && isEntityEditionId(edge.rightEndpoint))
+  );
+};
 
 export const isKnowledgeGraphOutwardEdge = (
   edge: OutwardEdge,
 ): edge is KnowledgeGraphOutwardEdge => {
-  return isKnowledgeGraphEdgeKind(edge.kind);
+  return (
+    isKnowledgeGraphEdgeKind(edge.kind) ||
+    (isSharedEdgeKind(edge.kind) && isOntologyTypeEditionId(edge.rightEndpoint))
+  );
 };

--- a/packages/@blockprotocol/graph/src/types/subgraph/edges/outward-edge.ts
+++ b/packages/@blockprotocol/graph/src/types/subgraph/edges/outward-edge.ts
@@ -1,0 +1,31 @@
+import { EntityId } from "../../entity";
+import { Timestamp } from "../time";
+import { isKnowledgeGraphEdgeKind, KnowledgeGraphEdgeKind } from "./kind";
+
+/**
+ * A "partial" definition of an edge which is complete when joined with the missing left-endpoint (usually the source
+ * of the edge)
+ */
+type GenericOutwardEdge<K, E> = {
+  kind: K;
+  reversed: boolean;
+  rightEndpoint: E;
+};
+
+/** @todo - Add the Ontology outward edges */
+export type KnowledgeGraphOutwardEdge = GenericOutwardEdge<
+  KnowledgeGraphEdgeKind,
+  {
+    baseId: EntityId;
+    timestamp: Timestamp;
+  }
+>;
+
+/** @todo - Add the Ontology outward edges */
+export type OutwardEdge = KnowledgeGraphOutwardEdge;
+
+export const isKnowledgeGraphOutwardEdge = (
+  edge: OutwardEdge,
+): edge is KnowledgeGraphOutwardEdge => {
+  return isKnowledgeGraphEdgeKind(edge.kind);
+};

--- a/packages/@blockprotocol/graph/src/types/subgraph/graph-resolve-depths.ts
+++ b/packages/@blockprotocol/graph/src/types/subgraph/graph-resolve-depths.ts
@@ -1,0 +1,11 @@
+export interface EdgeResolveDepths {
+  incoming: number;
+  outgoing: number;
+}
+
+/** @todo - Add documentation */
+/** @todo - expand this with ontology - related edges */
+export type GraphResolveDepths = {
+  hasLeftEntity: EdgeResolveDepths;
+  hasRightEntity: EdgeResolveDepths;
+};

--- a/packages/@blockprotocol/graph/src/types/subgraph/time.ts
+++ b/packages/@blockprotocol/graph/src/types/subgraph/time.ts
@@ -1,0 +1,5 @@
+// Comment to capture intention of this file, this can hold types related to time and versioning. This could include
+// Timestamps, intervals, possibly different dimensions of time, depending on how the BP grows.
+
+/** @todo - Consider branding this */
+export type Timestamp = string;

--- a/packages/@blockprotocol/graph/src/types/subgraph/vertices.ts
+++ b/packages/@blockprotocol/graph/src/types/subgraph/vertices.ts
@@ -1,9 +1,19 @@
 import { BaseUri } from "@blockprotocol/type-system/slim";
 
 import { Entity, EntityId, EntityVersion } from "../entity";
+import { DataTypeWithMetadata } from "../ontology/data-type";
 import { EntityTypeWithMetadata } from "../ontology/entity-type";
+import { PropertyTypeWithMetadata } from "../ontology/property-type";
 
-/** @todo - Add the remaining Ontology type vertices */
+export type DataTypeVertex = {
+  kind: "dataType";
+  inner: DataTypeWithMetadata;
+};
+
+export type PropertyTypeVertex = {
+  kind: "propertyType";
+  inner: PropertyTypeWithMetadata;
+};
 
 export type EntityTypeVertex = {
   kind: "entityType";
@@ -12,11 +22,24 @@ export type EntityTypeVertex = {
 
 export type EntityVertex = { kind: "entity"; inner: Entity };
 
-export type OntologyVertex = EntityTypeVertex;
+export type OntologyVertex =
+  | DataTypeVertex
+  | PropertyTypeVertex
+  | EntityTypeVertex;
 
 export type KnowledgeGraphVertex = EntityVertex;
 
 export type Vertex = OntologyVertex | KnowledgeGraphVertex;
+
+export const isDataTypeVertex = (vertex: Vertex): vertex is DataTypeVertex => {
+  return vertex.kind === "dataType";
+};
+
+export const isPropertyTypeVertex = (
+  vertex: Vertex,
+): vertex is PropertyTypeVertex => {
+  return vertex.kind === "propertyType";
+};
 
 export const isEntityTypeVertex = (
   vertex: Vertex,

--- a/packages/@blockprotocol/graph/src/types/subgraph/vertices.ts
+++ b/packages/@blockprotocol/graph/src/types/subgraph/vertices.ts
@@ -1,0 +1,39 @@
+import { BaseUri } from "@blockprotocol/type-system/slim";
+
+import { Entity, EntityId, EntityVersion } from "../entity";
+import { EntityTypeWithMetadata } from "../ontology/entity-type";
+
+/** @todo - Add the remaining Ontology type vertices */
+
+export type EntityTypeVertex = {
+  kind: "entityType";
+  inner: EntityTypeWithMetadata;
+};
+
+export type EntityVertex = { kind: "entity"; inner: Entity };
+
+export type OntologyVertex = EntityTypeVertex;
+
+export type KnowledgeGraphVertex = EntityVertex;
+
+export type Vertex = OntologyVertex | KnowledgeGraphVertex;
+
+export const isEntityTypeVertex = (
+  vertex: Vertex,
+): vertex is EntityTypeVertex => {
+  return vertex.kind === "entityType";
+};
+
+export const isEntityVertex = (vertex: Vertex): vertex is EntityVertex => {
+  return vertex.kind === "entity";
+};
+
+export type Vertices = {
+  [_: BaseUri]: {
+    [_: number]: OntologyVertex;
+  };
+} & {
+  [_: EntityId]: {
+    [_: EntityVersion]: KnowledgeGraphVertex;
+  };
+};


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The Block Protocol Graph service is centered around a data abstraction which is represented as a Graph. With the introduction of the Type System there are an increasing variety of elements within this graph, and the previous ways of representing their relationships weren't sufficient in the face of this.

This PR introduces the `Subgraph` type (and its constituent types). The `Subgraph` is likely to replace a lot of the return types for various `get` and `aggregate` queries within the Graph Service, which should allow users to configure how much contextual information they want about the elements they're querying (for example, they should be able to say how deep link entities should be resolved and returned).

It is being designed for the future to support complex EAs which may have temporal versioning schemes (a somewhat new introduction to the Block Protocol), but the intention is to abstract a lot of this complexity behind a standard library of functions which provide the `Subgraph` API. These will be created in follow-ups

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203363157432081/1203516598340492/f) _(internal)_

## 🚫 Blocked by

N/A

## 🔍 What does this change?

Please see commits, effort has been made to keep them clean, and reviewing commit-by-commit should help mitigate some of the diff caused by restructuring of the package.

## 📜 Does this require a change to the docs?

- Docs will be updated with the merge of the 0.3 branch

## ⚠️ Known issues

- `mock-block-dock` has not been updated, and is therefore broken, this will be fixed in follow-ups
- Some of the type guards require usage of the Type System package due to the use of `validateBaseUri`, this means that usages of this library also becomes dependent on the WASM being initialized. 

## 🐾 Next steps

- Add standard library for the `Subgraph`
- Add tests for the standard library

## 🛡 What tests cover this?

- Typescript compilation

## ❓ How to test this?

N/A at this time

## 📹 Demo

N/A
