### PR TITLE
Fix vote application error handling

### DIFF
--- a/apps/site/src/lib/api/mailchimp.ts
+++ b/apps/site/src/lib/api/mailchimp.ts
@@ -88,7 +88,8 @@ export const getMember = async (params: {
 
   return await getMailchimpApi()
     .get(`members/${memberID}`)
-    .then((res) => res.data);
+    .then((res) => res.data)
+    .catch(() => undefined);
 };
 
 export const updateMailchimpMemberInfo = async (params: {

--- a/apps/site/src/pages/api/vote-application.api.ts
+++ b/apps/site/src/pages/api/vote-application.api.ts
@@ -49,9 +49,7 @@ export default createBaseHandler<
   const member = await getMember({ email: req.body.email });
 
   try {
-    const payload = {
-      ...req.body,
-    };
+    const payload = { ...req.body };
 
     if (member?.merge_fields?.WISH_EA && payload?.merge_fields?.WISH_EA) {
       payload.merge_fields.WISH_EA = `${member?.merge_fields?.WISH_EA}, ${payload.merge_fields.WISH_EA}`;

--- a/apps/site/src/pages/api/vote-application.api.ts
+++ b/apps/site/src/pages/api/vote-application.api.ts
@@ -23,11 +23,11 @@ const validate = ajv.compile<VoteApplicationRequestBody>({
     merge_fields: {
       type: "object",
       properties: {
-        ECO_SANITY: { type: "string" },
-        ECO_STRAPI: { type: "string" },
-        ECO_CONFUL: { type: "string" },
-        ECO_GITHUB: { type: "string" },
-        ECO_OTHER: { type: "string" },
+        ECO_SANITY: { type: "string", enum: ["Yes", "No"] },
+        ECO_STRAPI: { type: "string", enum: ["Yes", "No"] },
+        ECO_CONFUL: { type: "string", enum: ["Yes", "No"] },
+        ECO_GITHUB: { type: "string", enum: ["Yes", "No"] },
+        ECO_OTHER: { type: "string", enum: ["Yes", "No"] },
         WISH_EA: { type: "string" },
       },
       additionalProperties: false,

--- a/apps/site/src/pages/api/vote-application.api.ts
+++ b/apps/site/src/pages/api/vote-application.api.ts
@@ -1,4 +1,5 @@
 import Ajv from "ajv";
+
 import { createBaseHandler } from "../../lib/api/handler/base-handler";
 import { getMember, subscribeToMailchimp } from "../../lib/api/mailchimp";
 
@@ -46,19 +47,19 @@ export default createBaseHandler<
   VoteApplicationRequestBody,
   VoteApplicationResponse
 >().put(async (req, res) => {
-  const member = await getMember({ email: req.body.email });
-
   try {
     const payload = { ...req.body };
-
-    if (member?.merge_fields?.WISH_EA && payload?.merge_fields?.WISH_EA) {
-      payload.merge_fields.WISH_EA = `${member?.merge_fields?.WISH_EA}, ${payload.merge_fields.WISH_EA}`;
-    }
 
     const valid = validate(payload);
 
     if (!valid) {
       throw new Error();
+    }
+
+    const member = await getMember({ email: payload.email });
+
+    if (member?.merge_fields?.WISH_EA && payload?.merge_fields?.WISH_EA) {
+      payload.merge_fields.WISH_EA = `${member?.merge_fields?.WISH_EA}, ${payload.merge_fields.WISH_EA}`;
     }
 
     await subscribeToMailchimp(payload);

--- a/apps/site/src/pages/api/vote-application.api.ts
+++ b/apps/site/src/pages/api/vote-application.api.ts
@@ -20,8 +20,16 @@ export default createBaseHandler<
 
     const payload = {
       email: req.body.email,
-      merge_fields: req.body.merge_fields,
+      merge_fields: {
+        ECO_SANITY: req.body.merge_fields?.ECO_SANITY,
+        ECO_STRAPI: req.body.merge_fields?.ECO_STRAPI,
+        ECO_CONFUL: req.body.merge_fields?.ECO_CONFUL,
+        ECO_GITHUB: req.body.merge_fields?.ECO_GITHUB,
+        ECO_OTHER: req.body.merge_fields?.ECO_OTHER,
+        WISH_EA: req.body.merge_fields?.WISH_EA,
+      },
     };
+
     if (member?.merge_fields?.WISH_EA && payload?.merge_fields?.WISH_EA) {
       payload.merge_fields.WISH_EA = `${member?.merge_fields?.WISH_EA}, ${payload.merge_fields.WISH_EA}`;
     }

--- a/apps/site/src/pages/api/vote-application.api.ts
+++ b/apps/site/src/pages/api/vote-application.api.ts
@@ -15,26 +15,24 @@ export default createBaseHandler<
   VoteApplicationRequestBody,
   VoteApplicationResponse
 >().put(async (req, res) => {
-  const member = await getMember({ email: req.body.email })
-    .then((mailchimpMember) => ({
-      id: mailchimpMember.id,
-      email: mailchimpMember.email_address,
-      merge_fields: mailchimpMember.merge_fields,
-    }))
-    .catch(() => {
-      return res.status(400).send({ error: true });
-    });
+  try {
+    const member = await getMember({ email: req.body.email }).then(
+      (mailchimpMember) => ({
+        id: mailchimpMember.id,
+        email: mailchimpMember.email_address,
+        merge_fields: mailchimpMember.merge_fields,
+      }),
+    );
 
-  const payload = { ...req.body };
-  if (member?.merge_fields?.WISH_EA && payload?.merge_fields?.WISH_EA) {
-    payload.merge_fields.WISH_EA = `${member?.merge_fields?.WISH_EA}, ${payload.merge_fields.WISH_EA}`;
-  }
+    const payload = { ...req.body };
+    if (member?.merge_fields?.WISH_EA && payload?.merge_fields?.WISH_EA) {
+      payload.merge_fields.WISH_EA = `${member?.merge_fields?.WISH_EA}, ${payload.merge_fields.WISH_EA}`;
+    }
 
-  return await subscribeToMailchimp(payload)
-    .then(() => {
+    return await subscribeToMailchimp(payload).then(() => {
       return res.json({ success: true });
-    })
-    .catch(() => {
-      return res.status(400).send({ error: true });
     });
+  } catch {
+    return res.status(400).send({ error: true });
+  }
 });

--- a/apps/site/src/pages/api/vote-application.api.ts
+++ b/apps/site/src/pages/api/vote-application.api.ts
@@ -1,10 +1,41 @@
+import Ajv from "ajv";
 import { createBaseHandler } from "../../lib/api/handler/base-handler";
 import { getMember, subscribeToMailchimp } from "../../lib/api/mailchimp";
 
 export type VoteApplicationRequestBody = {
   email: string;
-  merge_fields?: { [key: string]: any };
+  merge_fields: {
+    ECO_SANITY?: string;
+    ECO_STRAPI?: string;
+    ECO_CONFUL?: string;
+    ECO_GITHUB?: string;
+    ECO_OTHER?: string;
+    WISH_EA?: string;
+  };
 };
+
+const ajv = new Ajv();
+
+const validate = ajv.compile<VoteApplicationRequestBody>({
+  type: "object",
+  properties: {
+    email: { type: "string" },
+    merge_fields: {
+      type: "object",
+      properties: {
+        ECO_SANITY: { type: "string" },
+        ECO_STRAPI: { type: "string" },
+        ECO_CONFUL: { type: "string" },
+        ECO_GITHUB: { type: "string" },
+        ECO_OTHER: { type: "string" },
+        WISH_EA: { type: "string" },
+      },
+      additionalProperties: false,
+    },
+  },
+  required: ["email"],
+  additionalProperties: false,
+});
 
 export type VoteApplicationResponse = {
   success?: boolean;
@@ -15,23 +46,21 @@ export default createBaseHandler<
   VoteApplicationRequestBody,
   VoteApplicationResponse
 >().put(async (req, res) => {
-  try {
-    const member = await getMember({ email: req.body.email });
+  const member = await getMember({ email: req.body.email });
 
+  try {
     const payload = {
-      email: req.body.email,
-      merge_fields: {
-        ECO_SANITY: req.body.merge_fields?.ECO_SANITY,
-        ECO_STRAPI: req.body.merge_fields?.ECO_STRAPI,
-        ECO_CONFUL: req.body.merge_fields?.ECO_CONFUL,
-        ECO_GITHUB: req.body.merge_fields?.ECO_GITHUB,
-        ECO_OTHER: req.body.merge_fields?.ECO_OTHER,
-        WISH_EA: req.body.merge_fields?.WISH_EA,
-      },
+      ...req.body,
     };
 
     if (member?.merge_fields?.WISH_EA && payload?.merge_fields?.WISH_EA) {
       payload.merge_fields.WISH_EA = `${member?.merge_fields?.WISH_EA}, ${payload.merge_fields.WISH_EA}`;
+    }
+
+    const valid = validate(payload);
+
+    if (!valid) {
+      throw new Error();
     }
 
     await subscribeToMailchimp(payload);

--- a/apps/site/src/pages/api/vote-application.api.ts
+++ b/apps/site/src/pages/api/vote-application.api.ts
@@ -18,7 +18,10 @@ export default createBaseHandler<
   try {
     const member = await getMember({ email: req.body.email });
 
-    const payload = { ...req.body };
+    const payload = {
+      email: req.body.email,
+      merge_fields: req.body.merge_fields,
+    };
     if (member?.merge_fields?.WISH_EA && payload?.merge_fields?.WISH_EA) {
       payload.merge_fields.WISH_EA = `${member?.merge_fields?.WISH_EA}, ${payload.merge_fields.WISH_EA}`;
     }

--- a/apps/site/src/pages/api/vote-application.api.ts
+++ b/apps/site/src/pages/api/vote-application.api.ts
@@ -16,22 +16,16 @@ export default createBaseHandler<
   VoteApplicationResponse
 >().put(async (req, res) => {
   try {
-    const member = await getMember({ email: req.body.email }).then(
-      (mailchimpMember) => ({
-        id: mailchimpMember.id,
-        email: mailchimpMember.email_address,
-        merge_fields: mailchimpMember.merge_fields,
-      }),
-    );
+    const member = await getMember({ email: req.body.email });
 
     const payload = { ...req.body };
     if (member?.merge_fields?.WISH_EA && payload?.merge_fields?.WISH_EA) {
       payload.merge_fields.WISH_EA = `${member?.merge_fields?.WISH_EA}, ${payload.merge_fields.WISH_EA}`;
     }
 
-    return await subscribeToMailchimp(payload).then(() => {
-      return res.json({ success: true });
-    });
+    await subscribeToMailchimp(payload);
+
+    return res.json({ success: true });
   } catch {
     return res.status(400).send({ error: true });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8771,9 +8771,9 @@ json2mq@^0.2.0:
     string-convert "^0.2.0"
 
 json5@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
-  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
+  integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
   dependencies:
     minimist "^1.2.0"
 
@@ -10032,9 +10032,9 @@ minimist-options@^4.0.2:
     kind-of "^6.0.3"
 
 minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6, minimist@~1.2.5:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
-  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
+  integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
 
 minipass-collect@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR fixes the [error](https://sentry.io/organizations/hashintel/issues/3829279587/?environment=production&project=6603021&query=is%3Aunresolved&referrer=issue-stream) flagged by Sentry: `Cannot set headers after they are sent to the client` when submitting a vote on the BP page fails. 

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203543021352032/1203672578234992/f) _(internal)_


## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Removed duplicate error handling for the `vote-application` api method.


## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Try to vote without any mailchimp env vars (to force it to fail) and check for the error;
2.  Add the mailchimp env vars (DM me if you want to use mine) and test again to check if voting still works.

