### PR TITLE
Enable specifying npm tag/version in create-block-app

### DIFF
--- a/.changeset/eight-cups-shave.md
+++ b/.changeset/eight-cups-shave.md
@@ -1,0 +1,5 @@
+---
+"create-block-app": patch
+---
+
+enable passing an npm tag when specifying template

--- a/packages/@blockprotocol/graph/src/stdlib.ts
+++ b/packages/@blockprotocol/graph/src/stdlib.ts
@@ -12,12 +12,7 @@ import {
   getEntities as getEntitiesTemporal,
   getEntity as getEntityTemporal,
 } from "./stdlib/subgraph/element/entity.js";
-import {
-  Entity,
-  EntityId,
-  EntityPropertiesObject,
-  WithSimpleAccessors,
-} from "./types/entity.js";
+import { Entity, EntityId } from "./types/entity.js";
 import { LinkEntityAndRightEntity, Subgraph } from "./types/subgraph.js";
 
 export { buildSubgraph } from "./stdlib/subgraph/builder.js";

--- a/packages/create-block-app/create-block-app.js
+++ b/packages/create-block-app/create-block-app.js
@@ -58,7 +58,11 @@ const usage = commandLineUsage(helpSections);
 
   const slugifiedBlockName = slugify(blockName, { lower: true, strict: true });
 
-  if (!availableTemplates.includes(template)) {
+  if (
+    !availableTemplates.find(
+      (option) => template === option || template.startsWith(`${option}@`),
+    )
+  ) {
     console.error(
       `Requested template '${template}' is invalid. Please choose one of ${availableTemplates.join(
         ", ",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`npx create-block-app` allows you to specify a `--template`, picking from one of `custom-element`, `react`, and `html` – it will then fetch the appropriate `block-template-[template]` package from npm.

Being able to specify the version or tag of the template to install will be useful to us in development – particularly to be able to do things like `npx create-block-app@canary --template react@canary [blockname]`

This PR enables that by updating a check which would reject values for `--template` that do not exactly match an expected template name.

An alternative approach would be to specify `--tag` or `--version` as an explicit, documented option to `create-block-app`. I did not do this because there may be mismatches between versions of templates and the version of `create-block-app` being used, which somewhat relies on certain files being present in the block template, and we would almost always want external users to use the latest template version.

It also removes a couple of unused imports I missed in an earlier PR.

## ❓ How to test this?

1. Checkout the branch and run `npx create-block-app --template custom-element@latest test-block`