### PR TITLE
Increase pipeline timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
     name: NPM Packages
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-20.04
-    timeout-minutes: 30 ## https://github.com/actions/upload-artifact/issues/358
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v3
@@ -242,7 +242,7 @@ jobs:
           - iphone
           - pixel
           - safari
-    timeout-minutes: 30 ## https://github.com/actions/upload-artifact/issues/358
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/site-deployment.yml
+++ b/.github/workflows/site-deployment.yml
@@ -38,7 +38,7 @@ jobs:
     needs: [warm_up_vercel]
     if: github.event.deployment_status.state == 'success' || github.event.schedule == '0 4 * * *'
     runs-on: ubuntu-20.04
-    timeout-minutes: 30 ## https://github.com/actions/upload-artifact/issues/358
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Extracted from https://github.com/blockprotocol/blockprotocol/pull/680, unblocks #871 and other pending PRs.

I've increased timeout because cold yarn + rust warmup has been causing CI failures: https://github.com/blockprotocol/blockprotocol/actions/runs/3887049425/jobs/6632856500

We are no longer affected by https://github.com/actions/upload-artifact/issues/358 once https://github.com/blockprotocol/blockprotocol/pull/769 has been merged. I've kept a large timeout just in case, but I don't think we need it except for some really rare edge cases.

## 🛡 What tests cover this?

CI
