### PR TITLE
Expose ontology types of `repr` module

### DIFF
--- a/crates/type-system/src/ontology/data_type/mod.rs
+++ b/crates/type-system/src/ontology/data_type/mod.rs
@@ -4,6 +4,7 @@ pub(in crate::ontology) mod repr;
 mod wasm;
 
 use std::{collections::HashMap, str::FromStr};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub use error::ParseDataTypeError;
 
@@ -96,11 +97,29 @@ impl TryFrom<serde_json::Value> for DataType {
     }
 }
 
+impl<'de> Deserialize<'de> for DataType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::try_from(repr::DataType::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
 impl From<DataType> for serde_json::Value {
     fn from(data_type: DataType) -> Self {
         let data_type_repr: repr::DataType = data_type.into();
 
         serde_json::to_value(data_type_repr).expect("Failed to deserialize Data Type repr")
+    }
+}
+
+impl Serialize for DataType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        repr::DataType::from(self.clone()).serialize(serializer)
     }
 }
 

--- a/crates/type-system/src/ontology/data_type/mod.rs
+++ b/crates/type-system/src/ontology/data_type/mod.rs
@@ -115,6 +115,7 @@ impl ValidateUri for DataTypeReference {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
     use serde_json::json;
 
     use super::*;
@@ -122,35 +123,36 @@ mod tests {
         test_data,
         utils::tests::{check_serialization_from_str, ensure_failed_validation},
     };
+    use crate::uri::ParseVersionedUriError;
 
     #[test]
     fn text() {
-        check_serialization_from_str::<DataType>(test_data::data_type::TEXT_V1, None);
+        check_serialization_from_str::<DataType, repr::DataType>(test_data::data_type::TEXT_V1, None);
     }
 
     #[test]
     fn number() {
-        check_serialization_from_str::<DataType>(test_data::data_type::NUMBER_V1, None);
+        check_serialization_from_str::<DataType, repr::DataType>(test_data::data_type::NUMBER_V1, None);
     }
 
     #[test]
     fn boolean() {
-        check_serialization_from_str::<DataType>(test_data::data_type::BOOLEAN_V1, None);
+        check_serialization_from_str::<DataType, repr::DataType>(test_data::data_type::BOOLEAN_V1, None);
     }
 
     #[test]
     fn null() {
-        check_serialization_from_str::<DataType>(test_data::data_type::NULL_V1, None);
+        check_serialization_from_str::<DataType, repr::DataType>(test_data::data_type::NULL_V1, None);
     }
 
     #[test]
     fn object() {
-        check_serialization_from_str::<DataType>(test_data::data_type::OBJECT_V1, None);
+        check_serialization_from_str::<DataType, repr::DataType>(test_data::data_type::OBJECT_V1, None);
     }
 
     #[test]
     fn empty_list() {
-        check_serialization_from_str::<DataType>(test_data::data_type::EMPTY_LIST_V1, None);
+        check_serialization_from_str::<DataType, repr::DataType>(test_data::data_type::EMPTY_LIST_V1, None);
     }
 
     #[test]

--- a/crates/type-system/src/ontology/data_type/mod.rs
+++ b/crates/type-system/src/ontology/data_type/mod.rs
@@ -116,43 +116,62 @@ impl ValidateUri for DataTypeReference {
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
+
     use serde_json::json;
 
     use super::*;
     use crate::{
         test_data,
+        uri::ParseVersionedUriError,
         utils::tests::{check_serialization_from_str, ensure_failed_validation},
     };
-    use crate::uri::ParseVersionedUriError;
 
     #[test]
     fn text() {
-        check_serialization_from_str::<DataType, repr::DataType>(test_data::data_type::TEXT_V1, None);
+        check_serialization_from_str::<DataType, repr::DataType>(
+            test_data::data_type::TEXT_V1,
+            None,
+        );
     }
 
     #[test]
     fn number() {
-        check_serialization_from_str::<DataType, repr::DataType>(test_data::data_type::NUMBER_V1, None);
+        check_serialization_from_str::<DataType, repr::DataType>(
+            test_data::data_type::NUMBER_V1,
+            None,
+        );
     }
 
     #[test]
     fn boolean() {
-        check_serialization_from_str::<DataType, repr::DataType>(test_data::data_type::BOOLEAN_V1, None);
+        check_serialization_from_str::<DataType, repr::DataType>(
+            test_data::data_type::BOOLEAN_V1,
+            None,
+        );
     }
 
     #[test]
     fn null() {
-        check_serialization_from_str::<DataType, repr::DataType>(test_data::data_type::NULL_V1, None);
+        check_serialization_from_str::<DataType, repr::DataType>(
+            test_data::data_type::NULL_V1,
+            None,
+        );
     }
 
     #[test]
     fn object() {
-        check_serialization_from_str::<DataType, repr::DataType>(test_data::data_type::OBJECT_V1, None);
+        check_serialization_from_str::<DataType, repr::DataType>(
+            test_data::data_type::OBJECT_V1,
+            None,
+        );
     }
 
     #[test]
     fn empty_list() {
-        check_serialization_from_str::<DataType, repr::DataType>(test_data::data_type::EMPTY_LIST_V1, None);
+        check_serialization_from_str::<DataType, repr::DataType>(
+            test_data::data_type::EMPTY_LIST_V1,
+            None,
+        );
     }
 
     #[test]

--- a/crates/type-system/src/ontology/data_type/mod.rs
+++ b/crates/type-system/src/ontology/data_type/mod.rs
@@ -3,13 +3,12 @@ pub(in crate::ontology) mod repr;
 #[cfg(target_arch = "wasm32")]
 mod wasm;
 
-use std::{collections::HashMap, str::FromStr};
+use std::collections::HashMap;
 
 pub use error::ParseDataTypeError;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
-    uri::{BaseUri, ParseVersionedUriError, VersionedUri},
+    uri::{BaseUri, VersionedUri},
     ValidateUri, ValidationError,
 };
 
@@ -75,54 +74,6 @@ impl DataType {
     }
 }
 
