### PR TITLE
Stop linting license files

### DIFF
--- a/.github/licenses/LICENSE-APACHE.md
+++ b/.github/licenses/LICENSE-APACHE.md
@@ -1,5 +1,3 @@
-<!-- markdownlint-disable -->
-
 # Apache License
 
 _Version 2.0, January 2004_  

--- a/.github/licenses/LICENSE-ELASTIC.md
+++ b/.github/licenses/LICENSE-ELASTIC.md
@@ -1,5 +1,3 @@
-<!-- markdownlint-disable -->
-
 # Elastic License 2.0
 
 URL: https://www.elastic.co/licensing/elastic-license

--- a/.github/licenses/LICENSE-MIT.md
+++ b/.github/licenses/LICENSE-MIT.md
@@ -1,5 +1,3 @@
-<!-- markdownlint-disable -->
-
 # The MIT License (MIT)
 
 Copyright © 2021–, HASH

--- a/.gitignore
+++ b/.gitignore
@@ -64,11 +64,7 @@ apps/site/public/blocks
 apps/site/public/schemas
 apps/site/site-map.json
 apps/site/test-results
-libs/block-template-html/dev/src
-libs/mock-block-dock/src/version.ts
 libs/@blockprotocol/type-system/.rollup.cache
 libs/@blockprotocol/type-system/wasm
-
-##################
-## Specific to git
-##################
+libs/block-template-html/dev/src
+libs/mock-block-dock/src/version.ts

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -76,7 +76,15 @@ apps/site/public/blocks
 apps/site/public/schemas
 apps/site/site-map.json
 apps/site/test-results
-libs/block-template-html/dev/src
-libs/mock-block-dock/src/version.ts
 libs/@blockprotocol/type-system/.rollup.cache
 libs/@blockprotocol/type-system/wasm
+libs/block-template-html/dev/src
+libs/mock-block-dock/src/version.ts
+
+#########################
+## Shared between linters
+#########################
+
+# Keep license files as is
+LICENSE.md
+LICENSE-*.md

--- a/.prettierignore
+++ b/.prettierignore
@@ -87,7 +87,15 @@ apps/site/public/blocks
 apps/site/public/schemas
 apps/site/site-map.json
 apps/site/test-results
-libs/block-template-html/dev/src
-libs/mock-block-dock/src/version.ts
 libs/@blockprotocol/type-system/.rollup.cache
 libs/@blockprotocol/type-system/wasm
+libs/block-template-html/dev/src
+libs/mock-block-dock/src/version.ts
+
+#########################
+## Shared between linters
+#########################
+
+# Keep license files as is
+LICENSE.md
+LICENSE-*.md

--- a/libs/@blockprotocol/type-system/crate/LICENSE-APACHE.md
+++ b/libs/@blockprotocol/type-system/crate/LICENSE-APACHE.md
@@ -1,5 +1,3 @@
-<!-- markdownlint-disable -->
-
 # Apache License
 
 _Version 2.0, January 2004_  

--- a/libs/@local/eslint-config/generate-ignore-patterns.cjs
+++ b/libs/@local/eslint-config/generate-ignore-patterns.cjs
@@ -17,7 +17,7 @@ module.exports = (workspaceDirPath) => {
   const [, match] =
     fs
       .readFileSync(`${monorepoRoot}/.gitignore`, "utf8")
-      .match(/Shared between git and linters([^\0]*?)Specific to git/) ?? [];
+      .match(/Shared between git and linters([^\0]*?)$/) ?? [];
 
   if (!match) {
     throw new Error(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR excludes `LICENSE.md` and `LICENSE-*.md` files from `yarn lint:markdownlint` and `yarn lint:prettier`.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203193968491715/1203754204131512/f) _(internal)_
- https://github.com/hashintel/hash/pull/1847
