### PR TITLE
Increase Playwright test timeout for Webkit to fix CI

### DIFF
--- a/apps/site/tests/integration/api-keys.test.ts
+++ b/apps/site/tests/integration/api-keys.test.ts
@@ -7,6 +7,14 @@ test("API key page should generate a valid key", async ({
   browserName,
   request,
 }) => {
+  if (browserName === "webkit") {
+    // Some locator actions take 3 seconds instead of a few milliseconds,
+    // so this long test often takes more than 30 seconds to run.
+    // We can try switching back to the default timeout after updating Playwright.
+    // See details in ??
+    test.setTimeout(60000);
+  }
+
   await resetSite();
 
   await page.goto("/");

--- a/apps/site/tests/integration/api-keys.test.ts
+++ b/apps/site/tests/integration/api-keys.test.ts
@@ -11,7 +11,7 @@ test("API key page should generate a valid key", async ({
     // Some locator actions take 3 seconds instead of a few milliseconds,
     // so this long test often takes more than 30 seconds to run.
     // We can try switching back to the default timeout after updating Playwright.
-    // See details in ??
+    // See details in https://github.com/blockprotocol/blockprotocol/pull/821
     test.setTimeout(60000);
   }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR aims to fix CI failures which have been frequent since recently.
<img width="918" alt="Screenshot 2022-12-08 at 19 55 11" src="https://user-images.githubusercontent.com/608862/206554742-e9cd2029-2de1-4c5b-9fd8-34637c28d670.png">


Example: https://github.com/blockprotocol/blockprotocol/actions/runs/3649530904/jobs/6164329738

```
Running 34 tests using 1 worker
···××T········°·····°·°°·°·····°°°°·

  1) [integration-safari] › integration/api-keys.test.ts:5:1 › API key page should generate a valid key 

    Test timeout of 30000ms exceeded.
```

Here is what I saw in trace files ([example artifact URL](https://github.com/blockprotocol/blockprotocol/suites/9750206066/artifacts/468109554)):

<img width="1950" alt="Screenshot 2022-12-08 at 19 37 32" src="https://user-images.githubusercontent.com/608862/206556838-fb52ef69-eebb-49a5-97e5-ca8e5a5fca71.png">

<img width="1945" alt="Screenshot 2022-12-08 at 19 37 40" src="https://user-images.githubusercontent.com/608862/206556843-b9990398-0972-4b7c-9fb0-c00c27fb84e7.png">

The issue is with some actions like `locator.click()` which that take about 3 or 6 seconds instead of just a few milliseconds.

Webkit is used both in `iphone` and `safari` tests, but only Safari fails frequently. `iphone` tests I checked took just under 30 seconds so I guess we were just lucky with them. Perhaps, `safari` tests took just under 30 seconds to but become a little bit slower after we’ve started installing Rust or because of a slight change in GitHub infra.

Not sure what this is caused by and whether this is a new issue or not. Only `api-keys.test.ts` is affected, so the might be something special about its layout. Other tests don’t seem to be much slower in Webkit than in other browsers (multiples of 3s would be clearly seen). There are no signs of repeated locator attempts in logs, which suggests that this could be an internal engine issue:

<img width="1934" alt="Screenshot 2022-12-08 at 20 12 39" src="https://user-images.githubusercontent.com/608862/206558440-140de798-4efe-4fd1-85ef-fe030b78e2a1.png">
<img width="1921" alt="Screenshot 2022-12-08 at 20 12 45" src="https://user-images.githubusercontent.com/608862/206558445-508dcbcf-a758-49ba-8984-9b01620355a6.png">


## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203363157432081/1203518391853317/f) _(internal)_