-impl FromStr for DataType {
-    type Err = ParseDataTypeError;
-
-    fn from_str(data_type_str: &str) -> Result<Self, Self::Err> {
-        let data_type_repr: repr::DataType = serde_json::from_str(data_type_str)
-            .map_err(|err| ParseDataTypeError::InvalidJson(err.to_string()))?;
-
-        Self::try_from(data_type_repr)
-    }
-}
-
-impl TryFrom<serde_json::Value> for DataType {
-    type Error = ParseDataTypeError;
-
-    fn try_from(value: serde_json::Value) -> Result<Self, Self::Error> {
-        let data_type_repr: repr::DataType = serde_json::from_value(value)
-            .map_err(|err| ParseDataTypeError::InvalidJson(err.to_string()))?;
-
-        Self::try_from(data_type_repr)
-    }
-}
-
-impl<'de> Deserialize<'de> for DataType {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Self::try_from(repr::DataType::deserialize(deserializer)?).map_err(serde::de::Error::custom)
-    }
-}
-
-impl From<DataType> for serde_json::Value {
-    fn from(data_type: DataType) -> Self {
-        let data_type_repr: repr::DataType = data_type.into();
-
-        serde_json::to_value(data_type_repr).expect("Failed to serialize Data Type repr")
-    }
-}
-
-impl Serialize for DataType {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        repr::DataType::from(self.clone()).serialize(serializer)
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct DataTypeReference {
@@ -159,26 +110,6 @@ impl ValidateUri for DataTypeReference {
                 versioned_uri: self.uri().clone(),
             })
         }
-    }
-}
-
-impl TryFrom<serde_json::Value> for DataTypeReference {
-    type Error = ParseVersionedUriError;
-
-    fn try_from(value: serde_json::Value) -> Result<Self, Self::Error> {
-        let data_type_ref_repr: repr::DataTypeReference = serde_json::from_value(value)
-            .map_err(|err| ParseVersionedUriError::InvalidJson(err.to_string()))?;
-
-        Self::try_from(data_type_ref_repr)
-    }
-}
-
-impl From<DataTypeReference> for serde_json::Value {
-    fn from(data_type_ref: DataTypeReference) -> Self {
-        let data_type_ref_repr: repr::DataTypeReference = data_type_ref.into();
-
-        serde_json::to_value(data_type_ref_repr)
-            .expect("Failed to serialize Data Type Reference repr")
     }
 }
 

--- a/crates/type-system/src/ontology/data_type/mod.rs
+++ b/crates/type-system/src/ontology/data_type/mod.rs
@@ -4,9 +4,9 @@ pub(in crate::ontology) mod repr;
 mod wasm;
 
 use std::{collections::HashMap, str::FromStr};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub use error::ParseDataTypeError;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
     uri::{BaseUri, ParseVersionedUriError, VersionedUri},
@@ -110,7 +110,7 @@ impl From<DataType> for serde_json::Value {
     fn from(data_type: DataType) -> Self {
         let data_type_repr: repr::DataType = data_type.into();
 
-        serde_json::to_value(data_type_repr).expect("Failed to deserialize Data Type repr")
+        serde_json::to_value(data_type_repr).expect("Failed to serialize Data Type repr")
     }
 }
 
@@ -178,7 +178,7 @@ impl From<DataTypeReference> for serde_json::Value {
         let data_type_ref_repr: repr::DataTypeReference = data_type_ref.into();
 
         serde_json::to_value(data_type_ref_repr)
-            .expect("Failed to deserialize Data Type Reference repr")
+            .expect("Failed to serialize Data Type Reference repr")
     }
 }
 

