### PR TITLE
Replace 'schemas' with 'types' in copy

### DIFF
--- a/apps/site/src/components/modal/create-type-modal.tsx
+++ b/apps/site/src/components/modal/create-type-modal.tsx
@@ -15,16 +15,16 @@ import { Button } from "../button";
 import { TextField } from "../text-field";
 import { Modal } from "./modal";
 
-type CreateSchemaModalProps = {
+type CreateTypeModalProps = {
   open: boolean;
   onClose: () => void;
 };
 
-export const CreateSchemaModal: FunctionComponent<CreateSchemaModalProps> = ({
+export const CreateTypeModal: FunctionComponent<CreateTypeModalProps> = ({
   open,
   onClose,
 }) => {
-  const [newSchemaTitle, setNewSchemaTitle] = useState("");
+  const [newTypeTitle, setNewTypeTitle] = useState("");
   const [touchedInput, setTouchedInput] = useState(false);
   const [loading, setLoading] = useState(false);
   const [apiErrorMessage, setApiErrorMessage] = useState<ReactNode>(undefined);
@@ -33,7 +33,7 @@ export const CreateSchemaModal: FunctionComponent<CreateSchemaModalProps> = ({
 
   // @todo might be a good idea to split this into a hook
   // @see https://github.com/blockprotocol/blockprotocol/pull/223#discussion_r808072665
-  const handleSchemaTitleChange = (value: string) => {
+  const handleTypeTitleChange = (value: string) => {
     let formattedText = value.trim();
     // replace all empty spaces
     formattedText = formattedText.replace(/\s/g, "");
@@ -44,10 +44,10 @@ export const CreateSchemaModal: FunctionComponent<CreateSchemaModalProps> = ({
       formattedText = firstChar.toUpperCase() + formattedText.slice(1);
     }
 
-    setNewSchemaTitle(formattedText);
+    setNewTypeTitle(formattedText);
   };
 
-  const handleCreateSchema = useCallback(
+  const handleCreateType = useCallback(
     async (evt: FormEvent) => {
       evt.preventDefault();
       if (!user || user === "loading") {
@@ -61,30 +61,30 @@ export const CreateSchemaModal: FunctionComponent<CreateSchemaModalProps> = ({
       });
 
       const { data, error } = await apiClient.createEntityType({
-        schema: {
-          title: newSchemaTitle,
+        type: {
+          title: newTypeTitle,
         },
       });
       setLoading(false);
       if (error) {
         setApiErrorMessage(error.message);
       } else if (data) {
-        const schemaTitle = data.entityType.schema.title;
-        void router.push(`/@${user.shortname}/types/${schemaTitle}`);
+        const typeTitle = data.entityType.type.title;
+        void router.push(`/@${user.shortname}/types/${typeTitle}`);
       }
     },
-    [user, newSchemaTitle, router],
+    [user, newTypeTitle, router],
   );
 
   // @todo introduce a library for handling forms
   const helperText = touchedInput
     ? apiErrorMessage ||
-      (newSchemaTitle === "" ? "Please enter a valid value" : undefined)
+      (newTypeTitle === "" ? "Please enter a valid value" : undefined)
     : undefined;
 
-  const isSchemaTitleInvalid = !!apiErrorMessage || newSchemaTitle === "";
+  const isTypeTitleInvalid = !!apiErrorMessage || newTypeTitle === "";
 
-  const displayError = touchedInput && isSchemaTitleInvalid;
+  const displayError = touchedInput && isTypeTitleInvalid;
 
   return (
     <Modal
@@ -93,7 +93,7 @@ export const CreateSchemaModal: FunctionComponent<CreateSchemaModalProps> = ({
       contentStyle={{
         top: "40%",
       }}
-      data-testid="create-schema-modal"
+      data-testid="create-type-modal"
     >
       <Box>
         <Typography
@@ -103,7 +103,7 @@ export const CreateSchemaModal: FunctionComponent<CreateSchemaModalProps> = ({
             display: "block",
           }}
         >
-          Create New <strong>Schema</strong>
+          Create New <strong>Type</strong>
         </Typography>
         <Typography
           sx={{
@@ -113,29 +113,29 @@ export const CreateSchemaModal: FunctionComponent<CreateSchemaModalProps> = ({
             width: { xs: "90%", md: "85%" },
           }}
         >
-          Schemas are used to define the structure of entities - in other words,
+          Types are used to define the structure of entities - in other words,
           define a ‘type’ of entity
         </Typography>
-        <Box component="form" onSubmit={handleCreateSchema}>
+        <Box component="form" onSubmit={handleCreateType}>
           <TextField
             sx={{ mb: 3 }}
             autoFocus
-            label="Schema Title"
+            label="Type Title"
             fullWidth
             helperText={helperText}
-            value={newSchemaTitle}
+            value={newTypeTitle}
             onChange={(evt) => {
               if (apiErrorMessage) {
                 setApiErrorMessage(undefined);
               }
-              handleSchemaTitleChange(evt.target.value);
+              handleTypeTitleChange(evt.target.value);
             }}
             required
             error={displayError}
           />
 
           <Button
-            disabled={isSchemaTitleInvalid}
+            disabled={isTypeTitleInvalid}
             loading={loading}
             size="small"
             squared

--- a/apps/site/src/components/pages/dashboard/utils.ts
+++ b/apps/site/src/components/pages/dashboard/utils.ts
@@ -27,7 +27,7 @@ export const dashboardPages: { tabTitle: string; tabHref: string }[] = [
 export type DashboardSection = "create" | "manage" | "explore";
 
 export const getDashboardSectionCards = (props: {
-  openCreateSchemaModal: () => void;
+  openCreateTypeModal: () => void;
   profileLink: string;
 }): Record<DashboardSection, DashboardCardProps[]> => {
   return {
@@ -69,7 +69,7 @@ export const getDashboardSectionCards = (props: {
           "Types are a formal way to describe data, links, properties and entities",
         link: {
           title: "Create a type",
-          onClick: props.openCreateSchemaModal,
+          onClick: props.openCreateTypeModal,
         },
       },
     ],
@@ -114,7 +114,7 @@ export const getDashboardSectionCards = (props: {
           "View and update the types you’ve created and made public on the Hub",
         link: {
           title: "Manage types",
-          href: `${props.profileLink}/schemas`,
+          href: `${props.profileLink}/types`,
         },
         icon: faAsterisk,
         variant: "secondary",

--- a/apps/site/src/components/pages/user/tab-panel-contents-with-types.tsx
+++ b/apps/site/src/components/pages/user/tab-panel-contents-with-types.tsx
@@ -5,26 +5,26 @@ import { EntityType } from "../../../lib/api/model/entity-type.model";
 import { SerializedUser } from "../../../lib/api/model/user.model";
 import { formatUpdatedAt } from "../../../util/html-utils";
 import { Button } from "../../button";
-import { CreateSchemaModal } from "../../modal/create-schema-modal";
+import { CreateTypeModal } from "../../modal/create-type-modal";
 import { ListViewCard } from "./list-view-card";
 import { Placeholder } from "./placeholder";
-import { BrowseHubButton, CreateSchemaButton } from "./placeholder-buttons";
+import { BrowseHubButton, CreateTypeButton } from "./placeholder-buttons";
 import { useUserStatus } from "./use-user-status";
 
-export interface TabPanelContentsWithSchemasProps {
+export interface TabPanelContentsWithTypesProps {
   entityTypes: EntityType[];
   user: SerializedUser;
 }
 
-export const TabPanelContentsWithSchemas: FunctionComponent<
-  TabPanelContentsWithSchemasProps
+export const TabPanelContentsWithTypes: FunctionComponent<
+  TabPanelContentsWithTypesProps
 > = ({ user, entityTypes }) => {
-  const [schemaModalOpen, setSchemaModalOpen] = useState(false);
+  const [typeModalOpen, setTypeModalOpen] = useState(false);
   const userStatus = useUserStatus(user);
-  const createSchemaModal = (
-    <CreateSchemaModal
-      open={schemaModalOpen}
-      onClose={() => setSchemaModalOpen(false)}
+  const createTypeModal = (
+    <CreateTypeModal
+      open={typeModalOpen}
+      onClose={() => setTypeModalOpen(false)}
     />
   );
 
@@ -36,18 +36,18 @@ export const TabPanelContentsWithSchemas: FunctionComponent<
     return userStatus === "current" ? (
       <>
         <Placeholder
-          header="You haven’t created any schemas yet"
+          header="You haven’t created any types yet"
           tip="Start building to see your creations show up here."
           actions={
-            <CreateSchemaButton onClick={() => setSchemaModalOpen(true)} />
+            <CreateTypeButton onClick={() => setTypeModalOpen(true)} />
           }
         />
-        {createSchemaModal}
+        {createTypeModal}
       </>
     ) : (
       <Placeholder
-        header={`@${user.shortname} hasn’t published any schemas yet`}
-        tip="You can browse existing schemas on the Hub."
+        header={`@${user.shortname} hasn’t published any types yet`}
+        tip="You can browse existing types on the Hub."
         actions={<BrowseHubButton />}
       />
     );
@@ -62,21 +62,21 @@ export const TabPanelContentsWithSchemas: FunctionComponent<
             justifyContent: { xs: "flex-start", md: "flex-end" },
           }}
         >
-          <Button squared size="small" onClick={() => setSchemaModalOpen(true)}>
-            Create New Schema
+          <Button squared size="small" onClick={() => setTypeModalOpen(true)}>
+            Create New Type
           </Button>
         </Box>
       )}
-      {entityTypes.map(({ entityTypeId, schema, updatedAt }) => (
+      {entityTypes.map(({ entityTypeId, type, updatedAt }) => (
         <ListViewCard
           key={entityTypeId}
-          title={schema.title}
-          description={schema.description as string}
+          title={type.title}
+          description={type.description as string}
           extraContent={formatUpdatedAt(updatedAt as unknown as string)}
-          url={schema.$id}
+          url={type.$id}
         />
       ))}
-      {createSchemaModal}
+      {createTypeModal}
     </>
   );
 };

--- a/apps/site/src/components/pages/user/user-page-component.tsx
+++ b/apps/site/src/components/pages/user/user-page-component.tsx
@@ -14,7 +14,7 @@ import { ExpandedBlockMetadata } from "../../../lib/blocks";
 import { Sidebar } from "./sidebar";
 import { TabPanelContentsWithBlocks } from "./tab-panel-contents-with-blocks";
 import { TabPanelContentsWithOverview } from "./tab-panel-contents-with-overview";
-import { TabPanelContentsWithSchemas } from "./tab-panel-contents-with-schemas";
+import { TabPanelContentsWithTypes } from "./tab-panel-contents-with-types";
 import { TabHeader, TabPanel, TabValue } from "./tabs";
 
 const SIDEBAR_WIDTH = 300;
@@ -89,7 +89,7 @@ export const UserPageComponent: FunctionComponent<UserPageProps> = ({
               activeTab={activeTab}
               tabItemsCount={{
                 blocks: blocks.length,
-                schemas: entityTypes.length,
+                types: entityTypes.length,
               }}
             />
             {/* TAB PANELS  */}
@@ -103,8 +103,8 @@ export const UserPageComponent: FunctionComponent<UserPageProps> = ({
             <TabPanel activeTab={activeTab} value="blocks" index={1}>
               <TabPanelContentsWithBlocks user={user} blocks={blocks} />
             </TabPanel>
-            <TabPanel activeTab={activeTab} value="schemas" index={2}>
-              <TabPanelContentsWithSchemas
+            <TabPanel activeTab={activeTab} value="types" index={2}>
+              <TabPanelContentsWithTypes
                 user={user}
                 entityTypes={entityTypes}
               />

--- a/apps/site/src/pages/[shortname]/types/[title].page.tsx
+++ b/apps/site/src/pages/[shortname]/types/[title].page.tsx
@@ -7,7 +7,7 @@ import { NextSeo } from "next-seo";
 import { useEffect, useState } from "react";
 import { tw } from "twind";
 
-import { SchemaEditor } from "../../../components/entity-types/schema-editor/schema-editor";
+import { TypeEditor } from "../../../components/entity-types/type-editor/type-editor";
 import { Link } from "../../../components/link";
 import { useUser } from "../../../context/user-context";
 import { EntityType } from "../../../lib/api/model/entity-type.model";
@@ -76,10 +76,10 @@ const EntityTypePage: NextPage = () => {
     if (!args.data) {
       throw new Error("No data supplied to updateEntityType request");
     }
-    const { entityTypeId, schema } = args.data;
+    const { entityTypeId, type } = args.data;
 
     return apiClient
-      .updateEntityType({ schema: JSON.stringify(schema) }, entityTypeId)
+      .updateEntityType({ type: JSON.stringify(type) }, entityTypeId)
       .then(({ data }) => {
         if (data) {
           return {
@@ -109,11 +109,11 @@ const EntityTypePage: NextPage = () => {
   const userCanEdit =
     user !== "loading" && user?.shortname === shortnameWithoutLeadingAt;
 
-  const uri = entityType.schema.$id;
+  const uri = entityType.type.$id;
 
   return (
     <>
-      <NextSeo title={`Block Protocol – ${shortname}/${title} Schema`} />
+      <NextSeo title={`Block Protocol – ${shortname}/${title} Type`} />
       <Container
         sx={{
           marginTop: {
@@ -132,26 +132,25 @@ const EntityTypePage: NextPage = () => {
             {" >"}
           </Link>
           <Typography variant="bpHeading3" component="h1">
-            <strong>{title ?? "Unnamed"}</strong> Schema
+            <strong>{title ?? "Unnamed"}</strong> Type
           </Typography>
         </header>
 
         <section>
           <Typography variant="bpBodyCopy" sx={{ mb: 2 }}>
-            You can use this editor to build basic schemas, representing types
-            of entities.
+            You can use this editor to build basic entity types.
           </Typography>
           <Typography variant="bpBodyCopy" sx={{ mb: 2 }}>
-            You can use these entity types as the expected value for a property
-            in another schema.
+            These types will be deprecated in February 2023 and a new type
+            system will be introduced as part of the 0.3 specification.
           </Typography>
         </section>
 
         <main className={tw`pt-8 mb-14 w-auto`}>
-          <SchemaEditor
+          <TypeEditor
             aggregateEntityTypes={aggregateEntityTypes}
             entityTypeId={entityType.entityTypeId}
-            schema={entityType.schema}
+            type={entityType.type}
             updateEntityType={userCanEdit ? updateEntityType : undefined}
           />
         </main>
@@ -167,7 +166,7 @@ const EntityTypePage: NextPage = () => {
         </Box>
         <Box sx={{ mb: 2 }}>
           <Typography variant="bpSmallCopy" sx={{ maxWidth: "100%" }}>
-            This schema will always be available at{" "}
+            This type will always be available at{" "}
             <Link href={uri}>{uri}</Link> - this is its <strong>$id</strong>.
           </Typography>
         </Box>

--- a/apps/site/src/pages/_app.page.tsx
+++ b/apps/site/src/pages/_app.page.tsx
@@ -33,7 +33,7 @@ NProgress.configure({ showSpinner: false });
 const defaultSeoConfig: DefaultSeoProps = {
   title: "Block Protocol – an open standard for data-driven blocks",
   description:
-    "A standardized way to create blocks whose contents are mapped to schemas, which are both human and machine-readable.",
+    "A standardized way to create blocks which are both human and machine-readable, whose contents are mapped to schemas.",
 
   twitter: {
     cardType: "summary_large_image",

--- a/apps/site/tests/integration/accountpage.test.ts
+++ b/apps/site/tests/integration/accountpage.test.ts
@@ -20,7 +20,7 @@ test("key elements should be present when user views their account page", async 
   for (const [testId, href] of [
     ["profile-page-overview-tab", "/@alice"],
     ["profile-page-blocks-tab", "/@alice/blocks"],
-    ["profile-page-schemas-tab", "/@alice/schemas"],
+    ["profile-page-types-tab", "/@alice/types"],
   ] as const) {
     const item = page.locator(`[data-testid='${testId}']`);
     await expect(item).toBeVisible();
@@ -31,7 +31,7 @@ test("key elements should be present when user views their account page", async 
   await page.locator("[data-testid='profile-page-overview-tab']").click();
 
   await expect(
-    page.locator("text=You haven’t created any blocks or schemas yet"),
+    page.locator("text=You haven’t created any blocks or types yet"),
   ).toBeVisible();
 
   await expect(
@@ -45,7 +45,7 @@ test("key elements should be present when user views their account page", async 
     "/docs/developing-blocks",
   );
 
-  await expect(page.locator("text=Create a schema")).toBeVisible();
+  await expect(page.locator("text=Create a type")).toBeVisible();
 
   // Blocks tab tests
   await page.locator("[data-testid='profile-page-blocks-tab']").click();
@@ -65,18 +65,18 @@ test("key elements should be present when user views their account page", async 
     "/docs/developing-blocks",
   );
 
-  // Schema tab tests
-  await page.locator("[data-testid='profile-page-schemas-tab']").click();
+  // Type tab tests
+  await page.locator("[data-testid='profile-page-types-tab']").click();
 
   await expect(
-    page.locator("text=You haven’t created any schemas yet"),
+    page.locator("text=You haven’t created any types yet"),
   ).toBeVisible();
 
   await expect(
     page.locator("text=Start building to see your creations show up here."),
   ).toBeVisible();
 
-  await expect(page.locator("text=Create a schema")).toBeVisible();
+  await expect(page.locator("text=Create a type")).toBeVisible();
 });
 
 const codeBlockMetadata = (await getBlocksData()).find(
@@ -98,7 +98,7 @@ test("key elements should be present when guest user views account page", async 
   for (const [testId, href] of [
     ["profile-page-overview-tab", "/@hash"],
     ["profile-page-blocks-tab", "/@hash/blocks"],
-    ["profile-page-schemas-tab", "/@hash/schemas"],
+    ["profile-page-types-tab", "/@hash/types"],
   ] as const) {
     const item = page.locator(`[data-testid='${testId}']`);
     await expect(item).toBeVisible();
@@ -183,16 +183,16 @@ test("key elements should be present when guest user views account page", async 
     codeBlockListViewCard.locator(`text=${codeBlockMetadata.description}`),
   ).toBeVisible();
 
-  await page.locator("[data-testid='profile-page-schemas-tab']").click();
+  await page.locator("[data-testid='profile-page-types-tab']").click();
 
-  await expect(page).toHaveURL("/@hash/schemas");
+  await expect(page).toHaveURL("/@hash/types");
 
   await expect(
-    page.locator("text=@hash hasn’t published any schemas yet"),
+    page.locator("text=@hash hasn’t published any types yet"),
   ).toBeVisible();
 
   await expect(
-    page.locator("text=You can browse existing schemas on the Hub."),
+    page.locator("text=You can browse existing types on the Hub."),
   ).toBeVisible();
 
   await expect(page.locator("text=Browse the Hub")).toBeVisible();


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We're moving away from referring to entity types as "schemas", using the latter term now for any kind of type definition.

This updates copy on the Þ site to reflect.