### PR TITLE
Types from schema: add 'object' data type. Handle lowercase schema title

### DIFF
--- a/libs/@blockprotocol/graph/src/codegen/entity-type-to-typescript.ts
+++ b/libs/@blockprotocol/graph/src/codegen/entity-type-to-typescript.ts
@@ -70,7 +70,15 @@ const generateTypeNameFromSchema = (
   schema: EntityType,
   existingTypes: UriToType,
 ): string => {
-  const proposedName = schema.title?.replace(/ /g, "");
+  if (!schema.title) {
+    throw new Error("Schema must have a 'title'");
+  }
+
+  const nameToCase = schema.title.replace(/ /g, "");
+
+  const proposedName = `${nameToCase[0]!.toUpperCase()}${nameToCase.substring(
+    1,
+  )}`;
 
   let typeWithProposedName = typedEntries(existingTypes).find(
     ([_entityTypeId, { typeName }]) => typeName === proposedName,

--- a/libs/@blockprotocol/graph/src/codegen/hardcoded-bp-types.ts
+++ b/libs/@blockprotocol/graph/src/codegen/hardcoded-bp-types.ts
@@ -46,4 +46,11 @@ export const hardcodedBpTypes = {
     description: "A True or False value",
     type: "boolean",
   },
+  "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1": {
+    kind: "dataType",
+    $id: "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1",
+    title: "Object",
+    description: "An opaque, untyped JSON object",
+    type: "object",
+  },
 } as const;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fix two bugs in the `codegen` code in `@blockprotocol/graph`:
1. The 'object' data type was missing
2. When generating a type name, the schema title was unmodified, meaning that it could begin with a lowercase letter

