### PR TITLE
Bump block versions

### DIFF
--- a/hub/@alfie/github-pr-overview.json
+++ b/hub/@alfie/github-pr-overview.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "23e3976aa173034dd37946531be085f7a20071c3",
+  "commit": "44a5c25e36fdb4e4210f533713960bf2c46beec1",
 
   "workspace": "@blocks/github-pr-overview",
   "distDir": "dist"

--- a/hub/@hash/callout.json
+++ b/hub/@hash/callout.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "23e3976aa173034dd37946531be085f7a20071c3",
+  "commit": "44a5c25e36fdb4e4210f533713960bf2c46beec1",
 
   "workspace": "@blocks/callout",
   "distDir": "dist"

--- a/hub/@hash/code.json
+++ b/hub/@hash/code.json
@@ -1,7 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "23e3976aa173034dd37946531be085f7a20071c3",
-
+  "commit": "44a5c25e36fdb4e4210f533713960bf2c46beec1",
   "workspace": "@blocks/code",
   "distDir": "dist"
 }

--- a/hub/@hash/divider.json
+++ b/hub/@hash/divider.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "23e3976aa173034dd37946531be085f7a20071c3",
+  "commit": "44a5c25e36fdb4e4210f533713960bf2c46beec1",
 
   "workspace": "@blocks/divider",
   "distDir": "dist"

--- a/hub/@hash/embed.json
+++ b/hub/@hash/embed.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "23e3976aa173034dd37946531be085f7a20071c3",
+  "commit": "44a5c25e36fdb4e4210f533713960bf2c46beec1",
 
   "workspace": "@blocks/embed",
   "distDir": "dist"

--- a/hub/@hash/header.json
+++ b/hub/@hash/header.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "23e3976aa173034dd37946531be085f7a20071c3",
+  "commit": "44a5c25e36fdb4e4210f533713960bf2c46beec1",
 
   "workspace": "@blocks/header",
   "distDir": "dist"

--- a/hub/@hash/image.json
+++ b/hub/@hash/image.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "23e3976aa173034dd37946531be085f7a20071c3",
+  "commit": "44a5c25e36fdb4e4210f533713960bf2c46beec1",
 
   "workspace": "@blocks/image",
   "distDir": "dist"

--- a/hub/@hash/paragraph.json
+++ b/hub/@hash/paragraph.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "23e3976aa173034dd37946531be085f7a20071c3",
+  "commit": "44a5c25e36fdb4e4210f533713960bf2c46beec1",
 
   "workspace": "@blocks/paragraph",
   "distDir": "dist"

--- a/hub/@hash/person.json
+++ b/hub/@hash/person.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "23e3976aa173034dd37946531be085f7a20071c3",
+  "commit": "44a5c25e36fdb4e4210f533713960bf2c46beec1",
 
   "workspace": "@blocks/person",
   "distDir": "dist"

--- a/hub/@hash/shuffle.json
+++ b/hub/@hash/shuffle.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "23e3976aa173034dd37946531be085f7a20071c3",
+  "commit": "44a5c25e36fdb4e4210f533713960bf2c46beec1",
 
   "workspace": "@blocks/shuffle",
   "distDir": "dist"

--- a/hub/@hash/table.json
+++ b/hub/@hash/table.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "23e3976aa173034dd37946531be085f7a20071c3",
+  "commit": "44a5c25e36fdb4e4210f533713960bf2c46beec1",
 
   "workspace": "@blocks/table",
   "distDir": "dist"

--- a/hub/@hash/video.json
+++ b/hub/@hash/video.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "23e3976aa173034dd37946531be085f7a20071c3",
+  "commit": "44a5c25e36fdb4e4210f533713960bf2c46beec1",
 
   "workspace": "@blocks/video",
   "distDir": "dist"

--- a/hub/@thehabbos007/calculation.json
+++ b/hub/@thehabbos007/calculation.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "23e3976aa173034dd37946531be085f7a20071c3",
+  "commit": "44a5c25e36fdb4e4210f533713960bf2c46beec1",
 
   "workspace": "@blocks/calculation",
   "distDir": "dist"

--- a/hub/@timdiekmann/countdown.json
+++ b/hub/@timdiekmann/countdown.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "23e3976aa173034dd37946531be085f7a20071c3",
+  "commit": "44a5c25e36fdb4e4210f533713960bf2c46beec1",
 
   "workspace": "@blocks/countdown",
   "distDir": "dist"

--- a/hub/@timdiekmann/timer.json
+++ b/hub/@timdiekmann/timer.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "23e3976aa173034dd37946531be085f7a20071c3",
+  "commit": "44a5c25e36fdb4e4210f533713960bf2c46beec1",
 
   "workspace": "@blocks/timer",
   "distDir": "dist"

--- a/hub/@tldraw/drawing.json
+++ b/hub/@tldraw/drawing.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "23e3976aa173034dd37946531be085f7a20071c3",
+  "commit": "44a5c25e36fdb4e4210f533713960bf2c46beec1",
 
   "workspace": "@blocks/drawing",
   "distDir": "dist"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
Bumps block versions to the latest commit in `hash`.

This will make the Block Hub built off the `0.3` branch have the latest `Code` block, which is updated to 0.3. This will be used to have a serveable block loaded from the Hub for testing in updated embedding applications (HASH, WordPress).