--- a/crates/type-system/src/ontology/entity_type/mod.rs
+++ b/crates/type-system/src/ontology/entity_type/mod.rs
@@ -241,7 +241,10 @@ mod tests {
 
     #[test]
     fn book() {
-        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(test_data::entity_type::BOOK_V1, None);
+        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(
+            test_data::entity_type::BOOK_V1,
+            None,
+        );
 
         test_property_type_references(&entity_type, [
             "https://blockprotocol.org/@alice/types/property-type/name/v/1",
@@ -257,7 +260,10 @@ mod tests {
 
     #[test]
     fn address() {
-        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(test_data::entity_type::ADDRESS_V1, None);
+        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(
+            test_data::entity_type::ADDRESS_V1,
+            None,
+        );
 
         test_property_type_references(&entity_type, [
             "https://blockprotocol.org/@alice/types/property-type/address-line-1/v/1",
@@ -270,8 +276,10 @@ mod tests {
 
     #[test]
     fn organization() {
-        let entity_type =
-            check_serialization_from_str::<EntityType, repr::EntityType>(test_data::entity_type::ORGANIZATION_V1, None);
+        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(
+            test_data::entity_type::ORGANIZATION_V1,
+            None,
+        );
 
         test_property_type_references(&entity_type, [
             "https://blockprotocol.org/@alice/types/property-type/name/v/1",
@@ -282,7 +290,10 @@ mod tests {
 
     #[test]
     fn building() {
-        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(test_data::entity_type::BUILDING_V1, None);
+        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(
+            test_data::entity_type::BUILDING_V1,
+            None,
+        );
 
         test_property_type_references(&entity_type, []);
 
@@ -300,7 +311,10 @@ mod tests {
 
     #[test]
     fn person() {
-        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(test_data::entity_type::PERSON_V1, None);
+        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(
+            test_data::entity_type::PERSON_V1,
+            None,
+        );
 
         test_property_type_references(&entity_type, [
             "https://blockprotocol.org/@alice/types/property-type/name/v/1",
@@ -320,7 +334,10 @@ mod tests {
 
     #[test]
     fn playlist() {
-        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(test_data::entity_type::PLAYLIST_V1, None);
+        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(
+            test_data::entity_type::PLAYLIST_V1,
+            None,
+        );
 
         test_property_type_references(&entity_type, [
             "https://blockprotocol.org/@alice/types/property-type/name/v/1",
@@ -334,7 +351,10 @@ mod tests {
 
     #[test]
     fn song() {
-        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(test_data::entity_type::SONG_V1, None);
+        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(
+            test_data::entity_type::SONG_V1,
+            None,
+        );
 
         test_property_type_references(&entity_type, [
             "https://blockprotocol.org/@alice/types/property-type/name/v/1",
@@ -345,7 +365,10 @@ mod tests {
 
     #[test]
     fn page() {
-        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(test_data::entity_type::PAGE, None);
+        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(
+            test_data::entity_type::PAGE,
+            None,
+        );
 
         test_property_type_references(&entity_type, [
             "https://blockprotocol.org/@alice/types/property-type/text/v/1",

--- a/crates/type-system/src/ontology/entity_type/mod.rs
+++ b/crates/type-system/src/ontology/entity_type/mod.rs
@@ -8,6 +8,7 @@ use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
 };
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub use error::ParseEntityTypeError;
 
@@ -158,11 +159,29 @@ impl TryFrom<serde_json::Value> for EntityType {
     }
 }
 
+impl<'de> Deserialize<'de> for EntityType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+    {
+        Self::try_from(repr::EntityType::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
 impl From<EntityType> for serde_json::Value {
     fn from(property_type: EntityType) -> Self {
         let entity_type_repr: repr::EntityType = property_type.into();
 
         serde_json::to_value(entity_type_repr).expect("Failed to deserialize Entity Type repr")
+    }
+}
+
+impl Serialize for EntityType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+    {
+        repr::EntityType::from(self.clone()).serialize(serializer)
     }
 }
 

--- a/crates/type-system/src/ontology/entity_type/mod.rs
+++ b/crates/type-system/src/ontology/entity_type/mod.rs
@@ -8,9 +8,9 @@ use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
 };
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub use error::ParseEntityTypeError;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
     uri::{BaseUri, ParseVersionedUriError, VersionedUri},
@@ -161,10 +161,11 @@ impl TryFrom<serde_json::Value> for EntityType {
 
 impl<'de> Deserialize<'de> for EntityType {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
+    where
+        D: Deserializer<'de>,
     {
-        Self::try_from(repr::EntityType::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+        Self::try_from(repr::EntityType::deserialize(deserializer)?)
+            .map_err(serde::de::Error::custom)
     }
 }
 
@@ -172,14 +173,14 @@ impl From<EntityType> for serde_json::Value {
     fn from(property_type: EntityType) -> Self {
         let entity_type_repr: repr::EntityType = property_type.into();
 
-        serde_json::to_value(entity_type_repr).expect("Failed to deserialize Entity Type repr")
+        serde_json::to_value(entity_type_repr).expect("Failed to serialize Entity Type repr")
     }
 }
 
 impl Serialize for EntityType {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
+    where
+        S: Serializer,
     {
         repr::EntityType::from(self.clone()).serialize(serializer)
     }
@@ -240,7 +241,7 @@ impl From<EntityTypeReference> for serde_json::Value {
         let entity_type_ref_repr: repr::EntityTypeReference = entity_type_ref.into();
 
         serde_json::to_value(entity_type_ref_repr)
-            .expect("Failed to deserialize Entity Type Reference repr")
+            .expect("Failed to serialize Entity Type Reference repr")
     }
 }
 

--- a/crates/type-system/src/ontology/entity_type/mod.rs
+++ b/crates/type-system/src/ontology/entity_type/mod.rs
@@ -241,7 +241,7 @@ mod tests {
 
     #[test]
     fn book() {
-        let entity_type = check_serialization_from_str(test_data::entity_type::BOOK_V1, None);
+        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(test_data::entity_type::BOOK_V1, None);
 
         test_property_type_references(&entity_type, [
             "https://blockprotocol.org/@alice/types/property-type/name/v/1",
@@ -257,7 +257,7 @@ mod tests {
 
     #[test]
     fn address() {
-        let entity_type = check_serialization_from_str(test_data::entity_type::ADDRESS_V1, None);
+        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(test_data::entity_type::ADDRESS_V1, None);
 
         test_property_type_references(&entity_type, [
             "https://blockprotocol.org/@alice/types/property-type/address-line-1/v/1",
@@ -271,7 +271,7 @@ mod tests {
     #[test]
     fn organization() {
         let entity_type =
-            check_serialization_from_str(test_data::entity_type::ORGANIZATION_V1, None);
+            check_serialization_from_str::<EntityType, repr::EntityType>(test_data::entity_type::ORGANIZATION_V1, None);
 
         test_property_type_references(&entity_type, [
             "https://blockprotocol.org/@alice/types/property-type/name/v/1",
@@ -282,7 +282,7 @@ mod tests {
 
     #[test]
     fn building() {
-        let entity_type = check_serialization_from_str(test_data::entity_type::BUILDING_V1, None);
+        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(test_data::entity_type::BUILDING_V1, None);
 
         test_property_type_references(&entity_type, []);
 
@@ -300,7 +300,7 @@ mod tests {
 
     #[test]
     fn person() {
-        let entity_type = check_serialization_from_str(test_data::entity_type::PERSON_V1, None);
+        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(test_data::entity_type::PERSON_V1, None);
 
         test_property_type_references(&entity_type, [
             "https://blockprotocol.org/@alice/types/property-type/name/v/1",
@@ -320,7 +320,7 @@ mod tests {
 
     #[test]
     fn playlist() {
-        let entity_type = check_serialization_from_str(test_data::entity_type::PLAYLIST_V1, None);
+        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(test_data::entity_type::PLAYLIST_V1, None);
 
         test_property_type_references(&entity_type, [
             "https://blockprotocol.org/@alice/types/property-type/name/v/1",
@@ -334,7 +334,7 @@ mod tests {
 
     #[test]
     fn song() {
-        let entity_type = check_serialization_from_str(test_data::entity_type::SONG_V1, None);
+        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(test_data::entity_type::SONG_V1, None);
 
         test_property_type_references(&entity_type, [
             "https://blockprotocol.org/@alice/types/property-type/name/v/1",
@@ -345,7 +345,7 @@ mod tests {
 
     #[test]
     fn page() {
-        let entity_type = check_serialization_from_str(test_data::entity_type::PAGE, None);
+        let entity_type = check_serialization_from_str::<EntityType, repr::EntityType>(test_data::entity_type::PAGE, None);
 
         test_property_type_references(&entity_type, [
             "https://blockprotocol.org/@alice/types/property-type/text/v/1",

--- a/crates/type-system/src/ontology/mod.rs
+++ b/crates/type-system/src/ontology/mod.rs
@@ -36,21 +36,20 @@ pub use shared::{
     validate::{ValidateUri, ValidationError},
 };
 
-#[allow(
-    unused_imports,
-    reason = "We want to keep them here in case for the convenience of re-exporting"
-)]
 // Re-export the repr contents so they're nicely grouped and so that they're easier to import in
 // a non-ambiguous way where they don't get confused with their non repr counterparts.
 // For example, `import crate::repr` lets you then use `repr::DataType`
-pub(crate) mod repr {
+pub mod repr {
+    pub use super::{
+        data_type::repr::DataType, entity_type::repr::EntityType, property_type::repr::PropertyType,
+    };
     pub(crate) use super::{
-        data_type::repr::{DataType, DataTypeReference},
+        data_type::repr::DataTypeReference,
         entity_type::{
             links::repr::{Links, MaybeOneOfEntityTypeReference},
-            repr::{EntityType, EntityTypeReference},
+            repr::EntityTypeReference,
         },
-        property_type::repr::{PropertyType, PropertyTypeReference, PropertyValues},
+        property_type::repr::{PropertyTypeReference, PropertyValues},
         shared::{
             all_of::repr::AllOf,
             array::repr::{Array, ValueOrArray},

--- a/crates/type-system/src/ontology/mod.rs
+++ b/crates/type-system/src/ontology/mod.rs
@@ -41,15 +41,12 @@ pub use shared::{
 // For example, `import crate::repr` lets you then use `repr::DataType`
 pub mod repr {
     pub use super::{
-        data_type::repr::DataType, entity_type::repr::EntityType, property_type::repr::PropertyType,
-    };
-    pub(crate) use super::{
-        data_type::repr::DataTypeReference,
+        data_type::repr::{DataType, DataTypeReference},
         entity_type::{
             links::repr::{Links, MaybeOneOfEntityTypeReference},
-            repr::EntityTypeReference,
+            repr::{EntityType, EntityTypeReference},
         },
-        property_type::repr::{PropertyTypeReference, PropertyValues},
+        property_type::repr::{PropertyType, PropertyTypeReference, PropertyValues},
         shared::{
             all_of::repr::AllOf,
             array::repr::{Array, ValueOrArray},

--- a/crates/type-system/src/ontology/property_type/mod.rs
+++ b/crates/type-system/src/ontology/property_type/mod.rs
@@ -171,6 +171,7 @@ mod tests {
         utils::tests::{check_serialization_from_str, ensure_failed_validation},
         ParseOneOfError,
     };
+    use crate::uri::ParseVersionedUriError;
 
     fn test_property_type_data_refs(
         property_type: &PropertyType,
@@ -213,7 +214,7 @@ mod tests {
     #[test]
     fn favorite_quote() {
         let property_type =
-            check_serialization_from_str(test_data::property_type::FAVORITE_QUOTE_V1, None);
+            check_serialization_from_str::<PropertyType, repr::PropertyType>(test_data::property_type::FAVORITE_QUOTE_V1, None);
 
         test_property_type_data_refs(&property_type, [
             "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
@@ -224,7 +225,7 @@ mod tests {
 
     #[test]
     fn age() {
-        let property_type = check_serialization_from_str(test_data::property_type::AGE_V1, None);
+        let property_type = check_serialization_from_str::<PropertyType, repr::PropertyType>(test_data::property_type::AGE_V1, None);
 
         test_property_type_data_refs(&property_type, [
             "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1",
@@ -236,7 +237,7 @@ mod tests {
     #[test]
     fn user_id() {
         let property_type =
-            check_serialization_from_str(test_data::property_type::USER_ID_V2, None);
+            check_serialization_from_str::<PropertyType, repr::PropertyType>(test_data::property_type::USER_ID_V2, None);
 
         test_property_type_data_refs(&property_type, [
             "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1",
@@ -249,7 +250,7 @@ mod tests {
     #[test]
     fn contact_information() {
         let property_type =
-            check_serialization_from_str(test_data::property_type::CONTACT_INFORMATION_V1, None);
+            check_serialization_from_str::<PropertyType, repr::PropertyType>(test_data::property_type::CONTACT_INFORMATION_V1, None);
 
         test_property_type_data_refs(&property_type, []);
 
@@ -262,7 +263,7 @@ mod tests {
     #[test]
     fn interests() {
         let property_type =
-            check_serialization_from_str(test_data::property_type::INTERESTS_V1, None);
+            check_serialization_from_str::<PropertyType, repr::PropertyType>(test_data::property_type::INTERESTS_V1, None);
 
         test_property_type_data_refs(&property_type, []);
 
@@ -276,7 +277,7 @@ mod tests {
     #[test]
     fn numbers() {
         let property_type =
-            check_serialization_from_str(test_data::property_type::NUMBERS_V1, None);
+            check_serialization_from_str::<PropertyType, repr::PropertyType>(test_data::property_type::NUMBERS_V1, None);
 
         test_property_type_data_refs(&property_type, [
             "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1",
@@ -288,7 +289,7 @@ mod tests {
     #[test]
     fn contrived_property() {
         let property_type =
-            check_serialization_from_str(test_data::property_type::CONTRIVED_PROPERTY_V1, None);
+            check_serialization_from_str::<PropertyType, repr::PropertyType>(test_data::property_type::CONTRIVED_PROPERTY_V1, None);
 
         test_property_type_data_refs(&property_type, [
             "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1",

--- a/crates/type-system/src/ontology/property_type/mod.rs
+++ b/crates/type-system/src/ontology/property_type/mod.rs
@@ -168,10 +168,10 @@ mod tests {
     use super::*;
     use crate::{
         test_data,
+        uri::ParseVersionedUriError,
         utils::tests::{check_serialization_from_str, ensure_failed_validation},
         ParseOneOfError,
     };
-    use crate::uri::ParseVersionedUriError;
 
     fn test_property_type_data_refs(
         property_type: &PropertyType,
@@ -213,8 +213,10 @@ mod tests {
 
     #[test]
     fn favorite_quote() {
-        let property_type =
-            check_serialization_from_str::<PropertyType, repr::PropertyType>(test_data::property_type::FAVORITE_QUOTE_V1, None);
+        let property_type = check_serialization_from_str::<PropertyType, repr::PropertyType>(
+            test_data::property_type::FAVORITE_QUOTE_V1,
+            None,
+        );
 
         test_property_type_data_refs(&property_type, [
             "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
@@ -225,7 +227,10 @@ mod tests {
 
     #[test]
     fn age() {
-        let property_type = check_serialization_from_str::<PropertyType, repr::PropertyType>(test_data::property_type::AGE_V1, None);
+        let property_type = check_serialization_from_str::<PropertyType, repr::PropertyType>(
+            test_data::property_type::AGE_V1,
+            None,
+        );
 
         test_property_type_data_refs(&property_type, [
             "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1",
@@ -236,8 +241,10 @@ mod tests {
 
     #[test]
     fn user_id() {
-        let property_type =
-            check_serialization_from_str::<PropertyType, repr::PropertyType>(test_data::property_type::USER_ID_V2, None);
+        let property_type = check_serialization_from_str::<PropertyType, repr::PropertyType>(
+            test_data::property_type::USER_ID_V2,
+            None,
+        );
 
         test_property_type_data_refs(&property_type, [
             "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1",
@@ -249,8 +256,10 @@ mod tests {
 
     #[test]
     fn contact_information() {
-        let property_type =
-            check_serialization_from_str::<PropertyType, repr::PropertyType>(test_data::property_type::CONTACT_INFORMATION_V1, None);
+        let property_type = check_serialization_from_str::<PropertyType, repr::PropertyType>(
+            test_data::property_type::CONTACT_INFORMATION_V1,
+            None,
+        );
 
         test_property_type_data_refs(&property_type, []);
 
@@ -262,8 +271,10 @@ mod tests {
 
     #[test]
     fn interests() {
-        let property_type =
-            check_serialization_from_str::<PropertyType, repr::PropertyType>(test_data::property_type::INTERESTS_V1, None);
+        let property_type = check_serialization_from_str::<PropertyType, repr::PropertyType>(
+            test_data::property_type::INTERESTS_V1,
+            None,
+        );
 
         test_property_type_data_refs(&property_type, []);
 
@@ -276,8 +287,10 @@ mod tests {
 
     #[test]
     fn numbers() {
-        let property_type =
-            check_serialization_from_str::<PropertyType, repr::PropertyType>(test_data::property_type::NUMBERS_V1, None);
+        let property_type = check_serialization_from_str::<PropertyType, repr::PropertyType>(
+            test_data::property_type::NUMBERS_V1,
+            None,
+        );
 
         test_property_type_data_refs(&property_type, [
             "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1",
@@ -288,8 +301,10 @@ mod tests {
 
     #[test]
     fn contrived_property() {
-        let property_type =
-            check_serialization_from_str::<PropertyType, repr::PropertyType>(test_data::property_type::CONTRIVED_PROPERTY_V1, None);
+        let property_type = check_serialization_from_str::<PropertyType, repr::PropertyType>(
+            test_data::property_type::CONTRIVED_PROPERTY_V1,
+            None,
+        );
 
         test_property_type_data_refs(&property_type, [
             "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1",

--- a/crates/type-system/src/ontology/property_type/mod.rs
+++ b/crates/type-system/src/ontology/property_type/mod.rs
@@ -4,9 +4,9 @@ pub(in crate::ontology) mod repr;
 mod wasm;
 
 use std::{collections::HashSet, str::FromStr};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub use error::ParsePropertyTypeError;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
     uri::{BaseUri, ParseVersionedUriError, VersionedUri},
@@ -101,10 +101,11 @@ impl TryFrom<serde_json::Value> for PropertyType {
 
 impl<'de> Deserialize<'de> for PropertyType {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where
-            D: Deserializer<'de>,
+    where
+        D: Deserializer<'de>,
     {
-        Self::try_from(repr::PropertyType::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+        Self::try_from(repr::PropertyType::deserialize(deserializer)?)
+            .map_err(serde::de::Error::custom)
     }
 }
 
@@ -112,14 +113,14 @@ impl From<PropertyType> for serde_json::Value {
     fn from(property_type: PropertyType) -> Self {
         let property_type_repr: repr::PropertyType = property_type.into();
 
-        serde_json::to_value(property_type_repr).expect("Failed to deserialize Property Type repr")
+        serde_json::to_value(property_type_repr).expect("Failed to serialize Property Type repr")
     }
 }
 
 impl Serialize for PropertyType {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
+    where
+        S: Serializer,
     {
         repr::PropertyType::from(self.clone()).serialize(serializer)
     }
@@ -180,7 +181,7 @@ impl From<PropertyTypeReference> for serde_json::Value {
         let property_type_ref_repr: repr::PropertyTypeReference = property_type_ref.into();
 
         serde_json::to_value(property_type_ref_repr)
-            .expect("Failed to deserialize Property Type Reference repr")
+            .expect("Failed to serialize Property Type Reference repr")
     }
 }
 

--- a/crates/type-system/src/ontology/property_type/mod.rs
+++ b/crates/type-system/src/ontology/property_type/mod.rs
@@ -4,6 +4,7 @@ pub(in crate::ontology) mod repr;
 mod wasm;
 
 use std::{collections::HashSet, str::FromStr};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub use error::ParsePropertyTypeError;
 
@@ -98,11 +99,29 @@ impl TryFrom<serde_json::Value> for PropertyType {
     }
 }
 
+impl<'de> Deserialize<'de> for PropertyType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+    {
+        Self::try_from(repr::PropertyType::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
 impl From<PropertyType> for serde_json::Value {
     fn from(property_type: PropertyType) -> Self {
         let property_type_repr: repr::PropertyType = property_type.into();
 
         serde_json::to_value(property_type_repr).expect("Failed to deserialize Property Type repr")
+    }
+}
+
+impl Serialize for PropertyType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+    {
+        repr::PropertyType::from(self.clone()).serialize(serializer)
     }
 }
 

--- a/crates/type-system/src/ontology/property_type/mod.rs
+++ b/crates/type-system/src/ontology/property_type/mod.rs
@@ -3,13 +3,12 @@ pub(in crate::ontology) mod repr;
 #[cfg(target_arch = "wasm32")]
 mod wasm;
 
-use std::{collections::HashSet, str::FromStr};
+use std::collections::HashSet;
 
 pub use error::ParsePropertyTypeError;
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{
-    uri::{BaseUri, ParseVersionedUriError, VersionedUri},
+    uri::{BaseUri, VersionedUri},
     Array, DataTypeReference, Object, OneOf, ValidateUri, ValidationError, ValueOrArray,
 };
 
@@ -77,55 +76,6 @@ impl PropertyType {
     }
 }
 
-impl FromStr for PropertyType {
-    type Err = ParsePropertyTypeError;
-
-    fn from_str(property_type_str: &str) -> Result<Self, Self::Err> {
-        let property_type_repr: repr::PropertyType = serde_json::from_str(property_type_str)
-            .map_err(|err| ParsePropertyTypeError::InvalidJson(err.to_string()))?;
-
-        Self::try_from(property_type_repr)
-    }
-}
-
-impl TryFrom<serde_json::Value> for PropertyType {
-    type Error = ParsePropertyTypeError;
-
-    fn try_from(value: serde_json::Value) -> Result<Self, Self::Error> {
-        let property_type_repr: repr::PropertyType = serde_json::from_value(value)
-            .map_err(|err| ParsePropertyTypeError::InvalidJson(err.to_string()))?;
-
-        Self::try_from(property_type_repr)
-    }
-}
-
-impl<'de> Deserialize<'de> for PropertyType {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Self::try_from(repr::PropertyType::deserialize(deserializer)?)
-            .map_err(serde::de::Error::custom)
-    }
-}
-
-impl From<PropertyType> for serde_json::Value {
-    fn from(property_type: PropertyType) -> Self {
-        let property_type_repr: repr::PropertyType = property_type.into();
-
-        serde_json::to_value(property_type_repr).expect("Failed to serialize Property Type repr")
-    }
-}
-
-impl Serialize for PropertyType {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        repr::PropertyType::from(self.clone()).serialize(serializer)
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct PropertyTypeReference {
@@ -162,26 +112,6 @@ impl ValidateUri for PropertyTypeReference {
                 versioned_uri: self.uri().clone(),
             })
         }
-    }
-}
-
-impl TryFrom<serde_json::Value> for PropertyTypeReference {
-    type Error = ParseVersionedUriError;
-
-    fn try_from(value: serde_json::Value) -> Result<Self, Self::Error> {
-        let property_type_ref_repr: repr::PropertyTypeReference = serde_json::from_value(value)
-            .map_err(|err| ParseVersionedUriError::InvalidJson(err.to_string()))?;
-
-        Self::try_from(property_type_ref_repr)
-    }
-}
-
-impl From<PropertyTypeReference> for serde_json::Value {
-    fn from(property_type_ref: PropertyTypeReference) -> Self {
-        let property_type_ref_repr: repr::PropertyTypeReference = property_type_ref.into();
-
-        serde_json::to_value(property_type_ref_repr)
-            .expect("Failed to serialize Property Type Reference repr")
     }
 }
 

--- a/crates/type-system/src/ontology/property_type/repr.rs
+++ b/crates/type-system/src/ontology/property_type/repr.rs
@@ -100,7 +100,6 @@ impl From<super::PropertyTypeReference> for PropertyTypeReference {
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
-#[expect(clippy::enum_variant_names)]
 pub enum PropertyValues {
     DataTypeReference(repr::DataTypeReference),
     PropertyTypeObject(repr::Object<repr::ValueOrArray<PropertyTypeReference>>),

--- a/crates/type-system/src/utils.rs
+++ b/crates/type-system/src/utils.rs
@@ -64,14 +64,15 @@ pub(crate) mod tests {
         expected_native_repr: Option<R>,
     ) -> T
     where
-        T: TryFrom<R> + Clone + Debug,
+        T: Debug + Clone + TryFrom<R>,
         T::Error: Debug,
-        R: From<T> + PartialEq + Debug + Serialize + DeserializeOwned,
+        R: Debug + PartialEq + Clone + From<T> + Serialize + DeserializeOwned,
     {
         let deserialized_repr: R = serde_json::from_str(input).expect("failed to deserialize");
-        let value: T = deserialized_repr.try_into().expect("failed to convert");
+        let value: T = deserialized_repr.clone().try_into().expect("failed to convert");
         let re_serialized_repr: R = value.clone().into();
 
+        assert_eq!(deserialized_repr, re_serialized_repr);
         if let Some(repr) = expected_native_repr {
             assert_eq!(re_serialized_repr, repr);
         }

--- a/crates/type-system/src/utils.rs
+++ b/crates/type-system/src/utils.rs
@@ -36,9 +36,10 @@ mod wasm {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::{fmt::Debug, str::FromStr};
+    use std::{fmt::Debug};
 
     use serde::{Deserialize, Serialize};
+    use serde::de::DeserializeOwned;
 
     /// Will serialize as a constant value `"string"`
     #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -59,20 +60,24 @@ pub(crate) mod tests {
     /// serialized back.
     ///
     /// Optionally checks the deserialized object against an expected value.
-    pub(crate) fn check_serialization_from_str<T>(input: &str, expected_native_repr: Option<T>) -> T
+    pub(crate) fn check_serialization_from_str<T, R>(input: &str, expected_native_repr: Option<R>) -> T
     where
-        T: FromStr + Into<serde_json::Value> + Debug + Clone + PartialEq,
-        <T as FromStr>::Err: Debug,
+        T: TryFrom<R> + Clone + Debug,
+        T::Error: Debug,
+        R: From<T> + PartialEq + Debug + Serialize + DeserializeOwned,
     {
-        let deserialized: T = T::from_str(input).expect("failed to deserialize");
-        let _reserialized =
-            serde_json::to_value(deserialized.clone().into()).expect("failed to serialize");
+        let deserialized_repr: R = serde_json::from_str(input).expect("failed to deserialize");
+        let value: T = deserialized_repr.try_into().expect("failed to convert");
+        let re_serialized_repr: R = value.clone().into();
 
         if let Some(repr) = expected_native_repr {
-            assert_eq!(deserialized, repr);
+            assert_eq!(re_serialized_repr, repr);
         }
 
-        deserialized
+        let _re_serialized_value =
+            serde_json::to_value(re_serialized_repr).expect("failed to serialize");
+
+        value
     }
 
     /// Ensures a type can be deserialized from a given string to its equivalent [`repr`], but then

--- a/crates/type-system/src/utils.rs
+++ b/crates/type-system/src/utils.rs
@@ -36,10 +36,9 @@ mod wasm {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::{fmt::Debug};
+    use std::fmt::Debug;
 
-    use serde::{Deserialize, Serialize};
-    use serde::de::DeserializeOwned;
+    use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
     /// Will serialize as a constant value `"string"`
     #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -60,7 +59,10 @@ pub(crate) mod tests {
     /// serialized back.
     ///
     /// Optionally checks the deserialized object against an expected value.
-    pub(crate) fn check_serialization_from_str<T, R>(input: &str, expected_native_repr: Option<R>) -> T
+    pub(crate) fn check_serialization_from_str<T, R>(
+        input: &str,
+        expected_native_repr: Option<R>,
+    ) -> T
     where
         T: TryFrom<R> + Clone + Debug,
         T::Error: Debug,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In order to generalize over ontology types and entities in downstream applications (e.g. the HASH Graph API), it's required that the ontology types implements `Serialize` and `Deserialize` because of the orphan rule. 

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- Part of [Asana task](https://app.asana.com/0/1203363157432084/1203449432963806/f) _(internal)_


## 🔍 What does this change?

Implements `Deserialize` and `Serialize` for `DataType`, `PropertyType`, and `EntityType`

## ⚠️ Known issues

The current design requires the struct to be cloned. This is unfortunate, but without changing the implementation it's hard to work around this. However, it's better to have those traits implemented in the crate rather than specifying the implementation by hand in downstream crates.