### PR TITLE
Add helper function to get property types referenced in an entity type

### DIFF
--- a/packages/@blockprotocol/graph/src/stdlib/subgraph/edge/entity-type.ts
+++ b/packages/@blockprotocol/graph/src/stdlib/subgraph/edge/entity-type.ts
@@ -1,0 +1,48 @@
+import {
+  BaseUri,
+  extractBaseUri,
+  extractVersion,
+  VersionedUri,
+} from "@blockprotocol/type-system/slim";
+
+import {
+  isConstrainsPropertiesOnEdge,
+  OntologyTypeEditionId,
+  Subgraph,
+} from "../../../types/subgraph.js";
+
+/**
+ * Gets identifiers for all `PropertyType`s referenced within a given `EntityType` schema by searching for
+ * "ConstrainsPropertiesOn" `Edge`s from the respective `Vertex` within a `Subgraph`.
+ *
+ * @param subgraph {Subgraph} - The `Subgraph` containing the type tree of the `EntityType`
+ * @param entityTypeId {OntologyTypeEditionId | VersionedUri} - The identifier of the `EntityType` to search for
+ * @returns {OntologyTypeEditionId[]} - The identifiers of the `PropertyType`s referenced from the `EntityType`
+ */
+export const getPropertyTypesReferencedByEntityType = (
+  subgraph: Subgraph,
+  entityTypeId: OntologyTypeEditionId | VersionedUri,
+): OntologyTypeEditionId[] => {
+  let baseUri: BaseUri;
+  let version: number;
+
+  if (typeof entityTypeId === "string") {
+    [baseUri, version] = [
+      extractBaseUri(entityTypeId),
+      extractVersion(entityTypeId),
+    ];
+  } else {
+    baseUri = entityTypeId.baseId;
+    version = entityTypeId.versionId;
+  }
+
+  const outwardEdges = subgraph.edges[baseUri]?.[version];
+
+  if (outwardEdges === undefined) {
+    return [];
+  }
+
+  return outwardEdges
+    .filter(isConstrainsPropertiesOnEdge)
+    .map((outwardEdge) => outwardEdge.rightEndpoint);
+};

--- a/packages/@blockprotocol/graph/src/types/subgraph/edges/outward-edge-alias.ts
+++ b/packages/@blockprotocol/graph/src/types/subgraph/edges/outward-edge-alias.ts
@@ -3,9 +3,11 @@
  */
 
 import { Subtype } from "../../../util.js";
+import { OntologyTypeEditionId } from "../../ontology.js";
 import {
   EntityIdAndTimestamp,
   KnowledgeGraphOutwardEdge,
+  OntologyOutwardEdge,
   OutwardEdge,
 } from "./outward-edge.js";
 
@@ -67,4 +69,21 @@ export const isIncomingLinkEdge = (
   outwardEdge: OutwardEdge,
 ): outwardEdge is IncomingLinkEdge => {
   return outwardEdge.kind === "HAS_RIGHT_ENTITY" && outwardEdge.reversed;
+};
+
+export type ConstrainsPropertiesOnEdge = Subtype<
+  OntologyOutwardEdge,
+  {
+    reversed: false;
+    kind: "CONSTRAINS_PROPERTIES_ON";
+    rightEndpoint: OntologyTypeEditionId;
+  }
+>;
+
+export const isConstrainsPropertiesOnEdge = (
+  outwardEdge: OutwardEdge,
+): outwardEdge is ConstrainsPropertiesOnEdge => {
+  return (
+    outwardEdge.kind === "CONSTRAINS_PROPERTIES_ON" && !outwardEdge.reversed
+  );
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This expands the `stdlib` to provide a helper to get all `PropertyType`s referenced by a given `EntityType` by utilising the `Edges` of a `Subgraph`.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203363157432094/1203662893654909/f) _(internal)_

## 🚫 Blocked by

N/A

## 🔍 What does this change?

See commits, tiny diff

## 📜 Does this require a change to the docs?

Not to my knowledge

## ⚠️ Known issues

We have a slightly unclear strategy about when to return errors for missing things

## 🐾 Next steps

N/A

## 🛡 What tests cover this?

None

## ❓ How to test this?

We don't currently have tests for the subgraph library, if you want to see it in action you'll need to modify the existing code and use it somewhere
