### PR TITLE
Fix footer test, formatting. Commit mock-block-dock version change

### DIFF
--- a/apps/site/src/_pages/docs/5_faq.mdx
+++ b/apps/site/src/_pages/docs/5_faq.mdx
@@ -126,7 +126,7 @@ To save data beyond the session, blocks should make use of the [operations defin
 <FAQ question="What are the security considerations of blocks?">
 
 Similar to most programming language package managers, because anybody can publish executable code (in the form of a block), it's important you trust the block you're executing.
-  
+
 Because those inserting blocks are often non-technical end users, this isn't always practical. As such, we recommend that embedders implement both sandboxing within their environments, and allow/deny lists.
 
 - **Sandboxing** will be covered in depth in our [guide for embedders](https://blockprotocol.org/docs/embedding-blocks).

--- a/apps/site/src/components/coming-soon-banner.tsx
+++ b/apps/site/src/components/coming-soon-banner.tsx
@@ -77,7 +77,8 @@ export const ComingSoonBanner = () => {
             >
               <Box component="span" mr="0.5ch">
                 The current version of the &THORN; spec is about to be
-                deprecated. Learn more about v0.3, arriving 28<sup>th</sup> February 2023.
+                deprecated. Learn more about v0.3, arriving 28<sup>th</sup>{" "}
+                February 2023.
               </Box>
             </Typography>
             <Typography

--- a/apps/site/tests/integration/page-footer.test.ts
+++ b/apps/site/tests/integration/page-footer.test.ts
@@ -34,7 +34,7 @@ test("page footer navigation works", async ({ page, browserName }) => {
 
   await page.locator("footer").scrollIntoViewIfNeeded();
 
-  await expect(page.locator("footer >> a:text-is('Hub')")).toHaveAttribute(
+  await expect(page.locator("footer >> a:text-is('Þ Hub')")).toHaveAttribute(
     "href",
     "/hub",
   );

--- a/libs/mock-block-dock/src/version.ts
+++ b/libs/mock-block-dock/src/version.ts
@@ -1,1 +1,1 @@
-export const MOCK_BLOCK_DOCK_VERSION = "0.0.38";
+export const MOCK_BLOCK_DOCK_VERSION = "0.0.39";


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes a test that broke when text in the footer was changed, and some formatting.

Also commits an update to a file storing the latest version of `mock-block-dock`. I think this file exists so that Mock Block Dock's runtime code can refer to its own version without importing from `package.json`. This PR brings it into line. 