### PR TITLE
Stop using deprecated config in Sentry Replay

### DIFF
--- a/apps/site/sentry.client.config.ts
+++ b/apps/site/sentry.client.config.ts
@@ -8,15 +8,9 @@ Sentry.init({
   dsn,
   enabled: !!dsn,
   environment: process.env.NEXT_PUBLIC_VERCEL_ENV ?? "unset",
-  integrations: process.env.NEXT_PUBLIC_SENTRY_REPLAY_SESSION_SAMPLE_RATE
-    ? [
-        new Sentry.Replay({
-          errorSampleRate: 1,
-          sessionSampleRate: parseFloat(
-            process.env.NEXT_PUBLIC_SENTRY_REPLAY_SESSION_SAMPLE_RATE,
-          ),
-          stickySession: true,
-        }),
-      ]
-    : [],
+  integrations: [new Sentry.Replay({ stickySession: true })],
+  replaysOnErrorSampleRate: 1,
+  replaysSessionSampleRate: parseFloat(
+    process.env.NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE ?? "0",
+  ),
 });


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Follows https://github.com/blockprotocol/blockprotocol/pull/836, fixes e2e tests by not using deprecated options.

```
[warning] [Replay] You are passing `sessionSampleRate` to the Replay integration.
This option is deprecated and will be removed soon.
Instead, configure `replaysSessionSampleRate` directly in the SDK init options, e.g.:
Sentry.init({ replaysSessionSampleRate: 1 })

[warning] [Replay] You are passing `errorSampleRate` to the Replay integration.
This option is deprecated and will be removed soon.
Instead, configure `replaysOnErrorSampleRate` directly in the SDK init options, e.g.:
Sentry.init({ replaysOnErrorSampleRate: 1 })
```

https://github.com/blockprotocol/blockprotocol/actions/runs/3748171788/jobs/6365215227#step:5:164

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203363157432087/1203554618140219/f) _(internal)_
- [Sentry Replay docs](https://docs.sentry.io/platforms/javascript/session-replay/)


## 🔍 What does this change?

`NEXT_PUBLIC_SENTRY_REPLAY_SESSION_SAMPLE_RATE` renamed to
`NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE` to match new property name.

We can now keep it at zero (unset) to only collect replays with errors


## 🛡 What tests cover this?

CI