### PR TITLE
Update labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,7 +19,6 @@
   - ".github/**"
   - ".husky/**"
   - "infra/**"
-  - "scripts/**"
   - "*"
 
 "area: libs":

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: kachkaev/labeler@d89797c51d07680aec17049cc6790e9d323d9a93
-        ## @todo replace with actions/labeler@v3 (or newer) when this PR is merged
+      - uses: kachkaev/labeler@305cfeb74cfa5c4878bf6418b4815a4106f2e345
+        ## @todo replace with actions/labeler@v4 (or newer) when this PR is merged:
         ## https://github.com/actions/labeler/pull/316
         with:
           dot: true


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR syncs this repo’s labeler setup with https://github.com/hashintel/hash/pull/1934. In particular, it updates [actions/labeler](https://github.com/actions/labeler) to v4 and applies on top of it: https://github.com/actions/labeler/pull/316. This fixes deprecation warnings caused by [usage of Node 12](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/) in v3.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203543026679373/1203800233887959/f) _(internal)_
- [actions/labeler@v4.0.0 release notes](https://github.com/actions/labeler/releases/tag/v4.0.0)

## ❓ How to test this?

- CI (linting)
- Monitor label creation once this PR is merged