### PR TITLE
Fix canary block templates. Commit auto-generated types

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 libs/@blockprotocol/type-system-node/dist/* linguist-generated=true
 libs/@blockprotocol/type-system-web/dist/* linguist-generated=true
+*.gen.ts linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -69,5 +69,3 @@ libs/@blockprotocol/type-system/wasm
 libs/block-template-html/dev/src
 libs/mock-block-dock/src/version.ts
 
-## Auto-generated files
-*.gen.ts

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -81,9 +81,6 @@ libs/@blockprotocol/type-system/wasm
 libs/block-template-html/dev/src
 libs/mock-block-dock/src/version.ts
 
-## Auto-generated files
-*.gen.ts
-
 #########################
 ## Shared between linters
 #########################
@@ -91,3 +88,6 @@ libs/mock-block-dock/src/version.ts
 # Keep license files as is
 LICENSE.md
 LICENSE-*.md
+
+## Ignore auto-generated files
+*.gen.ts

--- a/.prettierignore
+++ b/.prettierignore
@@ -92,9 +92,6 @@ libs/@blockprotocol/type-system/wasm
 libs/block-template-html/dev/src
 libs/mock-block-dock/src/version.ts
 
-## Auto-generated files
-*.gen.ts
-
 #########################
 ## Shared between linters
 #########################
@@ -102,3 +99,6 @@ libs/mock-block-dock/src/version.ts
 # Keep license files as is
 LICENSE.md
 LICENSE-*.md
+
+## Ignore auto-generated files
+*.gen.ts

--- a/libs/@blockprotocol/graph/src/codegen/entity-type-to-typescript.ts
+++ b/libs/@blockprotocol/graph/src/codegen/entity-type-to-typescript.ts
@@ -17,8 +17,7 @@ import {
 import { hardcodedBpTypes } from "./hardcoded-bp-types.js";
 import { fetchTypeAsJson, typedEntries } from "./shared.js";
 
-const bannerComment = (uri: string, depth: number) => `/* eslint-disable */
-/**
+const bannerComment = (uri: string, depth: number) => `/**
  * This file was automatically generated – do not edit it.
  * @see ${uri} for the root JSON Schema these types were generated from
  * Types for link entities and their destination were generated to a depth of ${depth} from the root
@@ -218,8 +217,9 @@ const _jsonSchemaToTypeScript = async (
       generateLinkEntityAndRightEntityDefinition({
         sourceEntityTypeName: typeName,
         linkEntityTypeName: linkEntityType.typeName,
-        rightEntityTypeNames: (
-          rightEntityTypes ?? [{ typeName: "Entity" }]
+        rightEntityTypeNames: (rightEntityTypes.length > 0
+          ? rightEntityTypes
+          : [{ typeName: "Entity" }]
         ).map((type) => type.typeName),
       });
 

--- a/libs/@blockprotocol/graph/src/custom-element.ts
+++ b/libs/@blockprotocol/graph/src/custom-element.ts
@@ -3,7 +3,6 @@ import { LitElement } from "lit";
 import {
   BlockGraphProperties,
   Entity,
-  EntityEditionId,
   EntityPropertiesObject,
   GraphBlockHandler,
   LinkEntityAndRightEntity,
@@ -43,10 +42,17 @@ export abstract class BlockElementBase<
     /**
      * The 'graph' object contains messages sent under the graph service from the app to the block.
      * They are sent on initialization and again when the application has new values to send.
-     * One such message is 'graph.blockEntity', which is a data entity fitting the block's schema (its type).
+     * One such message is 'graph.blockEntitySubgraph', which is a graph rooted at the block entity.
      * @see https://blockprotocol.org/docs/spec/graph-service#message-definitions for a full list
      */
     graph: { type: Object },
