### PR TITLE
Better 'Object' type. Rename codegen script in templates

### DIFF
--- a/libs/@blockprotocol/graph/src/codegen/entity-type-to-typescript.ts
+++ b/libs/@blockprotocol/graph/src/codegen/entity-type-to-typescript.ts
@@ -179,6 +179,12 @@ const _jsonSchemaToTypeScript = async (
     "export type Link =",
   );
 
+  // Better type for the opaque JSON object type
+  compiledSchema = compiledSchema.replaceAll(
+    "export interface Object {}",
+    "export type Object = JsonObject;",
+  );
+
   const compiledType = { typeName, typeScriptString: compiledSchema };
 
   // add the compiled type to our map of already-resolved types in case it's encountered again when following links

--- a/libs/@blockprotocol/graph/src/codegen/entity-type-to-typescript/type-definition-generators.ts
+++ b/libs/@blockprotocol/graph/src/codegen/entity-type-to-typescript/type-definition-generators.ts
@@ -1,6 +1,6 @@
 // Generate imports for types we use from elsewhere
 export const generateImportStatements = () =>
-  `import { Entity } from "@blockprotocol/graph";\n\n`;
+  `import { Entity, JsonObject } from "@blockprotocol/graph";\n\n`;
 
 // Generate a typed Entity, given the name of the type to use in its Properties generic slot
 export const generateEntityDefinition = (

--- a/libs/@blockprotocol/graph/src/types/entity.ts
+++ b/libs/@blockprotocol/graph/src/types/entity.ts
@@ -1,9 +1,15 @@
-import { JsonValue } from "@blockprotocol/core";
+import type {
+  JsonObject as CoreJsonObject,
+  JsonValue as CoreJsonValue,
+} from "@blockprotocol/core";
 import { BaseUri, VersionedUri } from "@blockprotocol/type-system/slim";
 
 import { isOntologyTypeEditionId } from "../types.js";
 import { Subgraph, SubgraphRootTypes } from "./subgraph.js";
 import { GraphResolveDepths } from "./subgraph/graph-resolve-depths.js";
+
+export type JsonObject = CoreJsonObject;
+export type JsonValue = CoreJsonValue;
 
 /** @todo - Consider branding these */
 /** @todo - Add documentation for these if we keep them */

--- a/libs/block-template-custom-element/package.json
+++ b/libs/block-template-custom-element/package.json
@@ -65,6 +65,6 @@
     "image": "public/block-preview.png",
     "name": "block-template-custom-element",
     "protocol": "0.3",
-    "schema": "https://alpha.hash.ai/@hash/types/entity-type/page/v/1"
+    "schema": "https://alpha.hash.ai/@yusuf/types/entity-type/table-block/v/3"
   }
 }

--- a/libs/block-template-custom-element/package.json
+++ b/libs/block-template-custom-element/package.json
@@ -19,13 +19,13 @@
   },
   "scripts": {
     "build": "block-scripts build",
-    "codegen": "block-scripts codegen",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
     "format": "prettier --write --ignore-unknown .",
     "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "prepublishOnly": "PACKAGE_DIR=$(pwd) yarn workspace @local/package-chores exe scripts/cleanup-before-publishing.ts",
+    "schema": "block-scripts codegen",
     "serve": "block-scripts serve"
   },
   "prettier": {
@@ -65,6 +65,6 @@
     "image": "public/block-preview.png",
     "name": "block-template-custom-element",
     "protocol": "0.3",
-    "schema": "https://alpha.hash.ai/@yusuf/types/entity-type/table-block/v/3"
+    "schema": "https://alpha.hash.ai/@hash/types/entity-type/page/v/1"
   }
 }

--- a/libs/block-template-react/package.json
+++ b/libs/block-template-react/package.json
@@ -19,13 +19,13 @@
   },
   "scripts": {
     "build": "block-scripts build",
-    "codegen": "block-scripts codegen",
     "dev": "block-scripts dev",
     "fix:eslint": "eslint --fix .",
     "format": "prettier --write --ignore-unknown .",
     "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
     "prepublishOnly": "PACKAGE_DIR=$(pwd) yarn workspace @local/package-chores exe scripts/cleanup-before-publishing.ts",
+    "schema": "block-scripts codegen",
     "serve": "block-scripts serve"
   },
   "prettier": {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

1. Overwrites the default generated type for an opaque object with our own `JsonObject` type
  - this involves re-exporting `JsonObject` in `@blockprotocol/graph` to avoid users having to add `@blockprotocol/core` as a separate dependency (and therefore potentially becoming out of sync)
2. Renames `codegen` in templates to `schema` as a temporary measure. The generated type output is non-deterministic (types may appear in a different order), meaning that any run of Turborepo can result in a diff if the template's `codegen` scripts are run (internal Asana [task](https://app.asana.com/0/1203179076056209/1203843256013361/f) to figure out a permanent fix for this)
