### PR TITLE
Rename various elements of the Graph Service

### DIFF
--- a/libs/@blockprotocol/graph/src/custom-element.ts
+++ b/libs/@blockprotocol/graph/src/custom-element.ts
@@ -4,7 +4,6 @@ import {
   BlockGraphProperties,
   Entity,
   EntityPropertiesObject,
-  EntityRecordId,
   GraphBlockHandler,
   LinkEntityAndRightEntity,
 } from "./index.js";

--- a/libs/@blockprotocol/graph/src/custom-element.ts
+++ b/libs/@blockprotocol/graph/src/custom-element.ts
@@ -4,6 +4,7 @@ import {
   BlockGraphProperties,
   Entity,
   EntityPropertiesObject,
+  EntityRecordId,
   GraphBlockHandler,
   LinkEntityAndRightEntity,
 } from "./index.js";
@@ -68,7 +69,7 @@ export abstract class BlockElementBase<
       this.linkedEntities =
         getOutgoingLinkAndTargetEntities<RootEntityLinkedEntities>(
           blockEntitySubgraph,
-          rootEntity.metadata.editionId.baseId,
+          rootEntity.metadata.recordId.baseId,
         );
     }
   }
@@ -121,7 +122,7 @@ export abstract class BlockElementBase<
 
     return this.graphService.updateEntity({
       data: {
-        entityId: blockEntity.metadata.editionId.baseId,
+        entityId: blockEntity.metadata.recordId.baseId,
         entityTypeId: blockEntity.metadata.entityTypeId,
         properties,
         leftToRightOrder: blockEntity.linkData?.leftToRightOrder,

--- a/libs/@blockprotocol/graph/src/custom-element.ts
+++ b/libs/@blockprotocol/graph/src/custom-element.ts
@@ -68,7 +68,7 @@ export abstract class BlockElementBase<
       this.linkedEntities =
         getOutgoingLinkAndTargetEntities<RootEntityLinkedEntities>(
           blockEntitySubgraph,
-          rootEntity.metadata.recordId.baseId,
+          rootEntity.metadata.recordId.entityId,
         );
     }
   }
@@ -121,7 +121,7 @@ export abstract class BlockElementBase<
 
     return this.graphService.updateEntity({
       data: {
-        entityId: blockEntity.metadata.recordId.baseId,
+        entityId: blockEntity.metadata.recordId.entityId,
         entityTypeId: blockEntity.metadata.entityTypeId,
         properties,
         leftToRightOrder: blockEntity.linkData?.leftToRightOrder,

--- a/libs/@blockprotocol/graph/src/graph-block-handler.ts
+++ b/libs/@blockprotocol/graph/src/graph-block-handler.ts
@@ -20,11 +20,11 @@ import {
   DeleteEntityData,
   Entity,
   EntityPropertiesObject,
+  EntityRootedSubgraph,
+  EntityTypeRootedSubgraph,
   GetEntityData,
   GetEntityTypeData,
   ReadOrModifyResourceError,
-  Subgraph,
-  SubgraphRootTypes,
   UpdateEntityData,
   UploadFileData,
   UploadFileReturn,
@@ -134,10 +134,7 @@ export class GraphBlockHandler
   }
 
   getEntity({ data }: { data?: GetEntityData }) {
-    return this.sendMessage<
-      Subgraph<SubgraphRootTypes["entity"]>,
-      ReadOrModifyResourceError
-    >({
+    return this.sendMessage<EntityRootedSubgraph, ReadOrModifyResourceError>({
       message: {
         messageName: "getEntity",
         data,
@@ -148,7 +145,7 @@ export class GraphBlockHandler
 
   aggregateEntities({ data }: { data?: AggregateEntitiesData }) {
     return this.sendMessage<
-      AggregateEntitiesResult<Subgraph<SubgraphRootTypes["entity"]>>,
+      AggregateEntitiesResult<EntityRootedSubgraph>,
       ReadOrModifyResourceError
     >({
       message: {
@@ -193,7 +190,7 @@ export class GraphBlockHandler
 
   getEntityType({ data }: { data?: GetEntityTypeData }) {
     return this.sendMessage<
-      Subgraph<SubgraphRootTypes["entityType"]>,
+      EntityTypeRootedSubgraph,
       ReadOrModifyResourceError
     >({
       message: {
@@ -206,7 +203,7 @@ export class GraphBlockHandler
 
   aggregateEntityTypes({ data }: { data?: AggregateEntityTypesData }) {
     return this.sendMessage<
-      AggregateEntityTypesResult<Subgraph<SubgraphRootTypes["entityType"]>>,
+      AggregateEntityTypesResult<EntityTypeRootedSubgraph>,
       ReadOrModifyResourceError
     >({
       message: {

--- a/libs/@blockprotocol/graph/src/graph-block-handler.ts
+++ b/libs/@blockprotocol/graph/src/graph-block-handler.ts
@@ -20,11 +20,12 @@ import {
   DeleteEntityData,
   Entity,
   EntityPropertiesObject,
-  EntityRootedSubgraph,
-  EntityTypeRootedSubgraph,
+  EntityRootType,
+  EntityTypeRootType,
   GetEntityData,
   GetEntityTypeData,
   ReadOrModifyResourceError,
+  Subgraph,
   UpdateEntityData,
   UploadFileData,
   UploadFileReturn,
@@ -134,7 +135,10 @@ export class GraphBlockHandler
   }
 
   getEntity({ data }: { data?: GetEntityData }) {
-    return this.sendMessage<EntityRootedSubgraph, ReadOrModifyResourceError>({
+    return this.sendMessage<
+      Subgraph<EntityRootType>,
+      ReadOrModifyResourceError
+    >({
       message: {
         messageName: "getEntity",
         data,
@@ -145,7 +149,7 @@ export class GraphBlockHandler
 
   aggregateEntities({ data }: { data?: AggregateEntitiesData }) {
     return this.sendMessage<
-      AggregateEntitiesResult<EntityRootedSubgraph>,
+      AggregateEntitiesResult<Subgraph<EntityRootType>>,
       ReadOrModifyResourceError
     >({
       message: {
@@ -190,7 +194,7 @@ export class GraphBlockHandler
 
   getEntityType({ data }: { data?: GetEntityTypeData }) {
     return this.sendMessage<
-      EntityTypeRootedSubgraph,
+      Subgraph<EntityTypeRootType>,
       ReadOrModifyResourceError
     >({
       message: {
@@ -203,7 +207,7 @@ export class GraphBlockHandler
 
   aggregateEntityTypes({ data }: { data?: AggregateEntityTypesData }) {
     return this.sendMessage<
-      AggregateEntityTypesResult<EntityTypeRootedSubgraph>,
+      AggregateEntityTypesResult<Subgraph<EntityTypeRootType>>,
       ReadOrModifyResourceError
     >({
       message: {

--- a/libs/@blockprotocol/graph/src/graph-embedder-handler.ts
+++ b/libs/@blockprotocol/graph/src/graph-embedder-handler.ts
@@ -5,7 +5,8 @@ import { ServiceHandler } from "@blockprotocol/core";
 import {
   EmbedderGraphMessageCallbacks,
   EmbedderGraphMessages,
-  EntityRootedSubgraph,
+  EntityRootType,
+  Subgraph,
 } from "./types.js";
 
 /**
@@ -17,7 +18,7 @@ export class GraphEmbedderHandler
   extends ServiceHandler
   implements EmbedderGraphMessages
 {
-  private _blockEntitySubgraph?: EntityRootedSubgraph;
+  private _blockEntitySubgraph?: Subgraph<EntityRootType>;
   // private _linkedAggregations?: LinkedAggregations;
   private _readonly?: boolean;
 
@@ -28,7 +29,7 @@ export class GraphEmbedderHandler
     // linkedAggregations,
     readonly,
   }: {
-    blockEntitySubgraph?: EntityRootedSubgraph;
+    blockEntitySubgraph?: Subgraph<EntityRootType>;
     callbacks?: Partial<EmbedderGraphMessageCallbacks>;
     element: HTMLElement;
     // linkedAggregations?: LinkedAggregations;
@@ -90,7 +91,7 @@ export class GraphEmbedderHandler
     };
   }
 
-  blockEntitySubgraph({ data }: { data?: EntityRootedSubgraph }) {
+  blockEntitySubgraph({ data }: { data?: Subgraph<EntityRootType> }) {
     this._blockEntitySubgraph = data;
     this.sendMessage({
       message: {

--- a/libs/@blockprotocol/graph/src/graph-embedder-handler.ts
+++ b/libs/@blockprotocol/graph/src/graph-embedder-handler.ts
@@ -5,8 +5,7 @@ import { ServiceHandler } from "@blockprotocol/core";
 import {
   EmbedderGraphMessageCallbacks,
   EmbedderGraphMessages,
-  Subgraph,
-  SubgraphRootTypes,
+  EntityRootedSubgraph,
 } from "./types.js";
 
 /**
@@ -18,7 +17,7 @@ export class GraphEmbedderHandler
   extends ServiceHandler
   implements EmbedderGraphMessages
 {
-  private _blockEntitySubgraph?: Subgraph<SubgraphRootTypes["entity"]>;
+  private _blockEntitySubgraph?: EntityRootedSubgraph;
   // private _linkedAggregations?: LinkedAggregations;
   private _readonly?: boolean;
 
@@ -29,7 +28,7 @@ export class GraphEmbedderHandler
     // linkedAggregations,
     readonly,
   }: {
-    blockEntitySubgraph?: Subgraph<SubgraphRootTypes["entity"]>;
+    blockEntitySubgraph?: EntityRootedSubgraph;
     callbacks?: Partial<EmbedderGraphMessageCallbacks>;
     element: HTMLElement;
     // linkedAggregations?: LinkedAggregations;
@@ -91,11 +90,7 @@ export class GraphEmbedderHandler
     };
   }
 
-  blockEntitySubgraph({
-    data,
-  }: {
-    data?: Subgraph<SubgraphRootTypes["entity"]>;
-  }) {
+  blockEntitySubgraph({ data }: { data?: EntityRootedSubgraph }) {
     this._blockEntitySubgraph = data;
     this.sendMessage({
       message: {

--- a/libs/@blockprotocol/graph/src/internal/mutate-subgraph.ts
+++ b/libs/@blockprotocol/graph/src/internal/mutate-subgraph.ts
@@ -72,17 +72,17 @@ export const addEntitiesToSubgraphByMutation = (
   > = {};
 
   for (const entity of entities) {
-    const editionId = entity.metadata.editionId;
+    const recordId = entity.metadata.recordId;
     if (entity.linkData) {
-      const linkInfo = linkMap[editionId.baseId];
+      const linkInfo = linkMap[recordId.baseId];
       if (!linkInfo) {
-        linkMap[editionId.baseId] = {
+        linkMap[recordId.baseId] = {
           leftEntityId: entity.linkData.leftEntityId,
           rightEntityId: entity.linkData.rightEntityId,
-          earliestTime: editionId.versionId,
+          earliestTime: recordId.versionId,
         };
-      } else if (editionId.versionId < linkInfo.earliestTime) {
-        linkInfo.earliestTime = editionId.versionId;
+      } else if (recordId.versionId < linkInfo.earliestTime) {
+        linkInfo.earliestTime = recordId.versionId;
       }
     }
 
@@ -91,14 +91,14 @@ export const addEntitiesToSubgraphByMutation = (
       inner: entity,
     };
 
-    if (!subgraph.vertices[editionId.baseId]) {
+    if (!subgraph.vertices[recordId.baseId]) {
       // This is needed because ts can't differentiate between `EntityId` and `BaseUri`
-      (subgraph.vertices as KnowledgeGraphVertices)[editionId.baseId] = {
-        [editionId.versionId]: entityVertex,
+      (subgraph.vertices as KnowledgeGraphVertices)[recordId.baseId] = {
+        [recordId.versionId]: entityVertex,
       };
     } else {
-      (subgraph.vertices as KnowledgeGraphVertices)[editionId.baseId]![
-        editionId.versionId
+      (subgraph.vertices as KnowledgeGraphVertices)[recordId.baseId]![
+        recordId.versionId
       ] = entityVertex;
     }
   }

--- a/libs/@blockprotocol/graph/src/internal/mutate-subgraph.ts
+++ b/libs/@blockprotocol/graph/src/internal/mutate-subgraph.ts
@@ -74,15 +74,15 @@ export const addEntitiesToSubgraphByMutation = (
   for (const entity of entities) {
     const recordId = entity.metadata.recordId;
     if (entity.linkData) {
-      const linkInfo = linkMap[recordId.baseId];
+      const linkInfo = linkMap[recordId.entityId];
       if (!linkInfo) {
-        linkMap[recordId.baseId] = {
+        linkMap[recordId.entityId] = {
           leftEntityId: entity.linkData.leftEntityId,
           rightEntityId: entity.linkData.rightEntityId,
-          earliestTime: recordId.versionId,
+          earliestTime: recordId.editionId,
         };
-      } else if (recordId.versionId < linkInfo.earliestTime) {
-        linkInfo.earliestTime = recordId.versionId;
+      } else if (recordId.editionId < linkInfo.earliestTime) {
+        linkInfo.earliestTime = recordId.editionId;
       }
     }
 
@@ -91,14 +91,14 @@ export const addEntitiesToSubgraphByMutation = (
       inner: entity,
     };
 
-    if (!subgraph.vertices[recordId.baseId]) {
+    if (!subgraph.vertices[recordId.entityId]) {
       // This is needed because ts can't differentiate between `EntityId` and `BaseUri`
-      (subgraph.vertices as KnowledgeGraphVertices)[recordId.baseId] = {
-        [recordId.versionId]: entityVertex,
+      (subgraph.vertices as KnowledgeGraphVertices)[recordId.entityId] = {
+        [recordId.editionId]: entityVertex,
       };
     } else {
-      (subgraph.vertices as KnowledgeGraphVertices)[recordId.baseId]![
-        recordId.versionId
+      (subgraph.vertices as KnowledgeGraphVertices)[recordId.entityId]![
+        recordId.editionId
       ] = entityVertex;
     }
   }

--- a/libs/@blockprotocol/graph/src/react.ts
+++ b/libs/@blockprotocol/graph/src/react.ts
@@ -128,7 +128,7 @@ export const useEntitySubgraph = <
     const linkedEntities =
       getOutgoingLinkAndTargetEntities<RootEntityLinkedEntities>(
         entitySubgraph,
-        rootEntity.metadata.recordId.baseId,
+        rootEntity.metadata.recordId.entityId,
       );
 
     return {

--- a/libs/@blockprotocol/graph/src/react.ts
+++ b/libs/@blockprotocol/graph/src/react.ts
@@ -10,7 +10,7 @@ import {
 import {
   BlockGraphProperties,
   Entity,
-  EntityRecordId,
+  EntityVertexId,
   GraphBlockHandler,
   GraphEmbedderHandler,
   LinkEntityAndRightEntity,
@@ -115,7 +115,7 @@ export const useEntitySubgraph = <
   RootEntityLinkedEntities extends LinkEntityAndRightEntity[],
 >(
   entitySubgraph: Subgraph<{
-    recordId: EntityRecordId;
+    vertexId: EntityVertexId;
     element: RootEntity;
   }>,
 ) => {

--- a/libs/@blockprotocol/graph/src/react.ts
+++ b/libs/@blockprotocol/graph/src/react.ts
@@ -10,7 +10,7 @@ import {
 import {
   BlockGraphProperties,
   Entity,
-  EntityEditionId,
+  EntityRecordId,
   GraphBlockHandler,
   GraphEmbedderHandler,
   LinkEntityAndRightEntity,
@@ -115,7 +115,7 @@ export const useEntitySubgraph = <
   RootEntityLinkedEntities extends LinkEntityAndRightEntity[],
 >(
   entitySubgraph: Subgraph<{
-    editionId: EntityEditionId;
+    recordId: EntityRecordId;
     element: RootEntity;
   }>,
 ) => {
@@ -128,7 +128,7 @@ export const useEntitySubgraph = <
     const linkedEntities =
       getOutgoingLinkAndTargetEntities<RootEntityLinkedEntities>(
         entitySubgraph,
-        rootEntity.metadata.editionId.baseId,
+        rootEntity.metadata.recordId.baseId,
       );
 
     return {

--- a/libs/@blockprotocol/graph/src/stdlib.ts
+++ b/libs/@blockprotocol/graph/src/stdlib.ts
@@ -12,8 +12,8 @@ import {
   getEntities as getEntitiesTemporal,
   getEntity as getEntityTemporal,
 } from "./stdlib/subgraph/element/entity.js";
-import { Entity, EntityId } from "./types/entity.js";
-import { LinkEntityAndRightEntity, Subgraph } from "./types/subgraph.js";
+import { Entity, EntityId, LinkEntityAndRightEntity } from "./types/entity.js";
+import { Subgraph } from "./types/subgraph.js";
 
 export { buildSubgraph } from "./stdlib/subgraph/builder.js";
 export {

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/builder.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/builder.ts
@@ -22,7 +22,7 @@ import {
  * @param data – the data to build the subgraph from (which becomes the vertices)
  * @param data.entities – the entities to build the subgraph from
  * @param depths – the depth values to provide in the returned subgraph
- * @param roots – the root values to provide in the returned subgraph
+ * @param rootRecordIds – the root values to provide in the returned subgraph
  *
  * @returns a Subgraph containing:
  *   - 'vertices' containing the provided entities
@@ -36,10 +36,10 @@ import {
  */
 export const buildSubgraph = (
   data: { entities: Entity[] },
-  roots: EntityRecordId[],
+  rootRecordIds: EntityRecordId[],
   depths: GraphResolveDepths,
 ) => {
-  const missingRoots = roots.filter(
+  const missingRoots = rootRecordIds.filter(
     ({ baseId, versionId }) =>
       !data.entities.find(
         (entity) =>
@@ -58,6 +58,12 @@ export const buildSubgraph = (
         .join(", ")}`,
     );
   }
+
+  const roots = rootRecordIds.map((rootRecordId) => ({
+    baseId: rootRecordId.baseId,
+    /** @todo - This is temporary, and wrong */
+    revisionId: rootRecordId.versionId,
+  }));
 
   const subgraph: Subgraph = {
     roots,

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/builder.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/builder.ts
@@ -1,7 +1,7 @@
 import { addEntitiesToSubgraphByMutation } from "../../internal/mutate-subgraph.js";
 import {
   Entity,
-  EntityEditionId,
+  EntityRecordId,
   GraphResolveDepths,
   Subgraph,
 } from "../../types.js";
@@ -36,15 +36,15 @@ import {
  */
 export const buildSubgraph = (
   data: { entities: Entity[] },
-  roots: EntityEditionId[],
+  roots: EntityRecordId[],
   depths: GraphResolveDepths,
 ) => {
   const missingRoots = roots.filter(
     ({ baseId, versionId }) =>
       !data.entities.find(
         (entity) =>
-          entity.metadata.editionId.baseId === baseId &&
-          entity.metadata.editionId.versionId === versionId,
+          entity.metadata.recordId.baseId === baseId &&
+          entity.metadata.recordId.versionId === versionId,
       ),
   );
 

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/builder.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/builder.ts
@@ -40,11 +40,11 @@ export const buildSubgraph = (
   depths: GraphResolveDepths,
 ) => {
   const missingRoots = rootRecordIds.filter(
-    ({ baseId, versionId }) =>
+    ({ entityId, editionId }) =>
       !data.entities.find(
         (entity) =>
-          entity.metadata.recordId.baseId === baseId &&
-          entity.metadata.recordId.versionId === versionId,
+          entity.metadata.recordId.entityId === entityId &&
+          entity.metadata.recordId.editionId === editionId,
       ),
   );
 
@@ -53,16 +53,16 @@ export const buildSubgraph = (
       `Root(s) not present in data: ${missingRoots
         .map(
           (missingRoot) =>
-            `${missingRoot.baseId} at version ${missingRoot.versionId}`,
+            `${missingRoot.entityId} at version ${missingRoot.editionId}`,
         )
         .join(", ")}`,
     );
   }
 
   const roots = rootRecordIds.map((rootRecordId) => ({
-    baseId: rootRecordId.baseId,
+    baseId: rootRecordId.entityId,
     /** @todo - This is temporary, and wrong */
-    revisionId: rootRecordId.versionId,
+    revisionId: rootRecordId.editionId,
   }));
 
   const subgraph: Subgraph = {

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/entity-type.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/entity-type.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   isConstrainsPropertiesOnEdge,
-  OntologyTypeRecordId,
+  OntologyTypeVertexId,
   Subgraph,
 } from "../../../types/subgraph.js";
 
@@ -16,13 +16,13 @@ import {
  * "ConstrainsPropertiesOn" `Edge`s from the respective `Vertex` within a `Subgraph`.
  *
  * @param subgraph {Subgraph} - The `Subgraph` containing the type tree of the `EntityType`
- * @param entityTypeId {OntologyTypeRecordId | VersionedUri} - The identifier of the `EntityType` to search for
- * @returns {OntologyTypeRecordId[]} - The identifiers of the `PropertyType`s referenced from the `EntityType`
+ * @param entityTypeId {OntologyTypeVertexId | VersionedUri} - The identifier of the `EntityType` to search for
+ * @returns {OntologyTypeVertexId[]} - The identifiers of the `PropertyType`s referenced from the `EntityType`
  */
 export const getPropertyTypesReferencedByEntityType = (
   subgraph: Subgraph,
-  entityTypeId: OntologyTypeRecordId | VersionedUri,
-): OntologyTypeRecordId[] => {
+  entityTypeId: OntologyTypeVertexId | VersionedUri,
+): OntologyTypeVertexId[] => {
   let baseUri: BaseUri;
   let version: number;
 
@@ -33,7 +33,7 @@ export const getPropertyTypesReferencedByEntityType = (
     ];
   } else {
     baseUri = entityTypeId.baseId;
-    version = entityTypeId.versionId;
+    version = entityTypeId.revisionId;
   }
 
   const outwardEdges = subgraph.edges[baseUri]?.[version];

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/entity-type.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/entity-type.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   isConstrainsPropertiesOnEdge,
-  OntologyTypeEditionId,
+  OntologyTypeRecordId,
   Subgraph,
 } from "../../../types/subgraph.js";
 
@@ -16,13 +16,13 @@ import {
  * "ConstrainsPropertiesOn" `Edge`s from the respective `Vertex` within a `Subgraph`.
  *
  * @param subgraph {Subgraph} - The `Subgraph` containing the type tree of the `EntityType`
- * @param entityTypeId {OntologyTypeEditionId | VersionedUri} - The identifier of the `EntityType` to search for
- * @returns {OntologyTypeEditionId[]} - The identifiers of the `PropertyType`s referenced from the `EntityType`
+ * @param entityTypeId {OntologyTypeRecordId | VersionedUri} - The identifier of the `EntityType` to search for
+ * @returns {OntologyTypeRecordId[]} - The identifiers of the `PropertyType`s referenced from the `EntityType`
  */
 export const getPropertyTypesReferencedByEntityType = (
   subgraph: Subgraph,
-  entityTypeId: OntologyTypeEditionId | VersionedUri,
-): OntologyTypeEditionId[] => {
+  entityTypeId: OntologyTypeRecordId | VersionedUri,
+): OntologyTypeRecordId[] => {
   let baseUri: BaseUri;
   let version: number;
 

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/link-entity.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/link-entity.ts
@@ -221,7 +221,7 @@ export const getOutgoingLinkAndTargetEntities = <
         linkEntity,
         rightEntity: getRightEntityForLinkEntity(
           subgraph,
-          linkEntity.metadata.recordId.baseId,
+          linkEntity.metadata.recordId.entityId,
           timestamp,
         ),
       };

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/link-entity.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/link-entity.ts
@@ -1,9 +1,9 @@
-import { Entity, EntityId } from "../../../types/entity.js";
 import {
+  Entity,
+  EntityId,
   LinkEntityAndRightEntity,
-  OutwardEdge,
-  Subgraph,
-} from "../../../types/subgraph.js";
+} from "../../../types/entity.js";
+import { OutwardEdge, Subgraph } from "../../../types/subgraph.js";
 import {
   isHasLeftEntityEdge,
   isHasRightEntityEdge,

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/link-entity.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/link-entity.ts
@@ -25,11 +25,11 @@ const convertTimeToStringWithDefault = (timestamp?: Date | string) => {
 const getUniqueEntitiesFilter = () => {
   const set = new Set();
   return (entity: Entity) => {
-    const editionIdString = JSON.stringify(entity.metadata.editionId);
-    if (set.has(editionIdString)) {
+    const recordIdString = JSON.stringify(entity.metadata.recordId);
+    if (set.has(recordIdString)) {
       return false;
     } else {
-      set.add(editionIdString);
+      set.add(recordIdString);
       return true;
     }
   };
@@ -66,7 +66,7 @@ export const getOutgoingLinksForEntity = (
       .filter(
         ([edgeTimestamp, _outwardEdges]) => edgeTimestamp <= timestampString,
       )
-      // Extract the link `EntityEditionId`s from the endpoints of the link edges
+      // Extract the link `EntityRecordId`s from the endpoints of the link edges
       .flatMap(([_edgeTimestamp, outwardEdges]) => {
         return (outwardEdges as OutwardEdge[])
           .filter(isOutgoingLinkEdge)
@@ -74,12 +74,12 @@ export const getOutgoingLinksForEntity = (
             return edge.rightEndpoint;
           });
       })
-      .map(({ baseId: linkEntityId, timestamp: _firstEditionTimestamp }) => {
+      .map(({ baseId: linkEntityId, timestamp: _firstRevisionTimestamp }) => {
         return mustBeDefined(
           getEntity(
             subgraph,
             linkEntityId,
-            // Find the edition of the link at the given moment (not at `_firstEditionTimestamp`, the start of its history)
+            // Find the revision of the link at the given moment (not at `_firstRevisionTimestamp`, the start of its history)
             timestampString,
           ),
         );
@@ -117,7 +117,7 @@ export const getIncomingLinksForEntity = (
       .filter(
         ([edgeTimestamp, _outwardEdges]) => edgeTimestamp <= timestampString,
       )
-      // Extract the link `EntityEditionId`s from the endpoints of the link edges
+      // Extract the link `EntityRecordId`s from the endpoints of the link edges
       .flatMap(([_edgeTimestamp, outwardEdges]) => {
         return (outwardEdges as OutgoingLinkEdge[])
           .filter(isIncomingLinkEdge)
@@ -125,12 +125,12 @@ export const getIncomingLinksForEntity = (
             return edge.rightEndpoint;
           });
       })
-      .map(({ baseId: linkEntityId, timestamp: _firstEditionTimestamp }) => {
+      .map(({ baseId: linkEntityId, timestamp: _firstRevisionTimestamp }) => {
         return mustBeDefined(
           getEntity(
             subgraph,
             linkEntityId,
-            // Find the edition of the link at the given moment (not at `_firstEditionTimestamp`, the start of its history)
+            // Find the revision of the link at the given moment (not at `_firstRevisionTimestamp`, the start of its history)
             timestampString,
           ),
         );
@@ -221,7 +221,7 @@ export const getOutgoingLinkAndTargetEntities = <
         linkEntity,
         rightEntity: getRightEntityForLinkEntity(
           subgraph,
-          linkEntity.metadata.editionId.baseId,
+          linkEntity.metadata.recordId.baseId,
           timestamp,
         ),
       };

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/element/data-type.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/element/data-type.ts
@@ -5,7 +5,7 @@ import {
   VersionedUri,
 } from "@blockprotocol/type-system/slim";
 
-import { OntologyTypeEditionId } from "../../../types/ontology.js";
+import { OntologyTypeRecordId } from "../../../types/ontology.js";
 import { DataTypeWithMetadata } from "../../../types/ontology/data-type.js";
 import { Subgraph } from "../../../types/subgraph.js";
 import { isDataTypeVertex } from "../../../types/subgraph/vertices.js";
@@ -55,18 +55,18 @@ export const getDataTypeById = (
 };
 
 /**
- * Gets a `DataTypeWithMetadata` by its `OntologyTypeEditionId` from within the vertices of the subgraph. Returns
+ * Gets a `DataTypeWithMetadata` by its `OntologyTypeRecordId` from within the vertices of the subgraph. Returns
  * `undefined` if the data type couldn't be found.
  *
  * @param subgraph
- * @param editionId
+ * @param recordId
  * @throws if the vertex isn't a `DataTypeVertex`
  */
-export const getDataTypeByEditionId = (
+export const getDataTypeByRecordId = (
   subgraph: Subgraph,
-  editionId: OntologyTypeEditionId,
+  recordId: OntologyTypeRecordId,
 ): DataTypeWithMetadata | undefined => {
-  const vertex = subgraph.vertices[editionId.baseId]?.[editionId.versionId];
+  const vertex = subgraph.vertices[recordId.baseId]?.[recordId.versionId];
 
   if (!vertex) {
     return undefined;

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/element/data-type.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/element/data-type.ts
@@ -5,9 +5,8 @@ import {
   VersionedUri,
 } from "@blockprotocol/type-system/slim";
 
-import { OntologyTypeRecordId } from "../../../types/ontology.js";
 import { DataTypeWithMetadata } from "../../../types/ontology/data-type.js";
-import { Subgraph } from "../../../types/subgraph.js";
+import { OntologyTypeVertexId, Subgraph } from "../../../types/subgraph.js";
 import { isDataTypeVertex } from "../../../types/subgraph/vertices.js";
 
 /**
@@ -55,18 +54,18 @@ export const getDataTypeById = (
 };
 
 /**
- * Gets a `DataTypeWithMetadata` by its `OntologyTypeRecordId` from within the vertices of the subgraph. Returns
+ * Gets a `DataTypeWithMetadata` by its `OntologyTypeVertexId` from within the vertices of the subgraph. Returns
  * `undefined` if the data type couldn't be found.
  *
  * @param subgraph
- * @param recordId
+ * @param vertexId
  * @throws if the vertex isn't a `DataTypeVertex`
  */
-export const getDataTypeByRecordId = (
+export const getDataTypeByVertexId = (
   subgraph: Subgraph,
-  recordId: OntologyTypeRecordId,
+  vertexId: OntologyTypeVertexId,
 ): DataTypeWithMetadata | undefined => {
-  const vertex = subgraph.vertices[recordId.baseId]?.[recordId.versionId];
+  const vertex = subgraph.vertices[vertexId.baseId]?.[vertexId.revisionId];
 
   if (!vertex) {
     return undefined;

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/element/entity-type.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/element/entity-type.ts
@@ -5,7 +5,7 @@ import {
   VersionedUri,
 } from "@blockprotocol/type-system/slim";
 
-import { OntologyTypeEditionId } from "../../../types/ontology.js";
+import { OntologyTypeRecordId } from "../../../types/ontology.js";
 import { EntityTypeWithMetadata } from "../../../types/ontology/entity-type.js";
 import { Subgraph } from "../../../types/subgraph.js";
 import { isEntityTypeVertex } from "../../../types/subgraph/vertices.js";
@@ -57,18 +57,18 @@ export const getEntityTypeById = (
 };
 
 /**
- * Gets a `EntityTypeWithMetadata` by its `OntologyTypeEditionId` from within the vertices of the subgraph. Returns
+ * Gets a `EntityTypeWithMetadata` by its `OntologyTypeRecordId` from within the vertices of the subgraph. Returns
  * `undefined` if the entity type couldn't be found.
  *
  * @param subgraph
- * @param editionId
+ * @param recordId
  * @throws if the vertex isn't a `EntityTypeVertex`
  */
-export const getEntityTypeByEditionId = (
+export const getEntityTypeByRecordId = (
   subgraph: Subgraph,
-  editionId: OntologyTypeEditionId,
+  recordId: OntologyTypeRecordId,
 ): EntityTypeWithMetadata | undefined => {
-  const vertex = subgraph.vertices[editionId.baseId]?.[editionId.versionId];
+  const vertex = subgraph.vertices[recordId.baseId]?.[recordId.versionId];
 
   if (!vertex) {
     return undefined;

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/element/entity-type.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/element/entity-type.ts
@@ -5,9 +5,8 @@ import {
   VersionedUri,
 } from "@blockprotocol/type-system/slim";
 
-import { OntologyTypeRecordId } from "../../../types/ontology.js";
 import { EntityTypeWithMetadata } from "../../../types/ontology/entity-type.js";
-import { Subgraph } from "../../../types/subgraph.js";
+import { OntologyTypeVertexId, Subgraph } from "../../../types/subgraph.js";
 import { isEntityTypeVertex } from "../../../types/subgraph/vertices.js";
 
 /**
@@ -57,18 +56,18 @@ export const getEntityTypeById = (
 };
 
 /**
- * Gets a `EntityTypeWithMetadata` by its `OntologyTypeRecordId` from within the vertices of the subgraph. Returns
+ * Gets a `EntityTypeWithMetadata` by its `OntologyTypeVertexId` from within the vertices of the subgraph. Returns
  * `undefined` if the entity type couldn't be found.
  *
  * @param subgraph
- * @param recordId
+ * @param vertexId
  * @throws if the vertex isn't a `EntityTypeVertex`
  */
-export const getEntityTypeByRecordId = (
+export const getEntityTypeByVertexId = (
   subgraph: Subgraph,
-  recordId: OntologyTypeRecordId,
+  vertexId: OntologyTypeVertexId,
 ): EntityTypeWithMetadata | undefined => {
-  const vertex = subgraph.vertices[recordId.baseId]?.[recordId.versionId];
+  const vertex = subgraph.vertices[vertexId.baseId]?.[vertexId.revisionId];
 
   if (!vertex) {
     return undefined;

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/element/entity.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/element/entity.ts
@@ -4,10 +4,10 @@ import { Timestamp } from "../../../types/subgraph/time.js";
 import { isEntityVertex } from "../../../types/subgraph/vertices.js";
 
 /**
- * Returns all `Entity`s within the vertices of the subgraph, optionally filtering to only get their latest editions.
+ * Returns all `Entity`s within the vertices of the subgraph, optionally filtering to only get their latest revisions.
  *
  * @param subgraph
- * @param latest - whether or not to only return the latest editions of each entity
+ * @param latest - whether or not to only return the latest revisions of each entity
  */
 export const getEntities = (
   subgraph: Subgraph,
@@ -15,7 +15,7 @@ export const getEntities = (
 ): Entity[] => {
   return Object.values(
     Object.values(subgraph.vertices).flatMap((versionObject) => {
-      const entityEditionVertices = latest
+      const entityRevisionVertices = latest
         ? Object.keys(versionObject)
             .sort()
             .slice(-1)
@@ -23,87 +23,87 @@ export const getEntities = (
             .filter(isEntityVertex)
         : Object.values(versionObject).filter(isEntityVertex);
 
-      return entityEditionVertices.map((vertex) => vertex.inner);
+      return entityRevisionVertices.map((vertex) => vertex.inner);
     }),
   );
 };
 
 /**
- * Gets an `Entity` by its `EntityId` from within the vertices of the subgraph. If `targetEditionInformation` is not passed,
+ * Gets an `Entity` by its `EntityId` from within the vertices of the subgraph. If `targetRevisionInformation` is not passed,
  * then the latest version of the `Entity` will be returned.
  *
  * Returns `undefined` if the entity couldn't be found.
  *
  * @param subgraph
  * @param {EntityId} entityId - The `EntityId` of the entity to get.
- * @param {EntityVersion|Timestamp} [targetEditionInformation] - Optional information needed to uniquely identify an edition of
- *     an entity either by an explicit `EntityVersion`, or by a given `Timestamp` where the entity whose lifespan
- *     overlaps the given timestamp will be returned.
+ * @param {EntityRevisionId|Timestamp} [targetRevisionInformation] - Optional information needed to uniquely identify an
+ *     revision of an entity either by an explicit `EntityRevisionId`, or by a given `Timestamp` where the entity whose
+ *     lifespan overlaps the given timestamp will be returned.
  * @throws if the vertex isn't an `EntityVertex`
  */
 export const getEntity = (
   subgraph: Subgraph,
   entityId: EntityId,
-  targetEditionInformation?: EntityVersion | Timestamp | Date,
+  targetRevisionInformation?: EntityVersion | Timestamp | Date,
 ): Entity | undefined => {
-  const entityEditions = subgraph.vertices[entityId];
+  const entityRevisions = subgraph.vertices[entityId];
 
-  if (entityEditions === undefined) {
+  if (entityRevisions === undefined) {
     return undefined;
   }
 
-  const editionVersions = Object.keys(entityEditions).sort();
+  const revisionVersions = Object.keys(entityRevisions).sort();
 
-  let entityEdition: Entity | undefined;
+  let entityRevision: Entity | undefined;
 
   // Short circuit for efficiency, just take the latest
-  if (targetEditionInformation === undefined) {
-    [entityEdition] = editionVersions
+  if (targetRevisionInformation === undefined) {
+    [entityRevision] = revisionVersions
       .slice(-1)
-      .map((latestVersion) => entityEditions[latestVersion]!.inner);
+      .map((latestVersion) => entityRevisions[latestVersion]!.inner);
   } else {
     const targetTime =
-      typeof targetEditionInformation === "string"
-        ? targetEditionInformation
-        : targetEditionInformation.toISOString();
+      typeof targetRevisionInformation === "string"
+        ? targetRevisionInformation
+        : targetRevisionInformation.toISOString();
 
     let targetVersion: EntityVersion | undefined;
-    for (let idx = 0; idx < editionVersions.length; idx++) {
-      /** @todo - If we expose endTimes we can do an interval check here per edition, rather than needing to infer it */
-      // Rolling window: we've sorted, so for each edition's version check if the given timestamp is in between the
-      // start of this edition and the next one (lower-bound-inclusive)
-      const [editionVersion, nextEditionVersion] = editionVersions.slice(
+    for (let idx = 0; idx < revisionVersions.length; idx++) {
+      /** @todo - If we expose endTimes we can do an interval check here per revision, rather than needing to infer it */
+      // Rolling window: we've sorted, so for each revision's version check if the given timestamp is in between the
+      // start of this revision and the next one (lower-bound-inclusive)
+      const [revisionVersion, nextRevisionVersion] = revisionVersions.slice(
         idx,
         idx + 1,
       ) as [EntityVersion, EntityVersion | undefined];
 
       // The list is sorted so if this is beyond the target time then all of the ones after are too
-      if (editionVersion > targetTime) {
+      if (revisionVersion > targetTime) {
         break;
       }
 
       // Last element in the array (latest version), so we assume an half-closed interval (unbounded on the upper-bound)
-      if (nextEditionVersion === undefined) {
-        if (editionVersion <= targetTime) {
-          targetVersion = editionVersion;
+      if (nextRevisionVersion === undefined) {
+        if (revisionVersion <= targetTime) {
+          targetVersion = revisionVersion;
         }
         break;
       } else if (
-        editionVersion <= targetTime &&
-        targetTime < nextEditionVersion
+        revisionVersion <= targetTime &&
+        targetTime < nextRevisionVersion
       ) {
-        targetVersion = editionVersion;
+        targetVersion = revisionVersion;
         break;
       }
     }
 
-    entityEdition =
+    entityRevision =
       targetVersion !== undefined
-        ? entityEditions[targetVersion]!.inner
+        ? entityRevisions[targetVersion]!.inner
         : undefined;
   }
 
-  return entityEdition;
+  return entityRevision;
 };
 
 /**
@@ -112,7 +112,7 @@ export const getEntity = (
  * @param subgraph
  * @param entityId
  */
-export const getEntityEditionsByEntityId = (
+export const getEntityRevisionsByEntityId = (
   subgraph: Subgraph,
   entityId: EntityId,
 ): Entity[] => {

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/element/property-type.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/element/property-type.ts
@@ -5,7 +5,7 @@ import {
   VersionedUri,
 } from "@blockprotocol/type-system/slim";
 
-import { OntologyTypeEditionId } from "../../../types/ontology.js";
+import { OntologyTypeRecordId } from "../../../types/ontology.js";
 import { PropertyTypeWithMetadata } from "../../../types/ontology/property-type.js";
 import { Subgraph } from "../../../types/subgraph.js";
 import { isPropertyTypeVertex } from "../../../types/subgraph/vertices.js";
@@ -57,18 +57,18 @@ export const getPropertyTypeById = (
 };
 
 /**
- * Gets a `PropertyTypeWithMetadata` by its `OntologyTypeEditionId` from within the vertices of the subgraph. Returns
+ * Gets a `PropertyTypeWithMetadata` by its `OntologyTypeRecordId` from within the vertices of the subgraph. Returns
  * `undefined` if the property type couldn't be found.
  *
  * @param subgraph
- * @param editionId
+ * @param recordId
  * @throws if the vertex isn't a `PropertyTypeVertex`
  */
-export const getPropertyTypeByEditionId = (
+export const getPropertyTypeByRecordId = (
   subgraph: Subgraph,
-  editionId: OntologyTypeEditionId,
+  recordId: OntologyTypeRecordId,
 ): PropertyTypeWithMetadata | undefined => {
-  const vertex = subgraph.vertices[editionId.baseId]?.[editionId.versionId];
+  const vertex = subgraph.vertices[recordId.baseId]?.[recordId.versionId];
 
   if (!vertex) {
     return undefined;

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/element/property-type.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/element/property-type.ts
@@ -5,9 +5,8 @@ import {
   VersionedUri,
 } from "@blockprotocol/type-system/slim";
 
-import { OntologyTypeRecordId } from "../../../types/ontology.js";
 import { PropertyTypeWithMetadata } from "../../../types/ontology/property-type.js";
-import { Subgraph } from "../../../types/subgraph.js";
+import { OntologyTypeVertexId, Subgraph } from "../../../types/subgraph.js";
 import { isPropertyTypeVertex } from "../../../types/subgraph/vertices.js";
 
 /**
@@ -57,18 +56,18 @@ export const getPropertyTypeById = (
 };
 
 /**
- * Gets a `PropertyTypeWithMetadata` by its `OntologyTypeRecordId` from within the vertices of the subgraph. Returns
+ * Gets a `PropertyTypeWithMetadata` by its `OntologyTypeVertexId` from within the vertices of the subgraph. Returns
  * `undefined` if the property type couldn't be found.
  *
  * @param subgraph
- * @param recordId
+ * @param vertexId
  * @throws if the vertex isn't a `PropertyTypeVertex`
  */
-export const getPropertyTypeByRecordId = (
+export const getPropertyTypeByVertexId = (
   subgraph: Subgraph,
-  recordId: OntologyTypeRecordId,
+  vertexId: OntologyTypeVertexId,
 ): PropertyTypeWithMetadata | undefined => {
-  const vertex = subgraph.vertices[recordId.baseId]?.[recordId.versionId];
+  const vertex = subgraph.vertices[vertexId.baseId]?.[vertexId.revisionId];
 
   if (!vertex) {
     return undefined;

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/roots.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/roots.ts
@@ -1,5 +1,5 @@
-import { isEntityEditionId } from "../../types/entity.js";
-import { isOntologyTypeEditionId } from "../../types/ontology.js";
+import { isEntityRecordId } from "../../types/entity.js";
+import { isOntologyTypeRecordId } from "../../types/ontology.js";
 import {
   Subgraph,
   SubgraphRootType,
@@ -7,10 +7,10 @@ import {
 } from "../../types/subgraph.js";
 import { Vertex } from "../../types/subgraph/vertices.js";
 import { mustBeDefined } from "../must-be-defined.js";
-import { getDataTypeByEditionId } from "./element/data-type.js";
+import { getDataTypeByRecordId } from "./element/data-type.js";
 import { getEntity } from "./element/entity.js";
-import { getEntityTypeByEditionId } from "./element/entity-type.js";
-import { getPropertyTypeByEditionId } from "./element/property-type.js";
+import { getEntityTypeByRecordId } from "./element/entity-type.js";
+import { getPropertyTypeByRecordId } from "./element/property-type.js";
 
 /**
  * Returns all root elements.
@@ -26,16 +26,16 @@ import { getPropertyTypeByEditionId } from "./element/property-type.js";
 export const getRoots = <RootType extends SubgraphRootType>(
   subgraph: Subgraph<RootType>,
 ): RootType["element"][] =>
-  subgraph.roots.map((rootEditionId) => {
+  subgraph.roots.map((rootRecordId) => {
     const root = mustBeDefined(
-      subgraph.vertices[rootEditionId.baseId]?.[
+      subgraph.vertices[rootRecordId.baseId]?.[
         // We could use type-guards here to convince TS that it's safe, but that would be slower, it's currently not
         // smart enough to realise this can produce a value of type `Vertex` as it struggles with discriminating
         // `EntityId` and `BaseUri`
-        rootEditionId.versionId
+        rootRecordId.versionId
       ] as Vertex,
       `roots should have corresponding vertices but ${JSON.stringify(
-        rootEditionId,
+        rootRecordId,
       )} was missing`,
     );
 
@@ -53,15 +53,15 @@ export const getRoots = <RootType extends SubgraphRootType>(
 export const isDataTypeRootedSubgraph = (
   subgraph: Subgraph,
 ): subgraph is Subgraph<SubgraphRootTypes["dataType"]> => {
-  for (const rootEditionId of subgraph.roots) {
-    if (!isOntologyTypeEditionId(rootEditionId)) {
+  for (const rootRecordId of subgraph.roots) {
+    if (!isOntologyTypeRecordId(rootRecordId)) {
       return false;
     }
 
     mustBeDefined(
-      getDataTypeByEditionId(subgraph, rootEditionId),
+      getDataTypeByRecordId(subgraph, rootRecordId),
       `roots should have corresponding vertices but ${JSON.stringify(
-        rootEditionId,
+        rootRecordId,
       )} was missing`,
     );
   }
@@ -80,15 +80,15 @@ export const isDataTypeRootedSubgraph = (
 export const isPropertyTypeRootedSubgraph = (
   subgraph: Subgraph,
 ): subgraph is Subgraph<SubgraphRootTypes["propertyType"]> => {
-  for (const rootEditionId of subgraph.roots) {
-    if (!isOntologyTypeEditionId(rootEditionId)) {
+  for (const rootRecordId of subgraph.roots) {
+    if (!isOntologyTypeRecordId(rootRecordId)) {
       return false;
     }
 
     mustBeDefined(
-      getPropertyTypeByEditionId(subgraph, rootEditionId),
+      getPropertyTypeByRecordId(subgraph, rootRecordId),
       `roots should have corresponding vertices but ${JSON.stringify(
-        rootEditionId,
+        rootRecordId,
       )} was missing`,
     );
   }
@@ -107,15 +107,15 @@ export const isPropertyTypeRootedSubgraph = (
 export const isEntityTypeRootedSubgraph = (
   subgraph: Subgraph,
 ): subgraph is Subgraph<SubgraphRootTypes["entityType"]> => {
-  for (const rootEditionId of subgraph.roots) {
-    if (!isOntologyTypeEditionId(rootEditionId)) {
+  for (const rootRecordId of subgraph.roots) {
+    if (!isOntologyTypeRecordId(rootRecordId)) {
       return false;
     }
 
     mustBeDefined(
-      getEntityTypeByEditionId(subgraph, rootEditionId),
+      getEntityTypeByRecordId(subgraph, rootRecordId),
       `roots should have corresponding vertices but ${JSON.stringify(
-        rootEditionId,
+        rootRecordId,
       )} was missing`,
     );
   }
@@ -134,15 +134,15 @@ export const isEntityTypeRootedSubgraph = (
 export const isEntityRootedSubgraph = (
   subgraph: Subgraph,
 ): subgraph is Subgraph<SubgraphRootTypes["entity"]> => {
-  for (const rootEditionId of subgraph.roots) {
-    if (!isEntityEditionId(rootEditionId)) {
+  for (const rootRecordId of subgraph.roots) {
+    if (!isEntityRecordId(rootRecordId)) {
       return false;
     }
 
     mustBeDefined(
-      getEntity(subgraph, rootEditionId.baseId, rootEditionId.versionId),
+      getEntity(subgraph, rootRecordId.baseId, rootRecordId.versionId),
       `roots should have corresponding vertices but ${JSON.stringify(
-        rootEditionId,
+        rootRecordId,
       )} was missing`,
     );
   }

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/roots.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/roots.ts
@@ -1,16 +1,16 @@
-import { isEntityRecordId } from "../../types/entity.js";
-import { isOntologyTypeRecordId } from "../../types/ontology.js";
 import {
+  isEntityVertexId,
+  isOntologyTypeVertexId,
   Subgraph,
   SubgraphRootType,
   SubgraphRootTypes,
 } from "../../types/subgraph.js";
 import { Vertex } from "../../types/subgraph/vertices.js";
 import { mustBeDefined } from "../must-be-defined.js";
-import { getDataTypeByRecordId } from "./element/data-type.js";
+import { getDataTypeByVertexId } from "./element/data-type.js";
 import { getEntity } from "./element/entity.js";
-import { getEntityTypeByRecordId } from "./element/entity-type.js";
-import { getPropertyTypeByRecordId } from "./element/property-type.js";
+import { getEntityTypeByVertexId } from "./element/entity-type.js";
+import { getPropertyTypeByVertexId } from "./element/property-type.js";
 
 /**
  * Returns all root elements.
@@ -26,16 +26,16 @@ import { getPropertyTypeByRecordId } from "./element/property-type.js";
 export const getRoots = <RootType extends SubgraphRootType>(
   subgraph: Subgraph<RootType>,
 ): RootType["element"][] =>
-  subgraph.roots.map((rootRecordId) => {
+  subgraph.roots.map((rootVertexId) => {
     const root = mustBeDefined(
-      subgraph.vertices[rootRecordId.baseId]?.[
+      subgraph.vertices[rootVertexId.baseId]?.[
         // We could use type-guards here to convince TS that it's safe, but that would be slower, it's currently not
         // smart enough to realise this can produce a value of type `Vertex` as it struggles with discriminating
         // `EntityId` and `BaseUri`
-        rootRecordId.versionId
+        rootVertexId.revisionId
       ] as Vertex,
       `roots should have corresponding vertices but ${JSON.stringify(
-        rootRecordId,
+        rootVertexId,
       )} was missing`,
     );
 
@@ -53,15 +53,15 @@ export const getRoots = <RootType extends SubgraphRootType>(
 export const isDataTypeRootedSubgraph = (
   subgraph: Subgraph,
 ): subgraph is Subgraph<SubgraphRootTypes["dataType"]> => {
-  for (const rootRecordId of subgraph.roots) {
-    if (!isOntologyTypeRecordId(rootRecordId)) {
+  for (const rootVertexId of subgraph.roots) {
+    if (!isOntologyTypeVertexId(rootVertexId)) {
       return false;
     }
 
     mustBeDefined(
-      getDataTypeByRecordId(subgraph, rootRecordId),
+      getDataTypeByVertexId(subgraph, rootVertexId),
       `roots should have corresponding vertices but ${JSON.stringify(
-        rootRecordId,
+        rootVertexId,
       )} was missing`,
     );
   }
@@ -80,15 +80,15 @@ export const isDataTypeRootedSubgraph = (
 export const isPropertyTypeRootedSubgraph = (
   subgraph: Subgraph,
 ): subgraph is Subgraph<SubgraphRootTypes["propertyType"]> => {
-  for (const rootRecordId of subgraph.roots) {
-    if (!isOntologyTypeRecordId(rootRecordId)) {
+  for (const rootVertexId of subgraph.roots) {
+    if (!isOntologyTypeVertexId(rootVertexId)) {
       return false;
     }
 
     mustBeDefined(
-      getPropertyTypeByRecordId(subgraph, rootRecordId),
+      getPropertyTypeByVertexId(subgraph, rootVertexId),
       `roots should have corresponding vertices but ${JSON.stringify(
-        rootRecordId,
+        rootVertexId,
       )} was missing`,
     );
   }
@@ -107,15 +107,15 @@ export const isPropertyTypeRootedSubgraph = (
 export const isEntityTypeRootedSubgraph = (
   subgraph: Subgraph,
 ): subgraph is Subgraph<SubgraphRootTypes["entityType"]> => {
-  for (const rootRecordId of subgraph.roots) {
-    if (!isOntologyTypeRecordId(rootRecordId)) {
+  for (const rootVertexId of subgraph.roots) {
+    if (!isOntologyTypeVertexId(rootVertexId)) {
       return false;
     }
 
     mustBeDefined(
-      getEntityTypeByRecordId(subgraph, rootRecordId),
+      getEntityTypeByVertexId(subgraph, rootVertexId),
       `roots should have corresponding vertices but ${JSON.stringify(
-        rootRecordId,
+        rootVertexId,
       )} was missing`,
     );
   }
@@ -134,15 +134,15 @@ export const isEntityTypeRootedSubgraph = (
 export const isEntityRootedSubgraph = (
   subgraph: Subgraph,
 ): subgraph is Subgraph<SubgraphRootTypes["entity"]> => {
-  for (const rootRecordId of subgraph.roots) {
-    if (!isEntityRecordId(rootRecordId)) {
+  for (const rootVertexId of subgraph.roots) {
+    if (!isEntityVertexId(rootVertexId)) {
       return false;
     }
 
     mustBeDefined(
-      getEntity(subgraph, rootRecordId.baseId, rootRecordId.versionId),
+      getEntity(subgraph, rootVertexId.baseId, rootVertexId.revisionId),
       `roots should have corresponding vertices but ${JSON.stringify(
-        rootRecordId,
+        rootVertexId,
       )} was missing`,
     );
   }

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/roots.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/roots.ts
@@ -1,10 +1,10 @@
 import {
-  DataTypeRootedSubgraph,
-  EntityRootedSubgraph,
-  EntityTypeRootedSubgraph,
+  DataTypeRootType,
+  EntityRootType,
+  EntityTypeRootType,
   isEntityVertexId,
   isOntologyTypeVertexId,
-  PropertyTypeRootedSubgraph,
+  PropertyTypeRootType,
   Subgraph,
   SubgraphRootType,
 } from "../../types/subgraph.js";
@@ -19,10 +19,10 @@ import { getPropertyTypeByVertexId } from "./element/property-type.js";
  * Returns all root elements.
  *
  * For a narrower return type, first narrow the type of `subgraph` by using one of the helper type-guards:
- * - isDataTypeRootedSubgraph
- * - isPropertyTypeRootedSubgraph
- * - isEntityTypeRootedSubgraph
- * - isEntityRootedSubgraph
+ * - isSubgraph<DataTypeRootType>
+ * - isSubgraph<PropertyTypeRootType>
+ * - isSubgraph<EntityTypeRootType>
+ * - isSubgraph<EntityRootType>
  *
  * @param subgraph
  */
@@ -55,7 +55,7 @@ export const getRoots = <RootType extends SubgraphRootType>(
  */
 export const isDataTypeRootedSubgraph = (
   subgraph: Subgraph,
-): subgraph is DataTypeRootedSubgraph => {
+): subgraph is Subgraph<DataTypeRootType> => {
   for (const rootVertexId of subgraph.roots) {
     if (!isOntologyTypeVertexId(rootVertexId)) {
       return false;
@@ -82,7 +82,7 @@ export const isDataTypeRootedSubgraph = (
  */
 export const isPropertyTypeRootedSubgraph = (
   subgraph: Subgraph,
-): subgraph is PropertyTypeRootedSubgraph => {
+): subgraph is Subgraph<PropertyTypeRootType> => {
   for (const rootVertexId of subgraph.roots) {
     if (!isOntologyTypeVertexId(rootVertexId)) {
       return false;
@@ -109,7 +109,7 @@ export const isPropertyTypeRootedSubgraph = (
  */
 export const isEntityTypeRootedSubgraph = (
   subgraph: Subgraph,
-): subgraph is EntityTypeRootedSubgraph => {
+): subgraph is Subgraph<EntityTypeRootType> => {
   for (const rootVertexId of subgraph.roots) {
     if (!isOntologyTypeVertexId(rootVertexId)) {
       return false;
@@ -136,7 +136,7 @@ export const isEntityTypeRootedSubgraph = (
  */
 export const isEntityRootedSubgraph = (
   subgraph: Subgraph,
-): subgraph is EntityRootedSubgraph => {
+): subgraph is Subgraph<EntityRootType> => {
   for (const rootVertexId of subgraph.roots) {
     if (!isEntityVertexId(rootVertexId)) {
       return false;

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/roots.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/roots.ts
@@ -1,9 +1,12 @@
 import {
+  DataTypeRootedSubgraph,
+  EntityRootedSubgraph,
+  EntityTypeRootedSubgraph,
   isEntityVertexId,
   isOntologyTypeVertexId,
+  PropertyTypeRootedSubgraph,
   Subgraph,
   SubgraphRootType,
-  SubgraphRootTypes,
 } from "../../types/subgraph.js";
 import { Vertex } from "../../types/subgraph/vertices.js";
 import { mustBeDefined } from "../must-be-defined.js";
@@ -52,7 +55,7 @@ export const getRoots = <RootType extends SubgraphRootType>(
  */
 export const isDataTypeRootedSubgraph = (
   subgraph: Subgraph,
-): subgraph is Subgraph<SubgraphRootTypes["dataType"]> => {
+): subgraph is DataTypeRootedSubgraph => {
   for (const rootVertexId of subgraph.roots) {
     if (!isOntologyTypeVertexId(rootVertexId)) {
       return false;
@@ -79,7 +82,7 @@ export const isDataTypeRootedSubgraph = (
  */
 export const isPropertyTypeRootedSubgraph = (
   subgraph: Subgraph,
-): subgraph is Subgraph<SubgraphRootTypes["propertyType"]> => {
+): subgraph is PropertyTypeRootedSubgraph => {
   for (const rootVertexId of subgraph.roots) {
     if (!isOntologyTypeVertexId(rootVertexId)) {
       return false;
@@ -106,7 +109,7 @@ export const isPropertyTypeRootedSubgraph = (
  */
 export const isEntityTypeRootedSubgraph = (
   subgraph: Subgraph,
-): subgraph is Subgraph<SubgraphRootTypes["entityType"]> => {
+): subgraph is EntityTypeRootedSubgraph => {
   for (const rootVertexId of subgraph.roots) {
     if (!isOntologyTypeVertexId(rootVertexId)) {
       return false;
@@ -133,7 +136,7 @@ export const isEntityTypeRootedSubgraph = (
  */
 export const isEntityRootedSubgraph = (
   subgraph: Subgraph,
-): subgraph is Subgraph<SubgraphRootTypes["entity"]> => {
+): subgraph is EntityRootedSubgraph => {
   for (const rootVertexId of subgraph.roots) {
     if (!isEntityVertexId(rootVertexId)) {
       return false;

--- a/libs/@blockprotocol/graph/src/types/block-graph.ts
+++ b/libs/@blockprotocol/graph/src/types/block-graph.ts
@@ -6,7 +6,6 @@ import {
   CreateEntityData,
   DeleteEntityData,
   Entity,
-  EntityRecordId,
   GetEntityData,
   UpdateEntityData,
 } from "./entity.js";
@@ -16,7 +15,7 @@ import {
   AggregateEntityTypesResult,
   GetEntityTypeData,
 } from "./ontology/entity-type.js";
-import { Subgraph, SubgraphRootTypes } from "./subgraph.js";
+import { EntityVertexId, Subgraph, SubgraphRootTypes } from "./subgraph.js";
 
 export type BlockGraphProperties<RootEntity extends Entity = Entity> = {
   /**
@@ -27,7 +26,7 @@ export type BlockGraphProperties<RootEntity extends Entity = Entity> = {
    */
   graph: {
     blockEntitySubgraph?: Subgraph<{
-      recordId: EntityRecordId;
+      vertexId: EntityVertexId;
       element: RootEntity;
     }>;
     readonly?: boolean;

--- a/libs/@blockprotocol/graph/src/types/block-graph.ts
+++ b/libs/@blockprotocol/graph/src/types/block-graph.ts
@@ -6,7 +6,7 @@ import {
   CreateEntityData,
   DeleteEntityData,
   Entity,
-  EntityEditionId,
+  EntityRecordId,
   GetEntityData,
   UpdateEntityData,
 } from "./entity.js";
@@ -27,7 +27,7 @@ export type BlockGraphProperties<RootEntity extends Entity = Entity> = {
    */
   graph: {
     blockEntitySubgraph?: Subgraph<{
-      editionId: EntityEditionId;
+      recordId: EntityRecordId;
       element: RootEntity;
     }>;
     readonly?: boolean;

--- a/libs/@blockprotocol/graph/src/types/block-graph.ts
+++ b/libs/@blockprotocol/graph/src/types/block-graph.ts
@@ -15,7 +15,12 @@ import {
   AggregateEntityTypesResult,
   GetEntityTypeData,
 } from "./ontology/entity-type.js";
-import { EntityVertexId, Subgraph, SubgraphRootTypes } from "./subgraph.js";
+import {
+  EntityRootedSubgraph,
+  EntityTypeRootedSubgraph,
+  EntityVertexId,
+  Subgraph,
+} from "./subgraph.js";
 
 export type BlockGraphProperties<RootEntity extends Entity = Entity> = {
   /**
@@ -34,10 +39,7 @@ export type BlockGraphProperties<RootEntity extends Entity = Entity> = {
 };
 
 export type BlockGraphMessageCallbacks = {
-  blockEntitySubgraph: MessageCallback<
-    Subgraph<SubgraphRootTypes["entity"]>,
-    null
-  >;
+  blockEntitySubgraph: MessageCallback<EntityRootedSubgraph, null>;
   readonly: MessageCallback<boolean, null>;
 };
 
@@ -87,13 +89,13 @@ export type EmbedderGraphMessageCallbacks = {
   getEntity: MessageCallback<
     GetEntityData,
     null,
-    Subgraph<SubgraphRootTypes["entity"]>,
+    EntityRootedSubgraph,
     ReadOrModifyResourceError
   >;
   aggregateEntities: MessageCallback<
     AggregateEntitiesData,
     null,
-    AggregateEntitiesResult<Subgraph<SubgraphRootTypes["entity"]>>,
+    AggregateEntitiesResult<EntityRootedSubgraph>,
     ReadOrModifyResourceError
   >;
   /** @todo - Add Type System mutation methods */
@@ -118,13 +120,13 @@ export type EmbedderGraphMessageCallbacks = {
   getEntityType: MessageCallback<
     GetEntityTypeData,
     null,
-    Subgraph<SubgraphRootTypes["entityType"]>,
+    EntityTypeRootedSubgraph,
     ReadOrModifyResourceError
   >;
   aggregateEntityTypes: MessageCallback<
     AggregateEntityTypesData,
     null,
-    AggregateEntityTypesResult<Subgraph<SubgraphRootTypes["entityType"]>>,
+    AggregateEntityTypesResult<EntityTypeRootedSubgraph>,
     ReadOrModifyResourceError
   >;
   /** @todo - Reimplement linked aggregations */

--- a/libs/@blockprotocol/graph/src/types/block-graph.ts
+++ b/libs/@blockprotocol/graph/src/types/block-graph.ts
@@ -16,8 +16,8 @@ import {
   GetEntityTypeData,
 } from "./ontology/entity-type.js";
 import {
-  EntityRootedSubgraph,
-  EntityTypeRootedSubgraph,
+  EntityRootType,
+  EntityTypeRootType,
   EntityVertexId,
   Subgraph,
 } from "./subgraph.js";
@@ -39,7 +39,7 @@ export type BlockGraphProperties<RootEntity extends Entity = Entity> = {
 };
 
 export type BlockGraphMessageCallbacks = {
-  blockEntitySubgraph: MessageCallback<EntityRootedSubgraph, null>;
+  blockEntitySubgraph: MessageCallback<Subgraph<EntityRootType>, null>;
   readonly: MessageCallback<boolean, null>;
 };
 
@@ -89,13 +89,13 @@ export type EmbedderGraphMessageCallbacks = {
   getEntity: MessageCallback<
     GetEntityData,
     null,
-    EntityRootedSubgraph,
+    Subgraph<EntityRootType>,
     ReadOrModifyResourceError
   >;
   aggregateEntities: MessageCallback<
     AggregateEntitiesData,
     null,
-    AggregateEntitiesResult<EntityRootedSubgraph>,
+    AggregateEntitiesResult<Subgraph<EntityRootType>>,
     ReadOrModifyResourceError
   >;
   /** @todo - Add Type System mutation methods */
@@ -120,13 +120,13 @@ export type EmbedderGraphMessageCallbacks = {
   getEntityType: MessageCallback<
     GetEntityTypeData,
     null,
-    EntityTypeRootedSubgraph,
+    Subgraph<EntityTypeRootType>,
     ReadOrModifyResourceError
   >;
   aggregateEntityTypes: MessageCallback<
     AggregateEntityTypesData,
     null,
-    AggregateEntityTypesResult<EntityTypeRootedSubgraph>,
+    AggregateEntityTypesResult<Subgraph<EntityTypeRootType>>,
     ReadOrModifyResourceError
   >;
   /** @todo - Reimplement linked aggregations */

--- a/libs/@blockprotocol/graph/src/types/entity.ts
+++ b/libs/@blockprotocol/graph/src/types/entity.ts
@@ -4,8 +4,7 @@ import type {
 } from "@blockprotocol/core";
 import { BaseUri, VersionedUri } from "@blockprotocol/type-system/slim";
 
-import { Timestamp } from "../types.js";
-import { Subgraph, SubgraphRootTypes } from "./subgraph.js";
+import { EntityRootedSubgraph, Timestamp } from "../types.js";
 import { GraphResolveDepths } from "./subgraph/graph-resolve-depths.js";
 
 export type JsonObject = CoreJsonObject;
@@ -139,9 +138,7 @@ export type AggregateEntitiesData = {
   graphResolveDepths?: GraphResolveDepths;
 };
 
-export type AggregateEntitiesResult<
-  T extends Subgraph<SubgraphRootTypes["entity"]>,
-> = {
+export type AggregateEntitiesResult<T extends EntityRootedSubgraph> = {
   results: T;
   operation: AggregateOperationInput &
     Required<Pick<AggregateOperationInput, "pageNumber" | "itemsPerPage">> & {

--- a/libs/@blockprotocol/graph/src/types/entity.ts
+++ b/libs/@blockprotocol/graph/src/types/entity.ts
@@ -4,7 +4,7 @@ import type {
 } from "@blockprotocol/core";
 import { BaseUri, VersionedUri } from "@blockprotocol/type-system/slim";
 
-import { isOntologyTypeRecordId, Timestamp } from "../types.js";
+import { Timestamp } from "../types.js";
 import { Subgraph, SubgraphRootTypes } from "./subgraph.js";
 import { GraphResolveDepths } from "./subgraph/graph-resolve-depths.js";
 
@@ -17,11 +17,10 @@ export type EntityId = string;
 // This isn't necessary, it just _could_ provide greater clarity that this corresponds to an exact vertex and can be
 // used in a direct lookup and not a search in the vertices
 export type EntityRevisionId = Timestamp;
-export type EntityVersion = string;
 
 export type EntityRecordId = {
-  baseId: EntityId;
-  versionId: EntityVersion;
+  entityId: EntityId;
+  editionId: string;
 };
 
 export const isEntityRecordId = (
@@ -30,12 +29,8 @@ export const isEntityRecordId = (
   return (
     recordId != null &&
     typeof recordId === "object" &&
-    "baseId" in recordId &&
-    "versionId" in recordId &&
-    /** @todo - is it fine to just check that versionId is string, maybe timestamp if we want to lock it into being a
-     *    timestamp?
-     */
-    !isOntologyTypeRecordId(recordId)
+    "entityId" in recordId &&
+    "editionId" in recordId
   );
 };
 

--- a/libs/@blockprotocol/graph/src/types/entity.ts
+++ b/libs/@blockprotocol/graph/src/types/entity.ts
@@ -4,7 +4,7 @@ import type {
 } from "@blockprotocol/core";
 import { BaseUri, VersionedUri } from "@blockprotocol/type-system/slim";
 
-import { isOntologyTypeRecordId } from "../types.js";
+import { isOntologyTypeRecordId, Timestamp } from "../types.js";
 import { Subgraph, SubgraphRootTypes } from "./subgraph.js";
 import { GraphResolveDepths } from "./subgraph/graph-resolve-depths.js";
 
@@ -14,7 +14,11 @@ export type JsonValue = CoreJsonValue;
 /** @todo - Consider branding these */
 /** @todo - Add documentation for these if we keep them */
 export type EntityId = string;
+// This isn't necessary, it just _could_ provide greater clarity that this corresponds to an exact vertex and can be
+// used in a direct lookup and not a search in the vertices
+export type EntityRevisionId = Timestamp;
 export type EntityVersion = string;
+
 export type EntityRecordId = {
   baseId: EntityId;
   versionId: EntityVersion;

--- a/libs/@blockprotocol/graph/src/types/entity.ts
+++ b/libs/@blockprotocol/graph/src/types/entity.ts
@@ -4,7 +4,7 @@ import type {
 } from "@blockprotocol/core";
 import { BaseUri, VersionedUri } from "@blockprotocol/type-system/slim";
 
-import { isOntologyTypeEditionId } from "../types.js";
+import { isOntologyTypeRecordId } from "../types.js";
 import { Subgraph, SubgraphRootTypes } from "./subgraph.js";
 import { GraphResolveDepths } from "./subgraph/graph-resolve-depths.js";
 
@@ -15,23 +15,23 @@ export type JsonValue = CoreJsonValue;
 /** @todo - Add documentation for these if we keep them */
 export type EntityId = string;
 export type EntityVersion = string;
-export type EntityEditionId = {
+export type EntityRecordId = {
   baseId: EntityId;
   versionId: EntityVersion;
 };
 
-export const isEntityEditionId = (
-  editionId: unknown,
-): editionId is EntityEditionId => {
+export const isEntityRecordId = (
+  recordId: unknown,
+): recordId is EntityRecordId => {
   return (
-    editionId != null &&
-    typeof editionId === "object" &&
-    "baseId" in editionId &&
-    "versionId" in editionId &&
+    recordId != null &&
+    typeof recordId === "object" &&
+    "baseId" in recordId &&
+    "versionId" in recordId &&
     /** @todo - is it fine to just check that versionId is string, maybe timestamp if we want to lock it into being a
      *    timestamp?
      */
-    !isOntologyTypeEditionId(editionId)
+    !isOntologyTypeRecordId(recordId)
   );
 };
 
@@ -45,7 +45,7 @@ export type EntityPropertiesObject = {
 };
 
 export type EntityMetadata = {
-  editionId: EntityEditionId;
+  recordId: EntityRecordId;
   entityTypeId: VersionedUri;
 };
 

--- a/libs/@blockprotocol/graph/src/types/entity.ts
+++ b/libs/@blockprotocol/graph/src/types/entity.ts
@@ -66,6 +66,11 @@ export type Entity<
   linkData?: LinkData;
 } & (Properties extends null ? {} : { properties: Properties });
 
+export type LinkEntityAndRightEntity = {
+  linkEntity: Entity;
+  rightEntity: Entity;
+};
+
 export type CreateEntityData = {
   entityTypeId: VersionedUri;
   properties: EntityPropertiesObject;

--- a/libs/@blockprotocol/graph/src/types/entity.ts
+++ b/libs/@blockprotocol/graph/src/types/entity.ts
@@ -4,7 +4,7 @@ import type {
 } from "@blockprotocol/core";
 import { BaseUri, VersionedUri } from "@blockprotocol/type-system/slim";
 
-import { EntityRootedSubgraph, Timestamp } from "../types.js";
+import { EntityRootType, Subgraph, Timestamp } from "../types.js";
 import { GraphResolveDepths } from "./subgraph/graph-resolve-depths.js";
 
 export type JsonObject = CoreJsonObject;
@@ -138,7 +138,7 @@ export type AggregateEntitiesData = {
   graphResolveDepths?: GraphResolveDepths;
 };
 
-export type AggregateEntitiesResult<T extends EntityRootedSubgraph> = {
+export type AggregateEntitiesResult<T extends Subgraph<EntityRootType>> = {
   results: T;
   operation: AggregateOperationInput &
     Required<Pick<AggregateOperationInput, "pageNumber" | "itemsPerPage">> & {

--- a/libs/@blockprotocol/graph/src/types/linked-aggregation.ts
+++ b/libs/@blockprotocol/graph/src/types/linked-aggregation.ts
@@ -1,5 +1,5 @@
 import { AggregateEntitiesResult, AggregateOperationInput } from "./entity.js";
-import { EntityRootedSubgraph } from "./subgraph.js";
+import { EntityRootType, Subgraph } from "./subgraph.js";
 
 export type LinkedAggregationDefinition = {
   aggregationId: string;
@@ -9,7 +9,7 @@ export type LinkedAggregationDefinition = {
 };
 
 export type LinkedAggregation = Omit<LinkedAggregationDefinition, "operation"> &
-  AggregateEntitiesResult<EntityRootedSubgraph>;
+  AggregateEntitiesResult<Subgraph<EntityRootType>>;
 
 export type GetLinkedAggregationData = {
   aggregationId: string;

--- a/libs/@blockprotocol/graph/src/types/linked-aggregation.ts
+++ b/libs/@blockprotocol/graph/src/types/linked-aggregation.ts
@@ -1,5 +1,5 @@
 import { AggregateEntitiesResult, AggregateOperationInput } from "./entity.js";
-import { Subgraph, SubgraphRootTypes } from "./subgraph.js";
+import { EntityRootedSubgraph } from "./subgraph.js";
 
 export type LinkedAggregationDefinition = {
   aggregationId: string;
@@ -9,7 +9,7 @@ export type LinkedAggregationDefinition = {
 };
 
 export type LinkedAggregation = Omit<LinkedAggregationDefinition, "operation"> &
-  AggregateEntitiesResult<Subgraph<SubgraphRootTypes["entity"]>>;
+  AggregateEntitiesResult<EntityRootedSubgraph>;
 
 export type GetLinkedAggregationData = {
   aggregationId: string;

--- a/libs/@blockprotocol/graph/src/types/ontology.ts
+++ b/libs/@blockprotocol/graph/src/types/ontology.ts
@@ -13,8 +13,8 @@ export * from "./ontology/property-type.js";
  *      of the type system? Not sure the type system == ontology, it's more like the type system describes the ontology.
  */
 export type OntologyTypeRecordId = {
-  baseId: BaseUri;
-  versionId: number;
+  baseUri: BaseUri;
+  version: number;
 };
 
 export const isOntologyTypeRecordId = (
@@ -23,11 +23,11 @@ export const isOntologyTypeRecordId = (
   return (
     recordId != null &&
     typeof recordId === "object" &&
-    "baseId" in recordId &&
-    typeof recordId.baseId === "string" &&
+    "baseUri" in recordId &&
+    typeof recordId.baseUri === "string" &&
     /** @todo - This means we need to have initialized the type system */
-    validateBaseUri(recordId.baseId).type === "Ok" &&
-    "versionId" in recordId &&
-    typeof recordId.versionId === "number"
+    validateBaseUri(recordId.baseUri).type === "Ok" &&
+    "version" in recordId &&
+    typeof recordId.version === "number"
   );
 };

--- a/libs/@blockprotocol/graph/src/types/ontology.ts
+++ b/libs/@blockprotocol/graph/src/types/ontology.ts
@@ -8,26 +8,26 @@ export * from "./ontology/property-type.js";
 /** @todo - Add documentation */
 /**
  *  @todo - Do we want to introduce "ontology" into code? Alternatives:
- *    * `TypeEditionId` - "type" is so ambiguous in languages and tends to clash with protected keywords
+ *    * `TypeRecordId` - "type" is so ambiguous in languages and tends to clash with protected keywords
  *    * `TypeSystemElementId` - This is about as wordy as below, and is an element of the ontology the same as an element
  *      of the type system? Not sure the type system == ontology, it's more like the type system describes the ontology.
  */
-export type OntologyTypeEditionId = {
+export type OntologyTypeRecordId = {
   baseId: BaseUri;
   versionId: number;
 };
 
-export const isOntologyTypeEditionId = (
-  editionId: unknown,
-): editionId is OntologyTypeEditionId => {
+export const isOntologyTypeRecordId = (
+  recordId: unknown,
+): recordId is OntologyTypeRecordId => {
   return (
-    editionId != null &&
-    typeof editionId === "object" &&
-    "baseId" in editionId &&
-    typeof editionId.baseId === "string" &&
+    recordId != null &&
+    typeof recordId === "object" &&
+    "baseId" in recordId &&
+    typeof recordId.baseId === "string" &&
     /** @todo - This means we need to have initialized the type system */
-    validateBaseUri(editionId.baseId).type === "Ok" &&
-    "versionId" in editionId &&
-    typeof editionId.versionId === "number"
+    validateBaseUri(recordId.baseId).type === "Ok" &&
+    "versionId" in recordId &&
+    typeof recordId.versionId === "number"
   );
 };

--- a/libs/@blockprotocol/graph/src/types/ontology/entity-type.ts
+++ b/libs/@blockprotocol/graph/src/types/ontology/entity-type.ts
@@ -1,7 +1,7 @@
 import { EntityType, VersionedUri } from "@blockprotocol/type-system/slim";
 
 import { AggregateOperationInput } from "../entity.js";
-import { EntityTypeRootedSubgraph } from "../subgraph.js";
+import { EntityTypeRootType, Subgraph } from "../subgraph.js";
 import { OntologyElementMetadata } from "./metadata.js";
 
 /**
@@ -22,14 +22,15 @@ export type AggregateEntityTypesData = {
   operation?: Omit<AggregateOperationInput, "entityTypeId"> | null;
 };
 
-export type AggregateEntityTypesResult<T extends EntityTypeRootedSubgraph> = {
-  results: T[];
-  operation: AggregateOperationInput &
-    Required<Pick<AggregateOperationInput, "pageNumber" | "itemsPerPage">> & {
-      pageCount?: number | null;
-      totalCount?: number | null;
-    };
-};
+export type AggregateEntityTypesResult<T extends Subgraph<EntityTypeRootType>> =
+  {
+    results: T[];
+    operation: AggregateOperationInput &
+      Required<Pick<AggregateOperationInput, "pageNumber" | "itemsPerPage">> & {
+        pageCount?: number | null;
+        totalCount?: number | null;
+      };
+  };
 
 export type GetEntityTypeData = {
   entityTypeId: VersionedUri;

--- a/libs/@blockprotocol/graph/src/types/ontology/entity-type.ts
+++ b/libs/@blockprotocol/graph/src/types/ontology/entity-type.ts
@@ -1,7 +1,7 @@
 import { EntityType, VersionedUri } from "@blockprotocol/type-system/slim";
 
 import { AggregateOperationInput } from "../entity.js";
-import { Subgraph, SubgraphRootTypes } from "../subgraph.js";
+import { EntityTypeRootedSubgraph } from "../subgraph.js";
 import { OntologyElementMetadata } from "./metadata.js";
 
 /**
@@ -22,9 +22,7 @@ export type AggregateEntityTypesData = {
   operation?: Omit<AggregateOperationInput, "entityTypeId"> | null;
 };
 
-export type AggregateEntityTypesResult<
-  T extends Subgraph<SubgraphRootTypes["entityType"]>,
-> = {
+export type AggregateEntityTypesResult<T extends EntityTypeRootedSubgraph> = {
   results: T[];
   operation: AggregateOperationInput &
     Required<Pick<AggregateOperationInput, "pageNumber" | "itemsPerPage">> & {

--- a/libs/@blockprotocol/graph/src/types/ontology/metadata.ts
+++ b/libs/@blockprotocol/graph/src/types/ontology/metadata.ts
@@ -1,6 +1,6 @@
-import { OntologyTypeEditionId } from "../ontology.js";
+import { OntologyTypeRecordId } from "../ontology.js";
 
 export interface OntologyElementMetadata {
-  editionId: OntologyTypeEditionId;
+  recordId: OntologyTypeRecordId;
   ownedById: string;
 }

--- a/libs/@blockprotocol/graph/src/types/subgraph.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph.ts
@@ -1,5 +1,5 @@
-import { Entity, EntityEditionId } from "./entity.js";
-import { OntologyTypeEditionId } from "./ontology.js";
+import { Entity, EntityRecordId } from "./entity.js";
+import { OntologyTypeRecordId } from "./ontology.js";
 import { DataTypeWithMetadata } from "./ontology/data-type.js";
 import { EntityTypeWithMetadata } from "./ontology/entity-type.js";
 import { PropertyTypeWithMetadata } from "./ontology/property-type.js";
@@ -15,19 +15,19 @@ export * from "./subgraph/vertices.js";
 
 export type SubgraphRootTypes = {
   dataType: {
-    editionId: OntologyTypeEditionId;
+    recordId: OntologyTypeRecordId;
     element: DataTypeWithMetadata;
   };
   propertyType: {
-    editionId: OntologyTypeEditionId;
+    recordId: OntologyTypeRecordId;
     element: PropertyTypeWithMetadata;
   };
   entityType: {
-    editionId: OntologyTypeEditionId;
+    recordId: OntologyTypeRecordId;
     element: EntityTypeWithMetadata;
   };
   entity: {
-    editionId: EntityEditionId;
+    recordId: EntityRecordId;
     element: Entity;
   };
 };
@@ -35,7 +35,7 @@ export type SubgraphRootTypes = {
 export type SubgraphRootType = SubgraphRootTypes[keyof SubgraphRootTypes];
 
 export type Subgraph<RootType extends SubgraphRootType = SubgraphRootType> = {
-  roots: RootType["editionId"][];
+  roots: RootType["recordId"][];
   vertices: Vertices;
   edges: Edges;
   depths: GraphResolveDepths;

--- a/libs/@blockprotocol/graph/src/types/subgraph.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph.ts
@@ -1,11 +1,14 @@
-import { Entity, EntityRecordId } from "./entity.js";
-import { OntologyTypeRecordId } from "./ontology.js";
+import { Entity } from "./entity.js";
 import { DataTypeWithMetadata } from "./ontology/data-type.js";
 import { EntityTypeWithMetadata } from "./ontology/entity-type.js";
 import { PropertyTypeWithMetadata } from "./ontology/property-type.js";
 import { Edges } from "./subgraph/edges.js";
 import { GraphResolveDepths } from "./subgraph/graph-resolve-depths.js";
-import { Vertices } from "./subgraph/vertices.js";
+import {
+  EntityVertexId,
+  OntologyTypeVertexId,
+  Vertices,
+} from "./subgraph/vertices.js";
 
 export * from "./ontology.js";
 export * from "./subgraph/edges.js";
@@ -15,19 +18,19 @@ export * from "./subgraph/vertices.js";
 
 export type SubgraphRootTypes = {
   dataType: {
-    recordId: OntologyTypeRecordId;
+    vertexId: OntologyTypeVertexId;
     element: DataTypeWithMetadata;
   };
   propertyType: {
-    recordId: OntologyTypeRecordId;
+    vertexId: OntologyTypeVertexId;
     element: PropertyTypeWithMetadata;
   };
   entityType: {
-    recordId: OntologyTypeRecordId;
+    vertexId: OntologyTypeVertexId;
     element: EntityTypeWithMetadata;
   };
   entity: {
-    recordId: EntityRecordId;
+    vertexId: EntityVertexId;
     element: Entity;
   };
 };
@@ -35,7 +38,7 @@ export type SubgraphRootTypes = {
 export type SubgraphRootType = SubgraphRootTypes[keyof SubgraphRootTypes];
 
 export type Subgraph<RootType extends SubgraphRootType = SubgraphRootType> = {
-  roots: RootType["recordId"][];
+  roots: RootType["vertexId"][];
   vertices: Vertices;
   edges: Edges;
   depths: GraphResolveDepths;

--- a/libs/@blockprotocol/graph/src/types/subgraph.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph.ts
@@ -41,6 +41,15 @@ export type Subgraph<RootType extends SubgraphRootType = SubgraphRootType> = {
   depths: GraphResolveDepths;
 };
 
+export type EntityRootedSubgraph = Subgraph<SubgraphRootTypes["entity"]>;
+export type DataTypeRootedSubgraph = Subgraph<SubgraphRootTypes["dataType"]>;
+export type PropertyTypeRootedSubgraph = Subgraph<
+  SubgraphRootTypes["propertyType"]
+>;
+export type EntityTypeRootedSubgraph = Subgraph<
+  SubgraphRootTypes["entityType"]
+>;
+
 export type LinkEntityAndRightEntity = {
   linkEntity: Entity;
   rightEntity: Entity;

--- a/libs/@blockprotocol/graph/src/types/subgraph.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph.ts
@@ -49,8 +49,3 @@ export type PropertyTypeRootedSubgraph = Subgraph<
 export type EntityTypeRootedSubgraph = Subgraph<
   SubgraphRootTypes["entityType"]
 >;
-
-export type LinkEntityAndRightEntity = {
-  linkEntity: Entity;
-  rightEntity: Entity;
-};

--- a/libs/@blockprotocol/graph/src/types/subgraph.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph.ts
@@ -16,26 +16,31 @@ export * from "./subgraph/graph-resolve-depths.js";
 export * from "./subgraph/time.js";
 export * from "./subgraph/vertices.js";
 
-export type SubgraphRootTypes = {
-  dataType: {
-    vertexId: OntologyTypeVertexId;
-    element: DataTypeWithMetadata;
-  };
-  propertyType: {
-    vertexId: OntologyTypeVertexId;
-    element: PropertyTypeWithMetadata;
-  };
-  entityType: {
-    vertexId: OntologyTypeVertexId;
-    element: EntityTypeWithMetadata;
-  };
-  entity: {
-    vertexId: EntityVertexId;
-    element: Entity;
-  };
+export type DataTypeRootType = {
+  vertexId: OntologyTypeVertexId;
+  element: DataTypeWithMetadata;
 };
 
-export type SubgraphRootType = SubgraphRootTypes[keyof SubgraphRootTypes];
+export type PropertyTypeRootType = {
+  vertexId: OntologyTypeVertexId;
+  element: PropertyTypeWithMetadata;
+};
+
+export type EntityTypeRootType = {
+  vertexId: OntologyTypeVertexId;
+  element: EntityTypeWithMetadata;
+};
+
+export type EntityRootType = {
+  vertexId: EntityVertexId;
+  element: Entity;
+};
+
+export type SubgraphRootType =
+  | DataTypeRootType
+  | PropertyTypeRootType
+  | EntityTypeRootType
+  | EntityRootType;
 
 export type Subgraph<RootType extends SubgraphRootType = SubgraphRootType> = {
   roots: RootType["vertexId"][];
@@ -43,12 +48,3 @@ export type Subgraph<RootType extends SubgraphRootType = SubgraphRootType> = {
   edges: Edges;
   depths: GraphResolveDepths;
 };
-
-export type EntityRootedSubgraph = Subgraph<SubgraphRootTypes["entity"]>;
-export type DataTypeRootedSubgraph = Subgraph<SubgraphRootTypes["dataType"]>;
-export type PropertyTypeRootedSubgraph = Subgraph<
-  SubgraphRootTypes["propertyType"]
->;
-export type EntityTypeRootedSubgraph = Subgraph<
-  SubgraphRootTypes["entityType"]
->;

--- a/libs/@blockprotocol/graph/src/types/subgraph/edges/outward-edge-alias.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/edges/outward-edge-alias.ts
@@ -3,7 +3,7 @@
  */
 
 import { Subtype } from "../../../util.js";
-import { OntologyTypeEditionId } from "../../ontology.js";
+import { OntologyTypeRecordId } from "../../ontology.js";
 import {
   EntityIdAndTimestamp,
   KnowledgeGraphOutwardEdge,
@@ -76,7 +76,7 @@ export type ConstrainsPropertiesOnEdge = Subtype<
   {
     reversed: false;
     kind: "CONSTRAINS_PROPERTIES_ON";
-    rightEndpoint: OntologyTypeEditionId;
+    rightEndpoint: OntologyTypeRecordId;
   }
 >;
 

--- a/libs/@blockprotocol/graph/src/types/subgraph/edges/outward-edge-alias.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/edges/outward-edge-alias.ts
@@ -3,7 +3,7 @@
  */
 
 import { Subtype } from "../../../util.js";
-import { OntologyTypeRecordId } from "../../ontology.js";
+import { OntologyTypeVertexId } from "../vertices";
 import {
   EntityIdAndTimestamp,
   KnowledgeGraphOutwardEdge,
@@ -76,7 +76,7 @@ export type ConstrainsPropertiesOnEdge = Subtype<
   {
     reversed: false;
     kind: "CONSTRAINS_PROPERTIES_ON";
-    rightEndpoint: OntologyTypeRecordId;
+    rightEndpoint: OntologyTypeVertexId;
   }
 >;
 

--- a/libs/@blockprotocol/graph/src/types/subgraph/edges/outward-edge.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/edges/outward-edge.ts
@@ -1,7 +1,7 @@
-import { EntityEditionId, EntityId, isEntityEditionId } from "../../entity.js";
+import { EntityId, EntityRecordId, isEntityRecordId } from "../../entity.js";
 import {
-  isOntologyTypeEditionId,
-  OntologyTypeEditionId,
+  isOntologyTypeRecordId,
+  OntologyTypeRecordId,
 } from "../../ontology.js";
 import { Timestamp } from "../time.js";
 import {
@@ -33,12 +33,12 @@ export type EntityIdAndTimestamp = {
 };
 
 export type OntologyOutwardEdge =
-  | GenericOutwardEdge<OntologyEdgeKind, OntologyTypeEditionId>
-  | GenericOutwardEdge<SharedEdgeKind, EntityEditionId, true>;
+  | GenericOutwardEdge<OntologyEdgeKind, OntologyTypeRecordId>
+  | GenericOutwardEdge<SharedEdgeKind, EntityRecordId, true>;
 
 export type KnowledgeGraphOutwardEdge =
   | GenericOutwardEdge<KnowledgeGraphEdgeKind, EntityIdAndTimestamp>
-  | GenericOutwardEdge<SharedEdgeKind, OntologyTypeEditionId, false>;
+  | GenericOutwardEdge<SharedEdgeKind, OntologyTypeRecordId, false>;
 
 export type OutwardEdge = OntologyOutwardEdge | KnowledgeGraphOutwardEdge;
 
@@ -49,7 +49,7 @@ export const isOntologyOutwardEdge = (
 ): edge is OntologyOutwardEdge => {
   return (
     isOntologyEdgeKind(edge.kind) ||
-    (isSharedEdgeKind(edge.kind) && isEntityEditionId(edge.rightEndpoint))
+    (isSharedEdgeKind(edge.kind) && isEntityRecordId(edge.rightEndpoint))
   );
 };
 
@@ -58,6 +58,6 @@ export const isKnowledgeGraphOutwardEdge = (
 ): edge is KnowledgeGraphOutwardEdge => {
   return (
     isKnowledgeGraphEdgeKind(edge.kind) ||
-    (isSharedEdgeKind(edge.kind) && isOntologyTypeEditionId(edge.rightEndpoint))
+    (isSharedEdgeKind(edge.kind) && isOntologyTypeRecordId(edge.rightEndpoint))
   );
 };

--- a/libs/@blockprotocol/graph/src/types/subgraph/edges/outward-edge.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/edges/outward-edge.ts
@@ -1,9 +1,7 @@
-import { EntityId, EntityRecordId, isEntityRecordId } from "../../entity.js";
-import {
-  isOntologyTypeRecordId,
-  OntologyTypeRecordId,
-} from "../../ontology.js";
+import { EntityId, isEntityRecordId } from "../../entity.js";
+import { isOntologyTypeRecordId } from "../../ontology.js";
 import { Timestamp } from "../time.js";
+import { EntityVertexId, OntologyTypeVertexId } from "../vertices";
 import {
   isKnowledgeGraphEdgeKind,
   isOntologyEdgeKind,
@@ -33,12 +31,12 @@ export type EntityIdAndTimestamp = {
 };
 
 export type OntologyOutwardEdge =
-  | GenericOutwardEdge<OntologyEdgeKind, OntologyTypeRecordId>
-  | GenericOutwardEdge<SharedEdgeKind, EntityRecordId, true>;
+  | GenericOutwardEdge<OntologyEdgeKind, OntologyTypeVertexId>
+  | GenericOutwardEdge<SharedEdgeKind, EntityVertexId, true>;
 
 export type KnowledgeGraphOutwardEdge =
   | GenericOutwardEdge<KnowledgeGraphEdgeKind, EntityIdAndTimestamp>
-  | GenericOutwardEdge<SharedEdgeKind, OntologyTypeRecordId, false>;
+  | GenericOutwardEdge<SharedEdgeKind, OntologyTypeVertexId, false>;
 
 export type OutwardEdge = OntologyOutwardEdge | KnowledgeGraphOutwardEdge;
 

--- a/libs/@blockprotocol/graph/src/types/subgraph/vertices.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/vertices.ts
@@ -1,6 +1,12 @@
 import { BaseUri, validateBaseUri } from "@blockprotocol/type-system/slim";
 
-import { Entity, EntityId, EntityRevisionId } from "../entity.js";
+import {
+  Entity,
+  EntityId,
+  EntityPropertiesObject,
+  EntityPropertyValue,
+  EntityRevisionId,
+} from "../entity.js";
 import { isOntologyTypeRecordId } from "../ontology.js";
 import { DataTypeWithMetadata } from "../ontology/data-type.js";
 import { EntityTypeWithMetadata } from "../ontology/entity-type.js";
@@ -21,16 +27,31 @@ export type EntityTypeVertex = {
   inner: EntityTypeWithMetadata;
 };
 
-export type EntityVertex = { kind: "entity"; inner: Entity };
+export type EntityVertex<
+  Properties extends EntityPropertiesObject | null = Record<
+    BaseUri,
+    EntityPropertyValue
+  >,
+> = { kind: "entity"; inner: Entity<Properties> };
 
 export type OntologyVertex =
   | DataTypeVertex
   | PropertyTypeVertex
   | EntityTypeVertex;
 
-export type KnowledgeGraphVertex = EntityVertex;
+export type KnowledgeGraphVertex<
+  Properties extends EntityPropertiesObject | null = Record<
+    BaseUri,
+    EntityPropertyValue
+  >,
+> = EntityVertex<Properties>;
 
-export type Vertex = OntologyVertex | KnowledgeGraphVertex;
+export type Vertex<
+  Properties extends EntityPropertiesObject | null = Record<
+    BaseUri,
+    EntityPropertyValue
+  >,
+> = OntologyVertex | KnowledgeGraphVertex<Properties>;
 
 export const isDataTypeVertex = (vertex: Vertex): vertex is DataTypeVertex => {
   return vertex.kind === "dataType";

--- a/libs/@blockprotocol/graph/src/types/subgraph/vertices.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/vertices.ts
@@ -1,6 +1,7 @@
-import { BaseUri } from "@blockprotocol/type-system/slim";
+import { BaseUri, validateBaseUri } from "@blockprotocol/type-system/slim";
 
-import { Entity, EntityId, EntityVersion } from "../entity.js";
+import { Entity, EntityId, EntityRevisionId } from "../entity.js";
+import { isOntologyTypeRecordId } from "../ontology.js";
 import { DataTypeWithMetadata } from "../ontology/data-type.js";
 import { EntityTypeWithMetadata } from "../ontology/entity-type.js";
 import { PropertyTypeWithMetadata } from "../ontology/property-type.js";
@@ -51,6 +52,44 @@ export const isEntityVertex = (vertex: Vertex): vertex is EntityVertex => {
   return vertex.kind === "entity";
 };
 
+export type VertexId<BaseId, RevisionId> = {
+  baseId: BaseId;
+  revisionId: RevisionId;
+};
+export type EntityVertexId = VertexId<EntityId, EntityRevisionId>;
+export type OntologyTypeVertexId = VertexId<BaseUri, number>;
+export type GraphElementVertexId = EntityVertexId | OntologyTypeVertexId;
+
+export const isOntologyTypeVertexId = (
+  vertexId: unknown,
+): vertexId is OntologyTypeVertexId => {
+  return (
+    vertexId != null &&
+    typeof vertexId === "object" &&
+    "baseId" in vertexId &&
+    typeof vertexId.baseId === "string" &&
+    /** @todo - This means we need to have initialized the type system */
+    validateBaseUri(vertexId.baseId).type === "Ok" &&
+    "revisionId" in vertexId &&
+    typeof vertexId.revisionId === "number"
+  );
+};
+
+export const isEntityVertexId = (
+  vertexId: unknown,
+): vertexId is EntityVertexId => {
+  return (
+    vertexId != null &&
+    typeof vertexId === "object" &&
+    "baseId" in vertexId &&
+    "revisionId" in vertexId &&
+    /** @todo - is it fine to just check that versionId is string, maybe timestamp if we want to lock it into being a
+     *    timestamp?
+     */
+    !isOntologyTypeRecordId(vertexId)
+  );
+};
+
 export type OntologyVertices = {
   [typeBaseUri: BaseUri]: {
     [typeVersion: number]: OntologyVertex;
@@ -59,7 +98,7 @@ export type OntologyVertices = {
 
 export type KnowledgeGraphVertices = {
   [entityId: EntityId]: {
-    [entityVersion: EntityVersion]: KnowledgeGraphVertex;
+    [entityVersion: EntityRevisionId]: KnowledgeGraphVertex;
   };
 };
 

--- a/libs/block-template-custom-element/src/app.ts
+++ b/libs/block-template-custom-element/src/app.ts
@@ -33,7 +33,7 @@ export class BlockElement extends BlockElementBase<RootEntity> {
     this.graphService
       .updateEntity<RootEntity["properties"]>({
         data: {
-          entityId: this.blockEntity.metadata.editionId.baseId,
+          entityId: this.blockEntity.metadata.recordId.baseId,
           entityTypeId: this.blockEntity.metadata.entityTypeId,
           properties: {
             ...this.blockEntity.properties,
@@ -56,8 +56,8 @@ export class BlockElement extends BlockElementBase<RootEntity> {
       </h1>
       <p>
         The entityId of this block is
-        ${this.blockEntity?.metadata.editionId.baseId}. Use it to update its
-        data when calling updateEntity.
+        ${this.blockEntity?.metadata.recordId.baseId}. Use it to update its data
+        when calling updateEntity.
       </p>
       <!-- @see https://lit.dev/docs/components/events -->
       <input

--- a/libs/block-template-custom-element/src/app.ts
+++ b/libs/block-template-custom-element/src/app.ts
@@ -33,7 +33,7 @@ export class BlockElement extends BlockElementBase<RootEntity> {
     this.graphService
       .updateEntity<RootEntity["properties"]>({
         data: {
-          entityId: this.blockEntity.metadata.recordId.baseId,
+          entityId: this.blockEntity.metadata.recordId.entityId,
           entityTypeId: this.blockEntity.metadata.entityTypeId,
           properties: {
             ...this.blockEntity.properties,
@@ -56,8 +56,8 @@ export class BlockElement extends BlockElementBase<RootEntity> {
       </h1>
       <p>
         The entityId of this block is
-        ${this.blockEntity?.metadata.recordId.baseId}. Use it to update its data
-        when calling updateEntity.
+        ${this.blockEntity?.metadata.recordId.entityId}. Use it to update its
+        data when calling updateEntity.
       </p>
       <!-- @see https://lit.dev/docs/components/events -->
       <input

--- a/libs/block-template-custom-element/src/dev.tsx
+++ b/libs/block-template-custom-element/src/dev.tsx
@@ -11,7 +11,7 @@ const node = document.getElementById("app");
 // @todo make type blockprotocol.org/[etc]/ExampleEntity when we can host new types there
 const testEntity: RootEntity = {
   metadata: {
-    editionId: {
+    recordId: {
       baseId: "test-entity",
       versionId: new Date().toISOString(),
     },
@@ -50,7 +50,7 @@ const DevApp = () => {
           tagName,
         },
       }}
-      blockEntityEditionId={testEntity.metadata.editionId}
+      blockEntityRecordId={testEntity.metadata.recordId}
       blockInfo={packageJson.blockprotocol}
       debug // remove this to start with the debug UI minimised. You can also toggle it in the UI
       initialEntities={[testEntity]}

--- a/libs/block-template-custom-element/src/dev.tsx
+++ b/libs/block-template-custom-element/src/dev.tsx
@@ -12,8 +12,8 @@ const node = document.getElementById("app");
 const testEntity: RootEntity = {
   metadata: {
     recordId: {
-      baseId: "test-entity",
-      versionId: new Date().toISOString(),
+      entityId: "test-entity",
+      editionId: new Date().toISOString(),
     },
     entityTypeId: packageJson.blockprotocol.schema as VersionedUri,
   },

--- a/libs/block-template-react/src/app.tsx
+++ b/libs/block-template-react/src/app.tsx
@@ -63,7 +63,7 @@ export const App: BlockComponent<RootEntity> = ({
     RootEntityLinkedEntities
   >(blockEntitySubgraph);
 
-  const entityId = blockEntity.metadata.recordId.baseId;
+  const entityId = blockEntity.metadata.recordId.entityId;
 
   const titleKey: keyof RootEntity["properties"] =
     "https://alpha.hash.ai/@hash/types/property-type/title/";

--- a/libs/block-template-react/src/app.tsx
+++ b/libs/block-template-react/src/app.tsx
@@ -63,7 +63,7 @@ export const App: BlockComponent<RootEntity> = ({
     RootEntityLinkedEntities
   >(blockEntitySubgraph);
 
-  const entityId = blockEntity.metadata.editionId.baseId;
+  const entityId = blockEntity.metadata.recordId.baseId;
 
   const titleKey: keyof RootEntity["properties"] =
     "https://alpha.hash.ai/@hash/types/property-type/title/";

--- a/libs/block-template-react/src/dev.tsx
+++ b/libs/block-template-react/src/dev.tsx
@@ -11,7 +11,7 @@ const node = document.getElementById("app");
 // @todo make type blockprotocol.org/[etc]/ExampleEntity when we can host new types there
 const testEntity: RootEntity = {
   metadata: {
-    editionId: {
+    recordId: {
       baseId: "test-entity",
       versionId: new Date().toISOString(),
     },
@@ -38,7 +38,7 @@ const DevApp = () => {
   return (
     <MockBlockDock
       blockDefinition={{ ReactComponent: Component }}
-      blockEntityEditionId={testEntity.metadata.editionId}
+      blockEntityRecordId={testEntity.metadata.recordId}
       blockInfo={packageJson.blockprotocol}
       debug // remove this to start with the debug UI minimised. You can also toggle it in the UI
       initialEntities={[testEntity]}

--- a/libs/block-template-react/src/dev.tsx
+++ b/libs/block-template-react/src/dev.tsx
@@ -12,8 +12,8 @@ const node = document.getElementById("app");
 const testEntity: RootEntity = {
   metadata: {
     recordId: {
-      baseId: "test-entity",
-      versionId: new Date().toISOString(),
+      entityId: "test-entity",
+      editionId: new Date().toISOString(),
     },
     entityTypeId: packageJson.blockprotocol.schema as VersionedUri,
   },

--- a/libs/mock-block-dock/dev/dev-app.tsx
+++ b/libs/mock-block-dock/dev/dev-app.tsx
@@ -14,7 +14,7 @@ const node = document.getElementById("app");
 const blockEntityMap = {
   react: {
     metadata: {
-      editionId: {
+      recordId: {
         baseId: "entity-react",
         versionId: new Date().toISOString(),
       },
@@ -24,7 +24,7 @@ const blockEntityMap = {
   },
   "custom-element": {
     metadata: {
-      editionId: {
+      recordId: {
         baseId: "entity-custom-element",
         versionId: new Date().toISOString(),
       },
@@ -34,7 +34,7 @@ const blockEntityMap = {
   },
   "html-at-url": {
     metadata: {
-      editionId: {
+      recordId: {
         baseId: "entity-html-as-url",
         versionId: new Date().toISOString(),
       },
@@ -44,7 +44,7 @@ const blockEntityMap = {
   },
   "html-as-string": {
     metadata: {
-      editionId: {
+      recordId: {
         baseId: "entity-html-as-string",
         versionId: new Date().toISOString(),
       },
@@ -136,7 +136,7 @@ const DevApp: FunctionComponent = () => {
 
       <MockBlockDock
         blockDefinition={blockDefinition}
-        blockEntityEditionId={blockEntity.metadata.editionId}
+        blockEntityRecordId={blockEntity.metadata.recordId}
         blockInfo={{
           displayName: "Test Block",
           blockType: {

--- a/libs/mock-block-dock/dev/dev-app.tsx
+++ b/libs/mock-block-dock/dev/dev-app.tsx
@@ -15,8 +15,8 @@ const blockEntityMap = {
   react: {
     metadata: {
       recordId: {
-        baseId: "entity-react",
-        versionId: new Date().toISOString(),
+        entityId: "entity-react",
+        editionId: new Date().toISOString(),
       },
       entityTypeId: entityTypes.testType.$id,
     },
@@ -25,8 +25,8 @@ const blockEntityMap = {
   "custom-element": {
     metadata: {
       recordId: {
-        baseId: "entity-custom-element",
-        versionId: new Date().toISOString(),
+        entityId: "entity-custom-element",
+        editionId: new Date().toISOString(),
       },
       entityTypeId: entityTypes.testType.$id,
     },
@@ -35,8 +35,8 @@ const blockEntityMap = {
   "html-at-url": {
     metadata: {
       recordId: {
-        baseId: "entity-html-as-url",
-        versionId: new Date().toISOString(),
+        entityId: "entity-html-as-url",
+        editionId: new Date().toISOString(),
       },
       entityTypeId: entityTypes.testType.$id,
     },
@@ -45,8 +45,8 @@ const blockEntityMap = {
   "html-as-string": {
     metadata: {
       recordId: {
-        baseId: "entity-html-as-string",
-        versionId: new Date().toISOString(),
+        entityId: "entity-html-as-string",
+        editionId: new Date().toISOString(),
       },
       entityTypeId: entityTypes.testType.$id,
     },

--- a/libs/mock-block-dock/dev/test-custom-element-block.ts
+++ b/libs/mock-block-dock/dev/test-custom-element-block.ts
@@ -32,7 +32,7 @@ export class TestCustomElementBlock extends BlockElementBase {
         </h1>
         <p>
           The entityId of this block is
-          ${blockEntity?.metadata.editionId.baseId}.
+          ${blockEntity?.metadata.recordId.baseId}.
         </p>
         <p>
           ${blockEntity?.properties[extractBaseUri(propertyTypes.name.$id)]}
@@ -44,7 +44,7 @@ export class TestCustomElementBlock extends BlockElementBase {
         ${blockEntity?.properties[extractBaseUri(propertyTypes.name.$id)]}
       </h1>
       <p>
-        The entityId of this block is ${blockEntity?.metadata.editionId.baseId}.
+        The entityId of this block is ${blockEntity?.metadata.recordId.baseId}.
         Use it to update its data when calling updateEntities.
       </p>
       <input

--- a/libs/mock-block-dock/dev/test-custom-element-block.ts
+++ b/libs/mock-block-dock/dev/test-custom-element-block.ts
@@ -32,7 +32,7 @@ export class TestCustomElementBlock extends BlockElementBase {
         </h1>
         <p>
           The entityId of this block is
-          ${blockEntity?.metadata.recordId.baseId}.
+          ${blockEntity?.metadata.recordId.entityId}.
         </p>
         <p>
           ${blockEntity?.properties[extractBaseUri(propertyTypes.name.$id)]}
@@ -44,8 +44,9 @@ export class TestCustomElementBlock extends BlockElementBase {
         ${blockEntity?.properties[extractBaseUri(propertyTypes.name.$id)]}
       </h1>
       <p>
-        The entityId of this block is ${blockEntity?.metadata.recordId.baseId}.
-        Use it to update its data when calling updateEntities.
+        The entityId of this block is
+        ${blockEntity?.metadata.recordId.entityId}. Use it to update its data
+        when calling updateEntities.
       </p>
       <input
         @change=${this.handleInput}

--- a/libs/mock-block-dock/dev/test-react-block.tsx
+++ b/libs/mock-block-dock/dev/test-react-block.tsx
@@ -26,7 +26,7 @@ export const TestReactBlock: BlockComponent = ({ graph }) => {
     hookService,
     hookRef,
     "text",
-    blockEntity?.metadata.editionId.baseId ?? "",
+    blockEntity?.metadata.recordId.baseId ?? "",
     "$.description",
     () => {
       throw new Error(
@@ -45,7 +45,7 @@ export const TestReactBlock: BlockComponent = ({ graph }) => {
               | string
               | undefined
           }
-          ! The id of this block is {blockEntity?.metadata.editionId.baseId}
+          ! The id of this block is {blockEntity?.metadata.recordId.baseId}
         </h1>
         <h2>Block-handled name display</h2>
         <p style={{ marginBottom: 30 }}>
@@ -67,7 +67,7 @@ export const TestReactBlock: BlockComponent = ({ graph }) => {
         <>
           Hello{" "}
           {blockEntity?.properties[extractBaseUri(propertyTypes.name.$id)]}! The
-          id of this block is {blockEntity?.metadata.editionId.baseId}
+          id of this block is {blockEntity?.metadata.recordId.baseId}
         </>
       </h1>
       <h2>Block-handled name editing</h2>
@@ -86,7 +86,7 @@ export const TestReactBlock: BlockComponent = ({ graph }) => {
           try {
             const { data, errors } = await graphService!.updateEntity({
               data: {
-                entityId: blockEntity.metadata.editionId.baseId,
+                entityId: blockEntity.metadata.recordId.baseId,
                 entityTypeId: blockEntity.metadata.entityTypeId,
                 properties: {
                   ...blockEntity.properties,

--- a/libs/mock-block-dock/dev/test-react-block.tsx
+++ b/libs/mock-block-dock/dev/test-react-block.tsx
@@ -26,7 +26,7 @@ export const TestReactBlock: BlockComponent = ({ graph }) => {
     hookService,
     hookRef,
     "text",
-    blockEntity?.metadata.recordId.baseId ?? "",
+    blockEntity?.metadata.recordId.entityId ?? "",
     "$.description",
     () => {
       throw new Error(
@@ -45,7 +45,7 @@ export const TestReactBlock: BlockComponent = ({ graph }) => {
               | string
               | undefined
           }
-          ! The id of this block is {blockEntity?.metadata.recordId.baseId}
+          ! The id of this block is {blockEntity?.metadata.recordId.entityId}
         </h1>
         <h2>Block-handled name display</h2>
         <p style={{ marginBottom: 30 }}>
@@ -67,7 +67,7 @@ export const TestReactBlock: BlockComponent = ({ graph }) => {
         <>
           Hello{" "}
           {blockEntity?.properties[extractBaseUri(propertyTypes.name.$id)]}! The
-          id of this block is {blockEntity?.metadata.recordId.baseId}
+          id of this block is {blockEntity?.metadata.recordId.entityId}
         </>
       </h1>
       <h2>Block-handled name editing</h2>
@@ -86,7 +86,7 @@ export const TestReactBlock: BlockComponent = ({ graph }) => {
           try {
             const { data, errors } = await graphService!.updateEntity({
               data: {
-                entityId: blockEntity.metadata.recordId.baseId,
+                entityId: blockEntity.metadata.recordId.entityId,
                 entityTypeId: blockEntity.metadata.entityTypeId,
                 properties: {
                   ...blockEntity.properties,

--- a/libs/mock-block-dock/src/data/entities.ts
+++ b/libs/mock-block-dock/src/data/entities.ts
@@ -9,7 +9,7 @@ const createPerson = (entityId: number): Entity => {
   const name = personNames[entityId] ?? "Unknown Person";
   return {
     metadata: {
-      editionId: {
+      recordId: {
         baseId: `person-${entityId.toString()}`,
         versionId: new Date().toISOString(),
       },
@@ -28,7 +28,7 @@ const createCompany = (entityId: number): Entity => {
   const name = companyNames[entityId] ?? "Unknown Company";
   return {
     metadata: {
-      editionId: {
+      recordId: {
         baseId: `company-${entityId.toString()}`,
         versionId: new Date().toISOString(),
       },
@@ -49,7 +49,7 @@ const createWorksForLink = (
 ): Entity => {
   return {
     metadata: {
-      editionId: {
+      recordId: {
         baseId: `${sourceEntityId}-works-for-${destinationEntityId}`,
         versionId: new Date().toISOString(),
       },
@@ -69,7 +69,7 @@ const createFounderOfLink = (
 ): Entity => {
   return {
     metadata: {
-      editionId: {
+      recordId: {
         baseId: `${sourceEntityId}-founder-of-${destinationEntityId}`,
         versionId: new Date().toISOString(),
       },
@@ -105,8 +105,8 @@ const createEntities = (): Entity[] => {
     if (founder) {
       entities.push(
         createFounderOfLink(
-          founder.metadata.editionId.baseId,
-          company.metadata.editionId.baseId,
+          founder.metadata.recordId.baseId,
+          company.metadata.recordId.baseId,
         ),
       );
       entities.push(founder);
@@ -115,9 +115,9 @@ const createEntities = (): Entity[] => {
   for (const person of people) {
     entities.push(
       createWorksForLink(
-        person.metadata.editionId.baseId,
+        person.metadata.recordId.baseId,
         companies[Math.floor(Math.random() * companies.length)]!.metadata
-          .editionId.baseId,
+          .recordId.baseId,
       ),
     );
   }

--- a/libs/mock-block-dock/src/data/entities.ts
+++ b/libs/mock-block-dock/src/data/entities.ts
@@ -10,8 +10,8 @@ const createPerson = (entityId: number): Entity => {
   return {
     metadata: {
       recordId: {
-        baseId: `person-${entityId.toString()}`,
-        versionId: new Date().toISOString(),
+        entityId: `person-${entityId.toString()}`,
+        editionId: new Date().toISOString(),
       },
       entityTypeId: entityTypes.person.$id,
     },
@@ -29,8 +29,8 @@ const createCompany = (entityId: number): Entity => {
   return {
     metadata: {
       recordId: {
-        baseId: `company-${entityId.toString()}`,
-        versionId: new Date().toISOString(),
+        entityId: `company-${entityId.toString()}`,
+        editionId: new Date().toISOString(),
       },
       entityTypeId: entityTypes.company.$id,
     },
@@ -50,8 +50,8 @@ const createWorksForLink = (
   return {
     metadata: {
       recordId: {
-        baseId: `${sourceEntityId}-works-for-${destinationEntityId}`,
-        versionId: new Date().toISOString(),
+        entityId: `${sourceEntityId}-works-for-${destinationEntityId}`,
+        editionId: new Date().toISOString(),
       },
       entityTypeId: entityTypes.worksFor.$id,
     },
@@ -70,8 +70,8 @@ const createFounderOfLink = (
   return {
     metadata: {
       recordId: {
-        baseId: `${sourceEntityId}-founder-of-${destinationEntityId}`,
-        versionId: new Date().toISOString(),
+        entityId: `${sourceEntityId}-founder-of-${destinationEntityId}`,
+        editionId: new Date().toISOString(),
       },
       entityTypeId: entityTypes.founderOf.$id,
     },
@@ -105,8 +105,8 @@ const createEntities = (): Entity[] => {
     if (founder) {
       entities.push(
         createFounderOfLink(
-          founder.metadata.recordId.baseId,
-          company.metadata.recordId.baseId,
+          founder.metadata.recordId.entityId,
+          company.metadata.recordId.entityId,
         ),
       );
       entities.push(founder);
@@ -115,9 +115,9 @@ const createEntities = (): Entity[] => {
   for (const person of people) {
     entities.push(
       createWorksForLink(
-        person.metadata.recordId.baseId,
+        person.metadata.recordId.entityId,
         companies[Math.floor(Math.random() * companies.length)]!.metadata
-          .recordId.baseId,
+          .recordId.entityId,
       ),
     );
   }

--- a/libs/mock-block-dock/src/datastore/hook-implementations/entity/aggregate-entities.ts
+++ b/libs/mock-block-dock/src/datastore/hook-implementations/entity/aggregate-entities.ts
@@ -28,7 +28,11 @@ export const aggregateEntities = (
   );
 
   const subgraph = {
-    roots: results.map((entity) => entity.metadata.recordId),
+    /** @todo - This is temporary, and wrong */
+    roots: results.map((entity) => ({
+      baseId: entity.metadata.recordId.baseId,
+      revisionId: entity.metadata.recordId.versionId,
+    })),
     vertices: {},
     edges: {},
     depths: graphResolveDepths,

--- a/libs/mock-block-dock/src/datastore/hook-implementations/entity/aggregate-entities.ts
+++ b/libs/mock-block-dock/src/datastore/hook-implementations/entity/aggregate-entities.ts
@@ -28,18 +28,18 @@ export const aggregateEntities = (
   );
 
   const subgraph = {
-    roots: results.map((entity) => entity.metadata.editionId),
+    roots: results.map((entity) => entity.metadata.recordId),
     vertices: {},
     edges: {},
     depths: graphResolveDepths,
   };
 
   for (const {
-    metadata: { editionId },
+    metadata: { recordId },
   } of results) {
     traverseElement(
       subgraph,
-      editionId,
+      recordId,
       graph,
       new TraversalContext(graph),
       graphResolveDepths,

--- a/libs/mock-block-dock/src/datastore/hook-implementations/entity/aggregate-entities.ts
+++ b/libs/mock-block-dock/src/datastore/hook-implementations/entity/aggregate-entities.ts
@@ -30,8 +30,8 @@ export const aggregateEntities = (
   const subgraph = {
     /** @todo - This is temporary, and wrong */
     roots: results.map((entity) => ({
-      baseId: entity.metadata.recordId.baseId,
-      revisionId: entity.metadata.recordId.versionId,
+      baseId: entity.metadata.recordId.entityId,
+      revisionId: entity.metadata.recordId.editionId,
     })),
     vertices: {},
     edges: {},
@@ -43,7 +43,11 @@ export const aggregateEntities = (
   } of results) {
     traverseElement(
       subgraph,
-      recordId,
+      /** @todo - This is temporary, and wrong */
+      {
+        baseId: recordId.entityId,
+        revisionId: recordId.editionId,
+      },
       graph,
       new TraversalContext(graph),
       graphResolveDepths,

--- a/libs/mock-block-dock/src/datastore/hook-implementations/entity/aggregate-entities.ts
+++ b/libs/mock-block-dock/src/datastore/hook-implementations/entity/aggregate-entities.ts
@@ -1,8 +1,8 @@
 import {
   AggregateEntitiesData,
   AggregateEntitiesResult,
+  EntityRootedSubgraph,
   Subgraph,
-  SubgraphRootTypes,
 } from "@blockprotocol/graph";
 import { getEntities } from "@blockprotocol/graph/stdlib";
 
@@ -19,7 +19,7 @@ export const aggregateEntities = (
     },
   }: AggregateEntitiesData,
   graph: Subgraph,
-): AggregateEntitiesResult<Subgraph<SubgraphRootTypes["entity"]>> => {
+): AggregateEntitiesResult<EntityRootedSubgraph> => {
   const { results, operation: appliedOperation } = filterAndSortEntitiesOrTypes(
     getEntities(graph),
     {

--- a/libs/mock-block-dock/src/datastore/hook-implementations/entity/aggregate-entities.ts
+++ b/libs/mock-block-dock/src/datastore/hook-implementations/entity/aggregate-entities.ts
@@ -1,7 +1,7 @@
 import {
   AggregateEntitiesData,
   AggregateEntitiesResult,
-  EntityRootedSubgraph,
+  EntityRootType,
   Subgraph,
 } from "@blockprotocol/graph";
 import { getEntities } from "@blockprotocol/graph/stdlib";
@@ -19,7 +19,7 @@ export const aggregateEntities = (
     },
   }: AggregateEntitiesData,
   graph: Subgraph,
-): AggregateEntitiesResult<EntityRootedSubgraph> => {
+): AggregateEntitiesResult<Subgraph<EntityRootType>> => {
   const { results, operation: appliedOperation } = filterAndSortEntitiesOrTypes(
     getEntities(graph),
     {

--- a/libs/mock-block-dock/src/datastore/hook-implementations/entity/get-entity.ts
+++ b/libs/mock-block-dock/src/datastore/hook-implementations/entity/get-entity.ts
@@ -25,7 +25,13 @@ export const getEntity = (
   }
 
   const subgraph = {
-    roots: [entityRevision.metadata.recordId],
+    /** @todo - This is temporary, and wrong */
+    roots: [
+      {
+        baseId: entityRevision.metadata.recordId.baseId,
+        revisionId: entityRevision.metadata.recordId.versionId,
+      },
+    ],
     vertices: {},
     edges: {},
     depths: graphResolveDepths,

--- a/libs/mock-block-dock/src/datastore/hook-implementations/entity/get-entity.ts
+++ b/libs/mock-block-dock/src/datastore/hook-implementations/entity/get-entity.ts
@@ -28,8 +28,8 @@ export const getEntity = (
     /** @todo - This is temporary, and wrong */
     roots: [
       {
-        baseId: entityRevision.metadata.recordId.baseId,
-        revisionId: entityRevision.metadata.recordId.versionId,
+        baseId: entityRevision.metadata.recordId.entityId,
+        revisionId: entityRevision.metadata.recordId.editionId,
       },
     ],
     vertices: {},
@@ -39,7 +39,11 @@ export const getEntity = (
 
   traverseElement(
     subgraph,
-    entityRevision.metadata.recordId,
+    /** @todo - This is temporary, and wrong */
+    {
+      baseId: entityRevision.metadata.recordId.entityId,
+      revisionId: entityRevision.metadata.recordId.editionId,
+    },
     graph,
     new TraversalContext(graph),
     graphResolveDepths,

--- a/libs/mock-block-dock/src/datastore/hook-implementations/entity/get-entity.ts
+++ b/libs/mock-block-dock/src/datastore/hook-implementations/entity/get-entity.ts
@@ -18,14 +18,14 @@ export const getEntity = (
   }: GetEntityData,
   graph: Subgraph,
 ): Subgraph<SubgraphRootTypes["entity"]> | undefined => {
-  const entityEdition = getEntityFromSubgraph(graph, entityId);
+  const entityRevision = getEntityFromSubgraph(graph, entityId);
 
-  if (entityEdition === undefined) {
+  if (entityRevision === undefined) {
     return undefined;
   }
 
   const subgraph = {
-    roots: [entityEdition.metadata.editionId],
+    roots: [entityRevision.metadata.recordId],
     vertices: {},
     edges: {},
     depths: graphResolveDepths,
@@ -33,7 +33,7 @@ export const getEntity = (
 
   traverseElement(
     subgraph,
-    entityEdition.metadata.editionId,
+    entityRevision.metadata.recordId,
     graph,
     new TraversalContext(graph),
     graphResolveDepths,

--- a/libs/mock-block-dock/src/datastore/hook-implementations/entity/get-entity.ts
+++ b/libs/mock-block-dock/src/datastore/hook-implementations/entity/get-entity.ts
@@ -1,8 +1,4 @@
-import {
-  EntityRootedSubgraph,
-  GetEntityData,
-  Subgraph,
-} from "@blockprotocol/graph";
+import { EntityRootType, GetEntityData, Subgraph } from "@blockprotocol/graph";
 import { getEntity as getEntityFromSubgraph } from "@blockprotocol/graph/stdlib";
 
 import { traverseElement } from "../../traverse";
@@ -17,7 +13,7 @@ export const getEntity = (
     },
   }: GetEntityData,
   graph: Subgraph,
-): EntityRootedSubgraph | undefined => {
+): Subgraph<EntityRootType> | undefined => {
   const entityRevision = getEntityFromSubgraph(graph, entityId);
 
   if (entityRevision === undefined) {

--- a/libs/mock-block-dock/src/datastore/hook-implementations/entity/get-entity.ts
+++ b/libs/mock-block-dock/src/datastore/hook-implementations/entity/get-entity.ts
@@ -1,7 +1,7 @@
 import {
+  EntityRootedSubgraph,
   GetEntityData,
   Subgraph,
-  SubgraphRootTypes,
 } from "@blockprotocol/graph";
 import { getEntity as getEntityFromSubgraph } from "@blockprotocol/graph/stdlib";
 
@@ -17,7 +17,7 @@ export const getEntity = (
     },
   }: GetEntityData,
   graph: Subgraph,
-): Subgraph<SubgraphRootTypes["entity"]> | undefined => {
+): EntityRootedSubgraph | undefined => {
   const entityRevision = getEntityFromSubgraph(graph, entityId);
 
   if (entityRevision === undefined) {

--- a/libs/mock-block-dock/src/datastore/traverse.ts
+++ b/libs/mock-block-dock/src/datastore/traverse.ts
@@ -1,10 +1,10 @@
 import {
-  EntityEditionId,
   EntityId,
+  EntityRecordId,
   HasLeftEntityEdge,
   HasRightEntityEdge,
   IncomingLinkEdge,
-  OntologyTypeEditionId,
+  OntologyTypeRecordId,
   OutgoingLinkEdge,
   Subgraph,
 } from "@blockprotocol/graph";
@@ -25,7 +25,7 @@ import { PartialDepths, TraversalContext } from "./traverse/traversal-context";
 /** @todo - Update this to handle ontology edges */
 export const traverseElement = (
   traversalSubgraph: Subgraph,
-  elementIdentifier: EntityEditionId | OntologyTypeEditionId,
+  elementIdentifier: EntityRecordId | OntologyTypeRecordId,
   datastore: Subgraph,
   traversalContext: TraversalContext,
   currentTraversalDepths: PartialDepths,
@@ -50,12 +50,12 @@ export const traverseElement = (
     );
   }
 
-  const editionsInTraversalSubgraph =
+  const revisionsInTraversalSubgraph =
     traversalSubgraph.vertices[elementIdentifier.baseId];
 
   // `any` casts here are because TypeScript wants us to narrow the Identifier type before trusting us
-  if (editionsInTraversalSubgraph) {
-    (editionsInTraversalSubgraph as any)[elementIdentifier.versionId] = element;
+  if (revisionsInTraversalSubgraph) {
+    (revisionsInTraversalSubgraph as any)[elementIdentifier.versionId] = element;
   } else {
     // eslint-disable-next-line no-param-reassign -- The point of this function is to mutate the subgraph
     (traversalSubgraph as any).vertices[elementIdentifier.baseId] = {
@@ -81,7 +81,7 @@ export const traverseElement = (
             )) {
               const {
                 metadata: {
-                  editionId: {
+                  recordId: {
                     baseId: outgoingLinkEntityId,
                     versionId: edgeTimestamp,
                   },
@@ -104,7 +104,7 @@ export const traverseElement = (
                 outgoingLinkEdge,
               );
 
-              toResolve.insert(outgoingLinkEntity.metadata.editionId, {
+              toResolve.insert(outgoingLinkEntity.metadata.recordId, {
                 [edgeKind]: { incoming: depths.incoming - 1 },
               });
             }
@@ -122,7 +122,7 @@ export const traverseElement = (
               );
               const {
                 metadata: {
-                  editionId: { baseId: leftEntityId, versionId: edgeTimestamp },
+                  recordId: { baseId: leftEntityId, versionId: edgeTimestamp },
                 },
               } = leftEntity;
 
@@ -142,7 +142,7 @@ export const traverseElement = (
                 hasLeftEntityEdge,
               );
 
-              toResolve.insert(leftEntity.metadata.editionId, {
+              toResolve.insert(leftEntity.metadata.recordId, {
                 [edgeKind]: { outgoing: depths.outgoing - 1 },
               });
             }
@@ -161,7 +161,7 @@ export const traverseElement = (
             )) {
               const {
                 metadata: {
-                  editionId: {
+                  recordId: {
                     baseId: incomingLinkEntityId,
                     versionId: edgeTimestamp,
                   },
@@ -184,7 +184,7 @@ export const traverseElement = (
                 incomingLinkEdge,
               );
 
-              toResolve.insert(incomingLinkEntity.metadata.editionId, {
+              toResolve.insert(incomingLinkEntity.metadata.recordId, {
                 [edgeKind]: { incoming: depths.incoming - 1 },
               });
             }
@@ -202,10 +202,7 @@ export const traverseElement = (
               );
               const {
                 metadata: {
-                  editionId: {
-                    baseId: rightEntityId,
-                    versionId: edgeTimestamp,
-                  },
+                  recordId: { baseId: rightEntityId, versionId: edgeTimestamp },
                 },
               } = rightEntity;
 
@@ -225,7 +222,7 @@ export const traverseElement = (
                 hasLeftEntityEdge,
               );
 
-              toResolve.insert(rightEntity.metadata.editionId, {
+              toResolve.insert(rightEntity.metadata.recordId, {
                 [edgeKind]: { outgoing: depths.outgoing - 1 },
               });
             }
@@ -242,8 +239,8 @@ export const traverseElement = (
     traverseElement(
       traversalSubgraph,
       JSON.parse(siblingElementIdentifierString) as
-        | EntityEditionId
-        | OntologyTypeEditionId,
+        | EntityRecordId
+        | OntologyTypeRecordId,
       datastore,
       traversalContext,
       depths.inner,

--- a/libs/mock-block-dock/src/datastore/traverse/resolve-map.ts
+++ b/libs/mock-block-dock/src/datastore/traverse/resolve-map.ts
@@ -1,4 +1,8 @@
-import { EntityRecordId, OntologyTypeRecordId } from "@blockprotocol/graph";
+import {
+  EntityRecordId,
+  GraphElementVertexId,
+  OntologyTypeRecordId,
+} from "@blockprotocol/graph";
 
 import { Depths, PartialDepths } from "./traversal-context";
 
@@ -21,7 +25,7 @@ export class ResolveMap {
    * @returns {PartialDepths} - the depths which where greater or missing for the given element
    */
   insert(
-    identifier: EntityRecordId | OntologyTypeRecordId,
+    identifier: GraphElementVertexId,
     depths: PartialDepths,
   ): PartialDepths {
     const idString = JSON.stringify(identifier);

--- a/libs/mock-block-dock/src/datastore/traverse/resolve-map.ts
+++ b/libs/mock-block-dock/src/datastore/traverse/resolve-map.ts
@@ -1,4 +1,4 @@
-import { EntityEditionId, OntologyTypeEditionId } from "@blockprotocol/graph";
+import { EntityRecordId, OntologyTypeRecordId } from "@blockprotocol/graph";
 
 import { Depths, PartialDepths } from "./traversal-context";
 
@@ -21,7 +21,7 @@ export class ResolveMap {
    * @returns {PartialDepths} - the depths which where greater or missing for the given element
    */
   insert(
-    identifier: EntityEditionId | OntologyTypeEditionId,
+    identifier: EntityRecordId | OntologyTypeRecordId,
     depths: PartialDepths,
   ): PartialDepths {
     const idString = JSON.stringify(identifier);

--- a/libs/mock-block-dock/src/datastore/traverse/resolve-map.ts
+++ b/libs/mock-block-dock/src/datastore/traverse/resolve-map.ts
@@ -1,8 +1,4 @@
-import {
-  EntityRecordId,
-  GraphElementVertexId,
-  OntologyTypeRecordId,
-} from "@blockprotocol/graph";
+import { GraphElementVertexId } from "@blockprotocol/graph";
 
 import { Depths, PartialDepths } from "./traversal-context";
 

--- a/libs/mock-block-dock/src/datastore/traverse/traversal-context.ts
+++ b/libs/mock-block-dock/src/datastore/traverse/traversal-context.ts
@@ -1,7 +1,7 @@
 import {
-  EntityEditionId,
+  EntityRecordId,
   GraphResolveDepths,
-  OntologyTypeEditionId,
+  OntologyTypeRecordId,
   Subgraph,
 } from "@blockprotocol/graph";
 
@@ -88,7 +88,7 @@ export class TraversalContext {
    * @returns {PartialDepths} - the depths which hadn't been fully resolved yet while traversing
    */
   insert(
-    identifier: EntityEditionId | OntologyTypeEditionId,
+    identifier: EntityRecordId | OntologyTypeRecordId,
     depths: PartialDepths,
   ): PartialDepths {
     return this.resolveMap.insert(identifier, depths);

--- a/libs/mock-block-dock/src/datastore/traverse/traversal-context.ts
+++ b/libs/mock-block-dock/src/datastore/traverse/traversal-context.ts
@@ -1,5 +1,5 @@
 import {
-  EntityRecordId,
+  EntityRecordId, GraphElementVertexId,
   GraphResolveDepths,
   OntologyTypeRecordId,
   Subgraph,
@@ -88,7 +88,7 @@ export class TraversalContext {
    * @returns {PartialDepths} - the depths which hadn't been fully resolved yet while traversing
    */
   insert(
-    identifier: EntityRecordId | OntologyTypeRecordId,
+    identifier: GraphElementVertexId,
     depths: PartialDepths,
   ): PartialDepths {
     return this.resolveMap.insert(identifier, depths);

--- a/libs/mock-block-dock/src/datastore/traverse/traversal-context.ts
+++ b/libs/mock-block-dock/src/datastore/traverse/traversal-context.ts
@@ -1,7 +1,6 @@
 import {
-  EntityRecordId, GraphElementVertexId,
+  GraphElementVertexId,
   GraphResolveDepths,
-  OntologyTypeRecordId,
   Subgraph,
 } from "@blockprotocol/graph";
 

--- a/libs/mock-block-dock/src/datastore/use-mock-datastore.ts
+++ b/libs/mock-block-dock/src/datastore/use-mock-datastore.ts
@@ -89,8 +89,8 @@ export const useMockDatastore = (
         const newEntity: Entity = {
           metadata: {
             recordId: {
-              baseId: entityId,
-              versionId: new Date().toISOString(),
+              entityId,
+              editionId: new Date().toISOString(),
             },
             entityTypeId,
           },
@@ -223,8 +223,8 @@ export const useMockDatastore = (
             const updatedEntity: Entity = {
               metadata: {
                 recordId: {
-                  baseId: entityId,
-                  versionId: new Date().toISOString(),
+                  entityId,
+                  editionId: new Date().toISOString(),
                 },
                 entityTypeId,
               },

--- a/libs/mock-block-dock/src/datastore/use-mock-datastore.ts
+++ b/libs/mock-block-dock/src/datastore/use-mock-datastore.ts
@@ -88,7 +88,7 @@ export const useMockDatastore = (
         const { entityTypeId, properties, linkData } = data;
         const newEntity: Entity = {
           metadata: {
-            editionId: {
+            recordId: {
               baseId: entityId,
               versionId: new Date().toISOString(),
             },
@@ -222,7 +222,7 @@ export const useMockDatastore = (
 
             const updatedEntity: Entity = {
               metadata: {
-                editionId: {
+                recordId: {
                   baseId: entityId,
                   versionId: new Date().toISOString(),
                 },

--- a/libs/mock-block-dock/src/debug-view/dev-tools/datastore-graph-visualization.tsx
+++ b/libs/mock-block-dock/src/debug-view/dev-tools/datastore-graph-visualization.tsx
@@ -1,6 +1,6 @@
 import {
   Entity,
-  EntityEditionId,
+  EntityRecordId,
   isHasRightEntityEdge,
   isOutgoingLinkEdge,
   OutwardEdge,
@@ -24,7 +24,7 @@ import { typedEntries } from "../../util";
 const parseLabelFromEntity = (entityToLabel: Entity, subgraph: Subgraph) => {
   const getFallbackLabel = () => {
     // fallback to the entity type and a few characters of the entityUuid
-    const entityId = entityToLabel.metadata.editionId.baseId;
+    const entityId = entityToLabel.metadata.recordId.baseId;
 
     const entityType = getEntityTypeById(
       subgraph,
@@ -138,7 +138,7 @@ const mapEntityToEChartNode = (
   entity: Entity,
   subgraph: Subgraph,
 ): EChartNode => ({
-  id: JSON.stringify(entity.metadata.editionId),
+  id: JSON.stringify(entity.metadata.recordId),
   name: parseLabelFromEntity(entity, subgraph),
   label: { show: false },
 });
@@ -155,16 +155,16 @@ type EChartEdge = {
 
 /** todo - render ontology-related edges */
 const mapGraphEdgeToEChartEdge = (
-  sourceEditionId: EntityEditionId,
-  targetEditionId: EntityEditionId,
+  sourceRecordId: EntityRecordId,
+  targetRecordId: EntityRecordId,
   edgeKind: OutwardEdge["kind"],
 ): EChartEdge => ({
   /** @todo - Can we do better than this, this assumes that this triple is unique, which it might not be */
-  id: `${JSON.stringify(sourceEditionId)}-${edgeKind}->${JSON.stringify(
-    targetEditionId,
+  id: `${JSON.stringify(sourceRecordId)}-${edgeKind}->${JSON.stringify(
+    targetRecordId,
   )}`,
-  source: JSON.stringify(sourceEditionId),
-  target: JSON.stringify(targetEditionId),
+  source: JSON.stringify(sourceRecordId),
+  target: JSON.stringify(targetRecordId),
   kind: edgeKind,
   label: { show: false },
 });
@@ -207,26 +207,26 @@ const getSubgraphEdgesAsEChartEdges = (subgraph: Subgraph): EChartEdge[] =>
         return sourceVersions.flatMap((sourceVersion) =>
           targetVersions
             .flatMap((targetVersion) => {
-              const sourceEditionId = {
+              const sourceRecordId = {
                 baseId: sourceBaseId,
                 versionId: sourceVersion,
               };
 
-              const targetEditionId = {
+              const targetRecordId = {
                 baseId: outwardEdge.rightEndpoint.baseId,
                 versionId: targetVersion,
               };
 
               if (isOutgoingLinkEdge(outwardEdge)) {
                 return mapGraphEdgeToEChartEdge(
-                  sourceEditionId,
-                  targetEditionId,
+                  sourceRecordId,
+                  targetRecordId,
                   outwardEdge.kind,
                 );
               } else if (isHasRightEntityEdge(outwardEdge)) {
                 return mapGraphEdgeToEChartEdge(
-                  sourceEditionId,
-                  targetEditionId,
+                  sourceRecordId,
+                  targetRecordId,
                   outwardEdge.kind,
                 );
               }
@@ -279,13 +279,13 @@ export const DatastoreGraphVisualization = () => {
     setEChartEdges(getSubgraphEdgesAsEChartEdges(graph));
   }, [graph]);
 
-  const [selectedEntityEditionIdString, setSelectedEntityEditionIdString] =
+  const [selectedEntityRecordIdString, setSelectedEntityRecordIdString] =
     useState<string>();
 
   /** @todo: un-comment if we want to display something about the currently selected entity */
   // const selectedEntity = useMemo(
-  //   () => entities.find(({ entityId }) => entityId === selectedEntityEditionIdString),
-  //   [entities, selectedEntityEditionIdString],
+  //   () => entities.find(({ entityId }) => entityId === selectedEntityRecordIdString),
+  //   [entities, selectedEntityRecordIdString],
   // );
 
   useEffect(() => {
@@ -301,21 +301,21 @@ export const DatastoreGraphVisualization = () => {
   }, [chart, eChartEdges]);
 
   useEffect(() => {
-    if (chart && selectedEntityEditionIdString) {
+    if (chart && selectedEntityRecordIdString) {
       const outgoingLinkAndTargetEntities = getOutgoingLinkAndTargetEntities(
         graph,
-        (JSON.parse(selectedEntityEditionIdString) as EntityEditionId).baseId,
+        (JSON.parse(selectedEntityRecordIdString) as EntityRecordId).baseId,
       );
 
       const neighbourIds = outgoingLinkAndTargetEntities.flatMap(
         ({ linkEntity, rightEntity }) => [
-          JSON.stringify(linkEntity.metadata.editionId),
-          JSON.stringify(rightEntity.metadata.editionId),
+          JSON.stringify(linkEntity.metadata.recordId),
+          JSON.stringify(rightEntity.metadata.recordId),
         ],
       );
 
       const nodesWithVisibleLabelsIds = [
-        selectedEntityEditionIdString,
+        selectedEntityRecordIdString,
         ...neighbourIds,
       ];
 
@@ -338,14 +338,14 @@ export const DatastoreGraphVisualization = () => {
         })),
       );
     }
-  }, [chart, graph, selectedEntityEditionIdString]);
+  }, [chart, graph, selectedEntityRecordIdString]);
 
   useEffect(() => {
     if (!chart && eChartWrapperRef.current) {
       const initialisedChart = echarts.init(eChartWrapperRef.current);
 
       initialisedChart.on("click", { dataType: "node" }, ({ data: node }) =>
-        setSelectedEntityEditionIdString((node as EChartNode).id),
+        setSelectedEntityRecordIdString((node as EChartNode).id),
       );
 
       const initialOptions = createDefaultEChartOptions();

--- a/libs/mock-block-dock/src/debug-view/dev-tools/entity-switcher.tsx
+++ b/libs/mock-block-dock/src/debug-view/dev-tools/entity-switcher.tsx
@@ -40,7 +40,7 @@ export const EntitySwitcher = () => {
   );
   const [entityId, setEntityIdOfProposedEntityForBlock] = useState<
     string | undefined
-  >(blockEntity.metadata.recordId.baseId);
+  >(blockEntity.metadata.recordId.entityId);
 
   const selectedEntity = useMemo(
     () => (entityId ? getEntity(graph, entityId)! : blockEntity),
@@ -155,10 +155,10 @@ export const EntitySwitcher = () => {
                 )
                 .map((entity) => (
                   <MenuItem
-                    key={entity.metadata.recordId.baseId}
-                    value={entity.metadata.recordId.baseId}
+                    key={entity.metadata.recordId.entityId}
+                    value={entity.metadata.recordId.entityId}
                   >
-                    {entity.metadata.recordId.baseId}
+                    {entity.metadata.recordId.entityId}
                   </MenuItem>
                 ))}
             </Select>

--- a/libs/mock-block-dock/src/debug-view/dev-tools/entity-switcher.tsx
+++ b/libs/mock-block-dock/src/debug-view/dev-tools/entity-switcher.tsx
@@ -27,7 +27,7 @@ import { JsonView } from "./json-view";
 export const EntitySwitcher = () => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
-  const { blockEntitySubgraph, setEntityEditionIdOfEntityForBlock, graph } =
+  const { blockEntitySubgraph, setEntityRecordIdOfEntityForBlock, graph } =
     useMockBlockDockContext();
 
   const blockEntity = useMemo(
@@ -40,7 +40,7 @@ export const EntitySwitcher = () => {
   );
   const [entityId, setEntityIdOfProposedEntityForBlock] = useState<
     string | undefined
-  >(blockEntity.metadata.editionId.baseId);
+  >(blockEntity.metadata.recordId.baseId);
 
   const selectedEntity = useMemo(
     () => (entityId ? getEntity(graph, entityId)! : blockEntity),
@@ -57,7 +57,7 @@ export const EntitySwitcher = () => {
 
   const handleSubmit = () => {
     if (selectedEntity) {
-      setEntityEditionIdOfEntityForBlock(selectedEntity.metadata.editionId);
+      setEntityRecordIdOfEntityForBlock(selectedEntity.metadata.recordId);
     }
     closePopover();
   };
@@ -155,10 +155,10 @@ export const EntitySwitcher = () => {
                 )
                 .map((entity) => (
                   <MenuItem
-                    key={entity.metadata.editionId.baseId}
-                    value={entity.metadata.editionId.baseId}
+                    key={entity.metadata.recordId.baseId}
+                    value={entity.metadata.recordId.baseId}
                   >
-                    {entity.metadata.editionId.baseId}
+                    {entity.metadata.recordId.baseId}
                   </MenuItem>
                 ))}
             </Select>

--- a/libs/mock-block-dock/src/debug-view/dev-tools/entity-switcher.tsx
+++ b/libs/mock-block-dock/src/debug-view/dev-tools/entity-switcher.tsx
@@ -1,3 +1,4 @@
+import { SubgraphRootTypes } from "@blockprotocol/graph";
 import {
   getEntities,
   getEntity,
@@ -31,7 +32,10 @@ export const EntitySwitcher = () => {
     useMockBlockDockContext();
 
   const blockEntity = useMemo(
-    () => getRoots(blockEntitySubgraph)[0]!,
+    /**
+     * @todo - We shouldn't need to manually pass in the generic here, `blockEntitySubgraph` is typed as an `EntityRootedSubgraph`
+     */
+    () => getRoots<SubgraphRootTypes["entity"]>(blockEntitySubgraph)[0]!,
     [blockEntitySubgraph],
   );
 

--- a/libs/mock-block-dock/src/debug-view/dev-tools/entity-switcher.tsx
+++ b/libs/mock-block-dock/src/debug-view/dev-tools/entity-switcher.tsx
@@ -1,4 +1,3 @@
-import { SubgraphRootTypes } from "@blockprotocol/graph";
 import {
   getEntities,
   getEntity,
@@ -32,10 +31,7 @@ export const EntitySwitcher = () => {
     useMockBlockDockContext();
 
   const blockEntity = useMemo(
-    /**
-     * @todo - We shouldn't need to manually pass in the generic here, `blockEntitySubgraph` is typed as an `EntityRootedSubgraph`
-     */
-    () => getRoots<SubgraphRootTypes["entity"]>(blockEntitySubgraph)[0]!,
+    () => getRoots(blockEntitySubgraph)[0]!,
     [blockEntitySubgraph],
   );
 

--- a/libs/mock-block-dock/src/debug-view/dev-tools/properties.tsx
+++ b/libs/mock-block-dock/src/debug-view/dev-tools/properties.tsx
@@ -84,7 +84,7 @@ export const PropertiesView = () => {
                   const entity = args.updated_src as Entity;
                   void updateEntity({
                     data: {
-                      entityId: entity.metadata.editionId.baseId,
+                      entityId: entity.metadata.recordId.baseId,
                       entityTypeId: entity.metadata.entityTypeId,
                       properties: entity.properties,
                       leftToRightOrder: entity.linkData?.leftToRightOrder,
@@ -100,7 +100,7 @@ export const PropertiesView = () => {
                   const entity = args.updated_src as Entity;
                   void updateEntity({
                     data: {
-                      entityId: entity.metadata.editionId.baseId,
+                      entityId: entity.metadata.recordId.baseId,
                       entityTypeId: entity.metadata.entityTypeId,
                       properties: entity.properties,
                       leftToRightOrder: entity.linkData?.leftToRightOrder,
@@ -116,7 +116,7 @@ export const PropertiesView = () => {
                   const entity = args.updated_src as Entity;
                   void updateEntity({
                     data: {
-                      entityId: entity.metadata.editionId.baseId,
+                      entityId: entity.metadata.recordId.baseId,
                       entityTypeId: entity.metadata.entityTypeId,
                       properties: entity.properties,
                       leftToRightOrder: entity.linkData?.leftToRightOrder,

--- a/libs/mock-block-dock/src/debug-view/dev-tools/properties.tsx
+++ b/libs/mock-block-dock/src/debug-view/dev-tools/properties.tsx
@@ -84,7 +84,7 @@ export const PropertiesView = () => {
                   const entity = args.updated_src as Entity;
                   void updateEntity({
                     data: {
-                      entityId: entity.metadata.recordId.baseId,
+                      entityId: entity.metadata.recordId.entityId,
                       entityTypeId: entity.metadata.entityTypeId,
                       properties: entity.properties,
                       leftToRightOrder: entity.linkData?.leftToRightOrder,
@@ -100,7 +100,7 @@ export const PropertiesView = () => {
                   const entity = args.updated_src as Entity;
                   void updateEntity({
                     data: {
-                      entityId: entity.metadata.recordId.baseId,
+                      entityId: entity.metadata.recordId.entityId,
                       entityTypeId: entity.metadata.entityTypeId,
                       properties: entity.properties,
                       leftToRightOrder: entity.linkData?.leftToRightOrder,
@@ -116,7 +116,7 @@ export const PropertiesView = () => {
                   const entity = args.updated_src as Entity;
                   void updateEntity({
                     data: {
-                      entityId: entity.metadata.recordId.baseId,
+                      entityId: entity.metadata.recordId.entityId,
                       entityTypeId: entity.metadata.entityTypeId,
                       properties: entity.properties,
                       leftToRightOrder: entity.linkData?.leftToRightOrder,

--- a/libs/mock-block-dock/src/debug-view/dev-tools/properties.tsx
+++ b/libs/mock-block-dock/src/debug-view/dev-tools/properties.tsx
@@ -1,4 +1,4 @@
-import { Entity } from "@blockprotocol/graph";
+import { Entity, SubgraphRootTypes } from "@blockprotocol/graph";
 import { getEntityTypeById, getRoots } from "@blockprotocol/graph/stdlib";
 import {
   Box,
@@ -23,7 +23,10 @@ export const PropertiesView = () => {
     useMockBlockDockContext();
 
   const blockEntity = useMemo(
-    () => getRoots(blockEntitySubgraph)[0]!,
+    /**
+     * @todo - We shouldn't need to manually pass in the generic here, `blockEntitySubgraph` is typed as an `EntityRootedSubgraph`
+     */
+    () => getRoots<SubgraphRootTypes["entity"]>(blockEntitySubgraph)[0]!,
     [blockEntitySubgraph],
   );
 

--- a/libs/mock-block-dock/src/debug-view/dev-tools/properties.tsx
+++ b/libs/mock-block-dock/src/debug-view/dev-tools/properties.tsx
@@ -1,4 +1,4 @@
-import { Entity, SubgraphRootTypes } from "@blockprotocol/graph";
+import { Entity } from "@blockprotocol/graph";
 import { getEntityTypeById, getRoots } from "@blockprotocol/graph/stdlib";
 import {
   Box,
@@ -23,10 +23,7 @@ export const PropertiesView = () => {
     useMockBlockDockContext();
 
   const blockEntity = useMemo(
-    /**
-     * @todo - We shouldn't need to manually pass in the generic here, `blockEntitySubgraph` is typed as an `EntityRootedSubgraph`
-     */
-    () => getRoots<SubgraphRootTypes["entity"]>(blockEntitySubgraph)[0]!,
+    () => getRoots(blockEntitySubgraph)[0]!,
     [blockEntitySubgraph],
   );
 

--- a/libs/mock-block-dock/src/mock-block-dock-context.tsx
+++ b/libs/mock-block-dock/src/mock-block-dock-context.tsx
@@ -1,7 +1,7 @@
 import { Message } from "@blockprotocol/core";
 import {
   EmbedderGraphMessageCallbacks,
-  EntityEditionId,
+  EntityRecordId,
   Subgraph,
   SubgraphRootTypes,
 } from "@blockprotocol/graph";
@@ -33,7 +33,7 @@ type MockBlockDockInfo = {
   logs: Message[];
   readonly: boolean;
   setDebugMode: Dispatch<SetStateAction<boolean>>;
-  setEntityEditionIdOfEntityForBlock: Dispatch<SetStateAction<EntityEditionId>>;
+  setEntityRecordIdOfEntityForBlock: Dispatch<SetStateAction<EntityRecordId>>;
   setLogs: Dispatch<SetStateAction<Message[]>>;
   setReadonly: Dispatch<SetStateAction<boolean>>;
   updateEntity: EmbedderGraphMessageCallbacks["updateEntity"];

--- a/libs/mock-block-dock/src/mock-block-dock-context.tsx
+++ b/libs/mock-block-dock/src/mock-block-dock-context.tsx
@@ -2,8 +2,8 @@ import { Message } from "@blockprotocol/core";
 import {
   EmbedderGraphMessageCallbacks,
   EntityRecordId,
-  EntityRootedSubgraph,
   Subgraph,
+  SubgraphRootTypes,
 } from "@blockprotocol/graph";
 import {
   createContext,
@@ -17,7 +17,7 @@ import {
 } from "react";
 
 type MockBlockDockInfo = {
-  blockEntitySubgraph: EntityRootedSubgraph;
+  blockEntitySubgraph: Subgraph<SubgraphRootTypes["entity"]>;
   blockInfo: {
     blockType: {
       entryPoint?: "react" | "html" | "custom-element" | string;

--- a/libs/mock-block-dock/src/mock-block-dock-context.tsx
+++ b/libs/mock-block-dock/src/mock-block-dock-context.tsx
@@ -2,8 +2,8 @@ import { Message } from "@blockprotocol/core";
 import {
   EmbedderGraphMessageCallbacks,
   EntityRecordId,
+  EntityRootType,
   Subgraph,
-  SubgraphRootTypes,
 } from "@blockprotocol/graph";
 import {
   createContext,
@@ -17,7 +17,7 @@ import {
 } from "react";
 
 type MockBlockDockInfo = {
-  blockEntitySubgraph: Subgraph<SubgraphRootTypes["entity"]>;
+  blockEntitySubgraph: Subgraph<EntityRootType>;
   blockInfo: {
     blockType: {
       entryPoint?: "react" | "html" | "custom-element" | string;

--- a/libs/mock-block-dock/src/mock-block-dock-context.tsx
+++ b/libs/mock-block-dock/src/mock-block-dock-context.tsx
@@ -2,8 +2,8 @@ import { Message } from "@blockprotocol/core";
 import {
   EmbedderGraphMessageCallbacks,
   EntityRecordId,
+  EntityRootedSubgraph,
   Subgraph,
-  SubgraphRootTypes,
 } from "@blockprotocol/graph";
 import {
   createContext,
@@ -17,7 +17,7 @@ import {
 } from "react";
 
 type MockBlockDockInfo = {
-  blockEntitySubgraph: Subgraph<SubgraphRootTypes["entity"]>;
+  blockEntitySubgraph: EntityRootedSubgraph;
   blockInfo: {
     blockType: {
       entryPoint?: "react" | "html" | "custom-element" | string;

--- a/libs/mock-block-dock/src/mock-block-dock.tsx
+++ b/libs/mock-block-dock/src/mock-block-dock.tsx
@@ -109,7 +109,7 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps> = ({
 
   const blockEntitySubgraph = getEntity(
     {
-      entityId: blockEntityRecordId.baseId,
+      entityId: blockEntityRecordId.entityId,
       graphResolveDepths: {
         hasLeftEntity: { incoming: 2, outgoing: 2 },
         hasRightEntity: { incoming: 2, outgoing: 2 },

--- a/libs/mock-block-dock/src/mock-block-dock.tsx
+++ b/libs/mock-block-dock/src/mock-block-dock.tsx
@@ -2,7 +2,7 @@ import { HtmlBlockDefinition } from "@blockprotocol/core";
 import {
   BlockGraphProperties,
   Entity,
-  EntityEditionId,
+  EntityRecordId,
 } from "@blockprotocol/graph";
 import { useGraphEmbedderService } from "@blockprotocol/graph/react";
 import { EmbedderHookMessageCallbacks, HookData } from "@blockprotocol/hook/.";
@@ -45,7 +45,7 @@ type BlockDefinition =
 
 type MockBlockDockProps = {
   blockDefinition: BlockDefinition;
-  blockEntityEditionId?: EntityEditionId;
+  blockEntityRecordId?: EntityRecordId;
   debug?: boolean;
   hideDebugToggle?: boolean;
   initialEntities?: Entity[];
@@ -69,7 +69,7 @@ type MockBlockDockProps = {
  * See README.md for usage instructions.
  * @param props component props
  * @param props.blockDefinition the source for the block and any additional metadata required
- * @param [props.blockEntityEditionId] the `EntityEditionId` of the starting block entity
+ * @param [props.blockEntityRecordId] the `EntityRecordId` of the starting block entity
  * @param [props.blockInfo] metadata about the block
  * @param [props.debug=false] display debugging information
  * @param [props.hideDebugToggle=false] hide the ability to toggle the debug UI
@@ -79,7 +79,7 @@ type MockBlockDockProps = {
  */
 export const MockBlockDock: FunctionComponent<MockBlockDockProps> = ({
   blockDefinition,
-  blockEntityEditionId: initialBlockEntityEditionId,
+  blockEntityRecordId: initialBlockEntityRecordId,
   blockInfo,
   debug: initialDebug = false,
   hideDebugToggle = false,
@@ -88,14 +88,14 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps> = ({
   readonly: initialReadonly = false,
 }) => {
   const {
-    blockEntityEditionId,
+    blockEntityRecordId,
     mockDatastore,
     // linkedAggregations,
     readonly,
-    setEntityEditionIdOfEntityForBlock,
+    setEntityRecordIdOfEntityForBlock,
     setReadonly,
   } = useMockBlockProps({
-    blockEntityEditionId: initialBlockEntityEditionId,
+    blockEntityRecordId: initialBlockEntityRecordId,
     initialEntities,
     // initialLinkedAggregations,
     readonly: !!initialReadonly,
@@ -109,7 +109,7 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps> = ({
 
   const blockEntitySubgraph = getEntity(
     {
-      entityId: blockEntityEditionId.baseId,
+      entityId: blockEntityRecordId.baseId,
       graphResolveDepths: {
         hasLeftEntity: { incoming: 2, outgoing: 2 },
         hasRightEntity: { incoming: 2, outgoing: 2 },
@@ -289,7 +289,7 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps> = ({
       readonly={readonly}
       setReadonly={setReadonly}
       setDebugMode={setDebugMode}
-      setEntityEditionIdOfEntityForBlock={setEntityEditionIdOfEntityForBlock}
+      setEntityRecordIdOfEntityForBlock={setEntityRecordIdOfEntityForBlock}
       updateEntity={graphServiceCallbacks.updateEntity}
     >
       <HookPortals hooks={hooks} />

--- a/libs/mock-block-dock/src/use-mock-block-props.ts
+++ b/libs/mock-block-dock/src/use-mock-block-props.ts
@@ -41,8 +41,8 @@ export const useMockBlockProps = ({
   const [entityRecordIdOfEntityForBlock, setEntityRecordIdOfEntityForBlock] =
     useDefaultState<EntityRecordId>(
       externalBlockEntityRecordId ?? {
-        baseId: "",
-        versionId: new Date().toISOString(),
+        entityId: "",
+        editionId: new Date().toISOString(),
       },
     );
 
@@ -68,10 +68,10 @@ export const useMockBlockProps = ({
     if (externalBlockEntityRecordId) {
       blockEntity = nextMockData.entities.find(
         (entity) =>
-          entity.metadata.recordId.baseId ===
-            externalBlockEntityRecordId.baseId &&
-          entity.metadata.recordId.versionId ===
-            externalBlockEntityRecordId.versionId,
+          entity.metadata.recordId.entityId ===
+            externalBlockEntityRecordId.entityId &&
+          entity.metadata.recordId.editionId ===
+            externalBlockEntityRecordId.editionId,
       );
 
       if (blockEntity === undefined) {

--- a/libs/mock-block-dock/src/use-mock-block-props.ts
+++ b/libs/mock-block-dock/src/use-mock-block-props.ts
@@ -1,4 +1,4 @@
-import { Entity, EntityEditionId } from "@blockprotocol/graph";
+import { Entity, EntityRecordId } from "@blockprotocol/graph";
 import { Dispatch, SetStateAction, useMemo } from "react";
 
 import { mockData as initialMockData } from "./data";
@@ -10,37 +10,37 @@ import {
 import { useDefaultState } from "./use-default-state";
 
 export type MockBlockHookArgs = {
-  blockEntityEditionId?: EntityEditionId;
+  blockEntityRecordId?: EntityRecordId;
   initialEntities?: Entity[];
   // initialLinkedAggregations?: LinkedAggregationDefinition[];
   readonly: boolean;
 };
 
 export type MockBlockHookResult = {
-  blockEntityEditionId: EntityEditionId;
+  blockEntityRecordId: EntityRecordId;
   mockDatastore: MockDatastore;
   readonly: boolean;
   setReadonly: Dispatch<SetStateAction<boolean>>;
-  setEntityEditionIdOfEntityForBlock: Dispatch<SetStateAction<EntityEditionId>>;
+  setEntityRecordIdOfEntityForBlock: Dispatch<SetStateAction<EntityRecordId>>;
 };
 
 /**
  * A hook to generate Block Protocol properties and callbacks for use in testing blocks.
  * The starting mock data can be customized using the initial[X] props.
  * See README.md for usage instructions.
- * @param [blockEntityEditionId] the `EntityEditionId` of the block's own starting entity, if any
+ * @param [blockEntityRecordId] the `EntityRecordId` of the block's own starting entity, if any
  * @param [initialEntities] - The entities to include in the data store (NOT the block entity, which is always provided)
  * @param [initialLinkedAggregations] - The linkedAggregation DEFINITIONS to include in the data store (results will be resolved automatically)
  */
 export const useMockBlockProps = ({
-  blockEntityEditionId: externalBlockEntityEditionId,
+  blockEntityRecordId: externalBlockEntityRecordId,
   initialEntities,
   // initialLinkedAggregations,
   readonly: externalReadonly,
 }: MockBlockHookArgs): MockBlockHookResult => {
-  const [entityEditionIdOfEntityForBlock, setEntityEditionIdOfEntityForBlock] =
-    useDefaultState<EntityEditionId>(
-      externalBlockEntityEditionId ?? {
+  const [entityRecordIdOfEntityForBlock, setEntityRecordIdOfEntityForBlock] =
+    useDefaultState<EntityRecordId>(
+      externalBlockEntityRecordId ?? {
         baseId: "",
         versionId: new Date().toISOString(),
       },
@@ -65,43 +65,43 @@ export const useMockBlockProps = ({
     }
 
     let blockEntity;
-    if (externalBlockEntityEditionId) {
+    if (externalBlockEntityRecordId) {
       blockEntity = nextMockData.entities.find(
         (entity) =>
-          entity.metadata.editionId.baseId ===
-            externalBlockEntityEditionId.baseId &&
-          entity.metadata.editionId.versionId ===
-            externalBlockEntityEditionId.versionId,
+          entity.metadata.recordId.baseId ===
+            externalBlockEntityRecordId.baseId &&
+          entity.metadata.recordId.versionId ===
+            externalBlockEntityRecordId.versionId,
       );
 
       if (blockEntity === undefined) {
         throw new Error(
-          `Mock data didn't contain the given block entity edition ID: ${JSON.stringify(
-            externalBlockEntityEditionId,
+          `Mock data didn't contain the given block entity revision ID: ${JSON.stringify(
+            externalBlockEntityRecordId,
           )}`,
         );
       }
     } else {
       blockEntity = nextMockData.entities[0]!;
-      setEntityEditionIdOfEntityForBlock(blockEntity.metadata.editionId);
+      setEntityRecordIdOfEntityForBlock(blockEntity.metadata.recordId);
     }
 
     return { mockData: nextMockData };
   }, [
-    externalBlockEntityEditionId,
+    externalBlockEntityRecordId,
     initialEntities,
-    setEntityEditionIdOfEntityForBlock,
+    setEntityRecordIdOfEntityForBlock,
     // initialLinkedAggregations,
   ]);
 
   const mockDatastore = useMockDatastore(mockData, readonly);
 
   return {
-    blockEntityEditionId: entityEditionIdOfEntityForBlock,
+    blockEntityRecordId: entityRecordIdOfEntityForBlock,
     mockDatastore,
     // linkedAggregations,
     readonly,
-    setEntityEditionIdOfEntityForBlock,
+    setEntityRecordIdOfEntityForBlock,
     setReadonly,
   };
 };

--- a/libs/mock-block-dock/src/util.ts
+++ b/libs/mock-block-dock/src/util.ts
@@ -4,11 +4,12 @@ import {
   AggregateEntityTypesData,
   AggregateEntityTypesResult,
   Entity,
-  EntityRootedSubgraph,
+  EntityRootType,
   EntityType,
-  EntityTypeRootedSubgraph,
+  EntityTypeRootType,
   MultiFilter,
   MultiSort,
+  Subgraph,
 } from "@blockprotocol/graph";
 
 type TupleEntry<
@@ -187,8 +188,8 @@ export type FilterResult<T extends Entity | EntityType = Entity | EntityType> =
   {
     results: T[];
     operation:
-      | AggregateEntitiesResult<EntityRootedSubgraph>["operation"]
-      | AggregateEntityTypesResult<EntityTypeRootedSubgraph>["operation"];
+      | AggregateEntitiesResult<Subgraph<EntityRootType>>["operation"]
+      | AggregateEntityTypesResult<Subgraph<EntityTypeRootType>>["operation"];
   };
 
 export function filterAndSortEntitiesOrTypes(

--- a/libs/mock-block-dock/src/util.ts
+++ b/libs/mock-block-dock/src/util.ts
@@ -4,11 +4,11 @@ import {
   AggregateEntityTypesData,
   AggregateEntityTypesResult,
   Entity,
+  EntityRootedSubgraph,
   EntityType,
+  EntityTypeRootedSubgraph,
   MultiFilter,
   MultiSort,
-  Subgraph,
-  SubgraphRootTypes,
 } from "@blockprotocol/graph";
 
 type TupleEntry<
@@ -187,12 +187,8 @@ export type FilterResult<T extends Entity | EntityType = Entity | EntityType> =
   {
     results: T[];
     operation:
-      | AggregateEntitiesResult<
-          Subgraph<SubgraphRootTypes["entity"]>
-        >["operation"]
-      | AggregateEntityTypesResult<
-          Subgraph<SubgraphRootTypes["entityType"]>
-        >["operation"];
+      | AggregateEntitiesResult<EntityRootedSubgraph>["operation"]
+      | AggregateEntityTypesResult<EntityTypeRootedSubgraph>["operation"];
   };
 
 export function filterAndSortEntitiesOrTypes(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Over the course of developing this new release of the BP spec (and accompanying code) we've incrementally added quite a few new concepts. This PR will shortly be followed up by a number of PRs that greatly expand on the concept of "temporal versioning" within the Block Protocol. With the introduction of that code, we'd like to center on a common terminology that we can use consistently to encourage improved intuition.

This PR lays the foundation for that by renaming various fields to try and establish a consistent reasoned high-level picture of things. It also adds a few QoL improvements as a driveby (such as adding aliases for various Subgraph types rooted at different elements)

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203358502199087/1203756383156843/f) _(internal)_

## 🚫 Blocked by

N/A

## 🔍 What does this change?

- See commits for a discrete list, effort has been made to keep them self-contained, however here is the basic gist:
  - Elements of the abstract "datastore" will be associated with `RecordId`s. These should be viewed as immutable records, where `update` operations result in the creation of a new "record". This is made up of:
    - A base identifier (either `entityId` or `baseUri`), the identity of the element
    - An edition qualifier (either `editionId` or `number`), the discriminating identifier to find the specific row _for_ that element
  - We introduce the term "_revision_", which refers to a specific instance of some _thing_ within a specific `Subgraph`. In a `Subgraph` with temporal support (more information in a future PR), there may be multiple instances of a _thing_ within the `Subgraph`, these instances are associated with some versioning scheme, and each instance is referred to as a _revision_.
  - Elements contained within the `vertices` of a specific `Subgraph` will be identified by a `VertexId`. This is made up of:
    - a `baseId`, which is the _identity_ of the element, e.g. a specific ontology type or entity, and corresponds to the first level of nesting inside `vertices` and `edges`
    - a `revisionId`, which identifies the specific _revision_ of that element, e.g. the instance of the ontology type associated with a specific version, or the instance of the entity associated with a specific timestamp on that `Subgraph`'s variable temporal axis.

## 📜 Does this require a change to the docs?

- The model described above will need to be propagated to users in some form, that is not done as part of this PR.

## ⚠️ Known issues

- Using the `EntityRootedSubgraph` alias in `useMockBlockDockContext` seems to breaks TS generic resolution in `getRoots` (see [this commit](https://github.com/blockprotocol/blockprotocol/pull/899/commits/e202f31fa363b991defa9d121cf051d751575bd9))
- The HTML block in `mock-block-dock` wasn't updated for 0.3. [Asana task](https://app.asana.com/0/1203358502199087/1203866892869243) _(internal)_

## 🐾 Next steps

- Introduce multi-axis temporal versioning to the Graph service
- Update MBD and accompanying packages to handle temporal versioning

## 🛡 What tests cover this?

- I'm unsure, at the very least `tsc` and `eslint`. It's also possible to check, through running it, that MBD has not been broken incidentally

## ❓ How to test this?

- Confirm that `lint:tsc` and `lint:eslint` pass for all packages _except_:
  - `site`
  - `block-scripts`
- Confirm that MBD still behaves as expected

## 📹 Demo

N/A
