### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+LICENSE @blockprotocol/legal
+LICENSE.txt @blockprotocol/legal
+LICENSE.md @blockprotocol/legal


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Mirrors https://github.com/hashintel/hash/pull/1788

Adds a CODEOWNERS file requiring PRs be approved by a new @blockprotocol/legal team when they modify license files within this repo.

Covers LICENSE, LICENSE.txt and LICENSE.md files. Although the former two are not in use, if they were to be mistakenly or maliciously added, they should be covered.