### PR TITLE
Make wordpress signup into a form

### DIFF
--- a/apps/site/src/components/pages/wordpress/early-access-cta.tsx
+++ b/apps/site/src/components/pages/wordpress/early-access-cta.tsx
@@ -1,9 +1,9 @@
 import { faCheck } from "@fortawesome/free-solid-svg-icons";
-import { inputBaseClasses, Theme, useMediaQuery } from "@mui/material";
+import { Box, inputBaseClasses, Theme, useMediaQuery } from "@mui/material";
 // Our custom TextField hides the 'endAdornment' when the 'error' prop is true
 // eslint-disable-next-line no-restricted-imports
 import TextField from "@mui/material/TextField";
-import { MouseEvent, TouchEvent, useMemo, useRef, useState } from "react";
+import { FormEvent, useMemo, useRef, useState } from "react";
 
 import { apiClient } from "../../../lib/api-client";
 import { Button } from "../../button";
@@ -40,10 +40,12 @@ export const EarlyAccessCTA = () => {
 
   const displayError = touchedEmailInput && isEmailInvalid;
 
-  const handleSubmit = async (
-    event: MouseEvent<HTMLButtonElement> | TouchEvent<HTMLButtonElement>,
-  ) => {
+  const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
+    if (displayError || loading || !!submittedEmail) {
+      return;
+    }
+
     setTouchedEmailInput(true);
 
     if (isEmailInputValid) {
@@ -72,88 +74,90 @@ export const EarlyAccessCTA = () => {
   }, [submittedEmail, submitError, helperText]);
 
   return (
-    <TextField
-      disabled={loading || !!submittedEmail}
-      sx={{
-        marginBottom: 2,
-        maxWidth: 500,
-      }}
-      required
-      type="email"
-      error={displayError || submitError}
-      helperText={textFieldHelperText}
-      inputRef={emailInputRef}
-      fullWidth
-      placeholder={isSmall ? "Your email..." : "Enter your email address..."}
-      variant="outlined"
-      value={emailValue}
-      onChange={({ target }) => {
-        setSubmitError(false);
-        setEmailValue(target.value);
-      }}
-      InputProps={{
-        endAdornment: (
-          <Button
-            disabled={displayError || loading || !!submittedEmail}
-            sx={({ breakpoints }) => ({
-              zIndex: 1,
-              whiteSpace: "nowrap",
-              minWidth: "unset",
-              height: 1,
+    <Box component="form" onSubmit={handleSubmit}>
+      <TextField
+        disabled={loading || !!submittedEmail}
+        sx={{
+          marginBottom: 2,
+          maxWidth: 500,
+        }}
+        required
+        type="email"
+        error={displayError || submitError}
+        helperText={textFieldHelperText}
+        inputRef={emailInputRef}
+        fullWidth
+        placeholder={isSmall ? "Your email..." : "Enter your email address..."}
+        variant="outlined"
+        value={emailValue}
+        onChange={({ target }) => {
+          setSubmitError(false);
+          setEmailValue(target.value);
+        }}
+        InputProps={{
+          endAdornment: (
+            <Button
+              disabled={displayError || loading || !!submittedEmail}
+              type="submit"
+              sx={({ breakpoints }) => ({
+                zIndex: 1,
+                whiteSpace: "nowrap",
+                minWidth: "unset",
+                height: 1,
+                fontSize: 15,
+                ...(displayError
+                  ? {
+                      background: ({ palette }) =>
+                        `${palette.red[600]} !important`,
+                    }
+                  : {}),
+                ...(submittedEmail
+                  ? {
+                      background: ({ palette }) =>
+                        `${palette.green[80]} !important`,
+                    }
+                  : {}),
+                [breakpoints.down("sm")]: {
+                  px: 2.5,
+                },
+                "&.Mui-disabled": {
+                  borderColor: "#DDE7F0 !important",
+                },
+              })}
+              endIcon={
+                submittedEmail ? (
+                  <FontAwesomeIcon icon={faCheck} />
+                ) : (
+                  <ArrowRightIcon
+                    sx={{
+                      color: ({ palette }) =>
+                        `${palette.common.white} !important`,
+                    }}
+                  />
+                )
+              }
+              loading={loading}
+            >
+              {submittedEmail ? "Submitted" : "Get early access"}
+            </Button>
+          ),
+          sx: {
+            borderRadius: 34,
+            pr: 0,
+            [`.${inputBaseClasses.input}`]: {
+              boxSizing: "border-box",
+              height: 46,
               fontSize: 15,
-              ...(displayError
-                ? {
-                    background: ({ palette }) =>
-                      `${palette.red[600]} !important`,
-                  }
-                : {}),
-              ...(submittedEmail
-                ? {
-                    background: ({ palette }) =>
-                      `${palette.green[80]} !important`,
-                  }
-                : {}),
-              [breakpoints.down("sm")]: {
-                px: 2.5,
-              },
-              "&.Mui-disabled": {
+              lineHeight: 1.5,
+              pl: 3,
+            },
+            [`&.${inputBaseClasses.disabled} .MuiOutlinedInput-notchedOutline`]:
+              {
                 borderColor: "#DDE7F0 !important",
               },
-            })}
-            endIcon={
-              submittedEmail ? (
-                <FontAwesomeIcon icon={faCheck} />
-              ) : (
-                <ArrowRightIcon
-                  sx={{
-                    color: ({ palette }) =>
-                      `${palette.common.white} !important`,
-                  }}
-                />
-              )
-            }
-            onClick={handleSubmit}
-            onTouchStart={handleSubmit}
-            loading={loading}
-          >
-            {submittedEmail ? "Submitted" : "Get early access"}
-          </Button>
-        ),
-        sx: {
-          borderRadius: 34,
-          pr: 0,
-          [`.${inputBaseClasses.input}`]: {
-            boxSizing: "border-box",
-            height: 46,
-            fontSize: 15,
-            lineHeight: 1.5,
-            pl: 3,
           },
-          [`&.${inputBaseClasses.disabled} .MuiOutlinedInput-notchedOutline`]: {
-            borderColor: "#DDE7F0 !important",
-          },
-        },
-      }}
-    />
+        }}
+      />
+    </Box>
   );
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Wraps the form for early access WordPress plugin signup in a `form`, enabling 'hit enter to submit'.

Hide whitespace to see the meaningful diff