### PR TITLE
Fix workspace dirs in knip config

### DIFF
--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -28,18 +28,23 @@
     // thinking every workspace uses all ESLint plugins. That's why Knip's ESLint plugin is disabled everywhere else.
     // This resulted in two false positives: eslint-import-resolver-typescript for this workspace, and
     // @local/eslint-config for the others.
-    "packages/@local/eslint-config": {
+    "libs/@local/eslint-config": {
       "entry": [],
       "project": [],
       "eslint": "index.js"
     },
-    "packages/@local/tsconfig": {
+    "libs/@local/tsconfig": {
       "typescript": ["*.json", "!package.json"]
     },
-    "packages/@blockprotocol/core": {
+    "libs/@local/package-chores": {
+      "entry": "scripts/*.ts",
+      "project": "scripts/**/*.ts",
       "eslint": false
     },
-    "packages/mock-block-dock": {
+    "libs/@blockprotocol/core": {
+      "eslint": false
+    },
+    "libs/mock-block-dock": {
       "entry": ["src/index.ts", "dev/dev-app.tsx"],
       "project": "**/*.{ts,tsx}",
       "webpack": "dev/webpack.config.js",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint:changeset": "changeset status",
     "lint:dependency-version-consistency": "check-dependency-version-consistency .",
     "lint:eslint": "turbo run --continue lint:eslint",
-    "lint:knip": "knip -c .knip.jsonc --no-exit-code",
+    "lint:knip": "knip --no-exit-code",
     "lint:lockfile-lint": "lockfile-lint --path yarn.lock --allowed-hosts registry.yarnpkg.com --allowed-schemes \"https:\"",
     "lint:markdownlint": "markdownlint --dot .",
     "lint:prettier": "prettier --cache --check --ignore-unknown .",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Just saw that the knip config contains odd workspace keys. They should be the actual workspaces as defined in `package.json`. Not sure what happened, why it was like this. Anyway, here's a fix.