### PR TITLE
Homepage fixes

### DIFF
--- a/apps/site/src/components/pages/home/supported-applications.tsx
+++ b/apps/site/src/components/pages/home/supported-applications.tsx
@@ -146,19 +146,6 @@ export const SupportedApplications = () => {
                 />
 
                 <IconButtonWithTooltip
-                  href="/docs/using-blocks#github-blocks"
-                  label="GitHub Blocks"
-                  icon={
-                    <GithubIcon
-                      sx={{
-                        fill: ({ palette }) => palette.gray[90],
-                        fontSize: 54,
-                      }}
-                    />
-                  }
-                />
-
-                <IconButtonWithTooltip
                   href="/docs/using-blocks#hash"
                   label="HASH"
                   icon={
@@ -198,6 +185,19 @@ export const SupportedApplications = () => {
               </Typography>
 
               <Stack gap={2.5} flexDirection="row" justifyContent="center">
+                <IconButtonWithTooltip
+                  href="/docs/using-blocks#github-blocks"
+                  label="GitHub Blocks"
+                  icon={
+                    <GithubIcon
+                      sx={{
+                        fill: ({ palette }) => palette.gray[90],
+                        fontSize: 54,
+                      }}
+                    />
+                  }
+                />
+
                 <IconButtonWithTooltip
                   href="/docs/using-blocks#figma"
                   label="Figma"

--- a/apps/site/src/components/pages/home/supported-applications.tsx
+++ b/apps/site/src/components/pages/home/supported-applications.tsx
@@ -416,7 +416,10 @@ export const SupportedApplications = () => {
                 <LinkButton
                   href="/docs/using-blocks"
                   variant="primary"
-                  sx={{ color: ({ palette }) => palette.common.white }}
+                  sx={{
+                    color: ({ palette }) => palette.common.white,
+                    whiteSpace: "nowrap",
+                  }}
                   startIcon={
                     <BrowserIcon
                       sx={{
@@ -434,6 +437,7 @@ export const SupportedApplications = () => {
                   sx={{
                     color: ({ palette }) => palette.purple[70],
                     background: "transparent",
+                    whiteSpace: "nowrap",
                   }}
                   startIcon={
                     <BoxesStackedIcon

--- a/apps/site/src/components/pages/home/zero-application-developers.tsx
+++ b/apps/site/src/components/pages/home/zero-application-developers.tsx
@@ -97,7 +97,7 @@ export const ZeroApplicationDevelopers = () => {
       <LinkButton
         href="/docs/embedding-blocks"
         variant="primary"
-        sx={{ color: theme.palette.common.white }}
+        sx={{ color: theme.palette.common.white, whiteSpace: "nowrap" }}
         startIcon={
           <SolidSparklesIcon
             sx={{


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR moves the `GitHub Blocks` button to the `Coming Soon` section and fixes a couple of buttons on mobile screens.

## 📹 Demo


Before:
<!-- Add a screenshot or video showcasing your work -->

![image](https://user-images.githubusercontent.com/37453800/215070630-9e093a66-fda9-45ee-8efc-49a89288f5f9.png)
![image](https://user-images.githubusercontent.com/37453800/215070521-0d206bdf-b735-4033-8aab-e03c9ad154d8.png)
![image](https://user-images.githubusercontent.com/37453800/215070567-6969310a-b8ea-4b52-8794-2834a8c5a735.png)

After:

![image](https://user-images.githubusercontent.com/37453800/215070331-d8ccee76-d13d-4a49-9586-c07ab2983efa.png)
![image](https://user-images.githubusercontent.com/37453800/215070724-e04295a9-64c3-41ba-aa17-7b1e6a99b1d3.png)
![image](https://user-images.githubusercontent.com/37453800/215070763-f5028ddc-a45f-4d09-b978-590f1ab14ca2.png)