+
+    /**
+     * These are properties derived from the block subgraph – the root entity, and those linked from it
+     * // @see https://lit.dev/docs/components/properties/#internal-reactive-state
+     */
+    blockEntity: { state: true },
+    linkedEntities: { state: true },
   };
 
   private updateDerivedProperties() {

--- a/libs/@blockprotocol/graph/src/graph-block-handler.ts
+++ b/libs/@blockprotocol/graph/src/graph-block-handler.ts
@@ -19,6 +19,7 @@ import {
   CreateResourceError,
   DeleteEntityData,
   Entity,
+  EntityPropertiesObject,
   GetEntityData,
   GetEntityTypeData,
   ReadOrModifyResourceError,
@@ -97,7 +98,9 @@ export class GraphBlockHandler
 
   // @todo automate creation of these methods from graph-service.json and types.ts
 
-  createEntity({ data }: { data?: CreateEntityData }) {
+  createEntity<
+    ValidProperties extends EntityPropertiesObject = EntityPropertiesObject,
+  >({ data }: { data?: CreateEntityData & { properties: ValidProperties } }) {
     return this.sendMessage<Entity, CreateResourceError>({
       message: {
         messageName: "createEntity",
@@ -107,7 +110,9 @@ export class GraphBlockHandler
     });
   }
 
-  updateEntity({ data }: { data?: UpdateEntityData }) {
+  updateEntity<
+    ValidProperties extends EntityPropertiesObject = EntityPropertiesObject,
+  >({ data }: { data?: UpdateEntityData & { properties: ValidProperties } }) {
     return this.sendMessage<Entity, ReadOrModifyResourceError>({
       message: {
         messageName: "updateEntity",

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/builder.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/builder.ts
@@ -48,7 +48,7 @@ export const buildSubgraph = (
       ),
   );
 
-  if (missingRoots) {
+  if (missingRoots.length > 0) {
     throw new Error(
       `Root(s) not present in data: ${missingRoots
         .map(

--- a/libs/block-template-custom-element/src/app.ts
+++ b/libs/block-template-custom-element/src/app.ts
@@ -48,8 +48,6 @@ export class BlockElement extends BlockElementBase<RootEntity> {
 
   /** @see https://lit.dev/docs/components/rendering */
   render() {
-    console.log({ this: this });
-
     return html`<h1>
         Hello,
         ${this.blockEntity?.properties[

--- a/libs/block-template-custom-element/src/app.ts
+++ b/libs/block-template-custom-element/src/app.ts
@@ -17,7 +17,7 @@ export class BlockElement extends BlockElementBase<RootEntity> {
     font-family: sans-serif;
   `;
 
-  private handleInput(event: Event) {
+  private handleInput(event: InputEvent) {
     if (!this.graphService || !this.blockEntity) {
       return;
     }
@@ -31,11 +31,16 @@ export class BlockElement extends BlockElementBase<RootEntity> {
      * @see https://blockprotocol.org/docs/spec/graph-service#message-definitions
      */
     this.graphService
-      .updateEntity({
+      .updateEntity<RootEntity["properties"]>({
         data: {
           entityId: this.blockEntity.metadata.editionId.baseId,
           entityTypeId: this.blockEntity.metadata.entityTypeId,
-          properties: { name: (event.target as HTMLInputElement).value },
+          properties: {
+            ...this.blockEntity.properties,
+            "https://alpha.hash.ai/@hash/types/property-type/title/": (
+              event.target as HTMLInputElement
+            ).value,
+          },
         },
       })
       .catch((error) => console.error(`Error updating self: ${error}`));
@@ -43,7 +48,9 @@ export class BlockElement extends BlockElementBase<RootEntity> {
 
   /** @see https://lit.dev/docs/components/rendering */
   render() {
-    return html` <h1>
+    console.log({ this: this });
+
+    return html`<h1>
         Hello,
         ${this.blockEntity?.properties[
           "https://alpha.hash.ai/@hash/types/property-type/title/"

--- a/libs/block-template-custom-element/src/types.gen.ts
+++ b/libs/block-template-custom-element/src/types.gen.ts
@@ -1,0 +1,146 @@
+import { Entity } from "@blockprotocol/graph";
+
+/**
+ * This file was automatically generated – do not edit it.
+ * @see https://alpha.hash.ai/@hash/types/entity-type/page/v/1 for the root JSON Schema these types were generated from
+ * Types for link entities and their destination were generated to a depth of 2 from the root
+ */
+
+/**
+ * Whether or not something has been archived.
+ */
+export type Archived = Boolean;
+/**
+ * A True or False value
+ */
+export type Boolean = boolean;
+/**
+ * The title of something.
+ */
+export type Title = Text;
+/**
+ * An ordered sequence of characters
+ */
+export type Text = string;
+/**
+ * The summary of the something.
+ */
+export type Summary = Text;
+/**
+ * The (fractional) index indicating the current position of something.
+ */
+export type Index = Text;
+/**
+ * An emoji icon.
+ */
+export type Icon = Text;
+
+export type PageProperties = {
+  "https://alpha.hash.ai/@hash/types/property-type/archived/"?: Archived;
+  "https://alpha.hash.ai/@hash/types/property-type/title/": Title;
+  "https://alpha.hash.ai/@hash/types/property-type/summary/"?: Summary;
+  "https://alpha.hash.ai/@hash/types/property-type/index/": Index;
+  "https://alpha.hash.ai/@hash/types/property-type/icon/"?: Icon;
+}
+
+export type Page = Entity<PageProperties>;
+
+/**
+ * The parent of something.
+ */
+export type ParentProperties = ParentProperties1 & ParentProperties2;
+export type ParentProperties1 = Link;
+
+export type Link = {
+  leftEntityId?: string;
+  rightEntityId?: string;
+}
+export type ParentProperties2 = {}
+
+export type Parent = Entity<ParentProperties>;
+export type ParentLinksByLinkTypeId = {
+
+};
+
+export type ParentLinkAndRightEntities = NonNullable<
+  ParentLinksByLinkTypeId[keyof ParentLinksByLinkTypeId]
+>;
+
+export type PageParentLinks = [] |
+  {
+    linkEntity: Parent;
+    rightEntity: Page;
+  }[];
+
+
+/**
+ * Something containing something.
+ */
+export type ContainsProperties = ContainsProperties1 & ContainsProperties2;
+export type ContainsProperties1 = Link;
+
+
+export type ContainsProperties2 = {}
+
+export type Contains = Entity<ContainsProperties>;
+export type ContainsLinksByLinkTypeId = {
+
+};
+
+export type ContainsLinkAndRightEntities = NonNullable<
+  ContainsLinksByLinkTypeId[keyof ContainsLinksByLinkTypeId]
+>;
+export type ComponentId = Text;
+/**
+ * An ordered sequence of characters
+ */
+
+
+export type BlockProperties = {
+  "https://alpha.hash.ai/@hash/types/property-type/component-id/": ComponentId;
+}
+
+export type Block = Entity<BlockProperties>;
+
+/**
+ * The entity representing the data in a block.
+ */
+export type BlockDataProperties = BlockDataProperties1 & BlockDataProperties2;
+export type BlockDataProperties1 = Link;
+
+
+export type BlockDataProperties2 = {}
+
+export type BlockData = Entity<BlockDataProperties>;
+
+export type BlockBlockDataLinks = [] |
+  {
+    linkEntity: BlockData;
+    rightEntity: Entity;
+  }[];
+
+export type BlockLinksByLinkTypeId = {
+  "https://alpha.hash.ai/@hash/types/entity-type/block-data/v/1": BlockBlockDataLinks;
+};
+
+export type BlockLinkAndRightEntities = NonNullable<
+  BlockLinksByLinkTypeId[keyof BlockLinksByLinkTypeId]
+>;
+export type PageContainsLinks = [] |
+  {
+    linkEntity: Contains;
+    rightEntity: Block;
+  }[];
+
+export type PageLinksByLinkTypeId = {
+  "https://alpha.hash.ai/@hash/types/entity-type/parent/v/1": PageParentLinks;
+  "https://alpha.hash.ai/@hash/types/entity-type/contains/v/1": PageContainsLinks;
+};
+
+export type PageLinkAndRightEntities = NonNullable<
+  PageLinksByLinkTypeId[keyof PageLinksByLinkTypeId]
+>;
+
+export type RootEntity = Page;
+export type RootEntityLinkedEntities = PageLinkAndRightEntities;
+export type RootLinkMap = PageLinksByLinkTypeId;

--- a/libs/block-template-react/src/app.tsx
+++ b/libs/block-template-react/src/app.tsx
@@ -3,7 +3,6 @@ import {
   useEntitySubgraph,
   useGraphBlockService,
 } from "@blockprotocol/graph/react";
-import { addSimpleAccessors } from "@blockprotocol/graph/stdlib";
 import { useRef } from "react";
 
 /**
@@ -66,9 +65,10 @@ export const App: BlockComponent<RootEntity> = ({
 
   const entityId = blockEntity.metadata.editionId.baseId;
 
-  const simpleBlockEntity = addSimpleAccessors(blockEntity);
+  const titleKey: keyof RootEntity["properties"] =
+    "https://alpha.hash.ai/@hash/types/property-type/title/";
 
-  const { title } = simpleBlockEntity.properties;
+  const title = blockEntity.properties[titleKey];
 
   return (
     /**
@@ -99,7 +99,7 @@ export const App: BlockComponent<RootEntity> = ({
             data: {
               entityId,
               entityTypeId: blockEntity.metadata.entityTypeId,
-              properties: { title: supplyRandomName() },
+              properties: { [titleKey]: supplyRandomName() },
             },
           })
         }

--- a/libs/block-template-react/src/types.gen.ts
+++ b/libs/block-template-react/src/types.gen.ts
@@ -1,0 +1,146 @@
+import { Entity } from "@blockprotocol/graph";
+
+/**
+ * This file was automatically generated – do not edit it.
+ * @see https://alpha.hash.ai/@hash/types/entity-type/page/v/1 for the root JSON Schema these types were generated from
+ * Types for link entities and their destination were generated to a depth of 2 from the root
+ */
+
+/**
+ * The summary of the something.
+ */
+export type Summary = Text;
+/**
+ * An ordered sequence of characters
+ */
+export type Text = string;
+/**
+ * The (fractional) index indicating the current position of something.
+ */
+export type Index = Text;
+/**
+ * The title of something.
+ */
+export type Title = Text;
+/**
+ * An emoji icon.
+ */
+export type Icon = Text;
+/**
+ * Whether or not something has been archived.
+ */
+export type Archived = Boolean;
+/**
+ * A True or False value
+ */
+export type Boolean = boolean;
+
+export type PageProperties = {
+  "https://alpha.hash.ai/@hash/types/property-type/summary/"?: Summary;
+  "https://alpha.hash.ai/@hash/types/property-type/index/": Index;
+  "https://alpha.hash.ai/@hash/types/property-type/title/": Title;
+  "https://alpha.hash.ai/@hash/types/property-type/icon/"?: Icon;
+  "https://alpha.hash.ai/@hash/types/property-type/archived/"?: Archived;
+}
+
+export type Page = Entity<PageProperties>;
+
+/**
+ * The parent of something.
+ */
+export type ParentProperties = ParentProperties1 & ParentProperties2;
+export type ParentProperties1 = Link;
+
+export type Link = {
+  leftEntityId?: string;
+  rightEntityId?: string;
+}
+export type ParentProperties2 = {}
+
+export type Parent = Entity<ParentProperties>;
+export type ParentLinksByLinkTypeId = {
+
+};
+
+export type ParentLinkAndRightEntities = NonNullable<
+  ParentLinksByLinkTypeId[keyof ParentLinksByLinkTypeId]
+>;
+
+export type PageParentLinks = [] |
+  {
+    linkEntity: Parent;
+    rightEntity: Page;
+  }[];
+
+
+/**
+ * Something containing something.
+ */
+export type ContainsProperties = ContainsProperties1 & ContainsProperties2;
+export type ContainsProperties1 = Link;
+
+
+export type ContainsProperties2 = {}
+
+export type Contains = Entity<ContainsProperties>;
+export type ContainsLinksByLinkTypeId = {
+
+};
+
+export type ContainsLinkAndRightEntities = NonNullable<
+  ContainsLinksByLinkTypeId[keyof ContainsLinksByLinkTypeId]
+>;
+export type ComponentId = Text;
+/**
+ * An ordered sequence of characters
+ */
+
+
+export type BlockProperties = {
+  "https://alpha.hash.ai/@hash/types/property-type/component-id/": ComponentId;
+}
+
+export type Block = Entity<BlockProperties>;
+
+/**
+ * The entity representing the data in a block.
+ */
+export type BlockDataProperties = BlockDataProperties1 & BlockDataProperties2;
+export type BlockDataProperties1 = Link;
+
+
+export type BlockDataProperties2 = {}
+
+export type BlockData = Entity<BlockDataProperties>;
+
+export type BlockBlockDataLinks = [] |
+  {
+    linkEntity: BlockData;
+    rightEntity: Entity;
+  }[];
+
+export type BlockLinksByLinkTypeId = {
+  "https://alpha.hash.ai/@hash/types/entity-type/block-data/v/1": BlockBlockDataLinks;
+};
+
+export type BlockLinkAndRightEntities = NonNullable<
+  BlockLinksByLinkTypeId[keyof BlockLinksByLinkTypeId]
+>;
+export type PageContainsLinks = [] |
+  {
+    linkEntity: Contains;
+    rightEntity: Block;
+  }[];
+
+export type PageLinksByLinkTypeId = {
+  "https://alpha.hash.ai/@hash/types/entity-type/parent/v/1": PageParentLinks;
+  "https://alpha.hash.ai/@hash/types/entity-type/contains/v/1": PageContainsLinks;
+};
+
+export type PageLinkAndRightEntities = NonNullable<
+  PageLinksByLinkTypeId[keyof PageLinksByLinkTypeId]
+>;
+
+export type RootEntity = Page;
+export type RootEntityLinkedEntities = PageLinkAndRightEntities;
+export type RootLinkMap = PageLinksByLinkTypeId;

--- a/libs/create-block-app/create-block-app.js
+++ b/libs/create-block-app/create-block-app.js
@@ -131,7 +131,6 @@ const usage = commandLineUsage(helpSections);
   } else {
     packageJson.blockprotocol.displayName = blockName;
     packageJson.blockprotocol.name = slugifiedBlockName;
-    packageJson.postinstall = "yarn codegen";
   }
 
   delete packageJson.homepage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12190,15 +12190,10 @@ prettier-plugin-sh@0.12.8:
     sh-syntax "^0.3.6"
     synckit "^0.8.1"
 
-prettier@2.8.2, prettier@^2.7.1:
+prettier@2.8.2, prettier@^2.6.2, prettier@^2.7.1:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.2.tgz#c4ea1b5b454d7c4b59966db2e06ed7eec5dfd160"
   integrity sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==
-
-prettier@^2.6.2:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.0.tgz#c7df58393c9ba77d6fba3921ae01faf994fb9dc9"
-  integrity sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==
 
 pretty-error@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

1. Fix some bugs in the block templates (see comments on diff)

2. Commit the auto-generated types for blocks, rather than ignoring them – this removes type generation from an external URI as a dependency in the build process. Types are immutable and should not change. I've set `linguist-generated=true` to collapse them in the diff by default

## 🔗 Related links

- [Asana task for committing types](https://app.asana.com/0/1203358502199087/1203774997009906/f) _(internal)_
- [Bug report on block template](https://hashintel.slack.com/archives/C02LG39FJAU/p1674582285578809) _(internal)_

## 🐾 Next steps

– Update #879 and publish new canary versions
