### PR TITLE
Set git author in canary release workflow

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -12,10 +12,14 @@ jobs:
       - name: Publish changesets to npm, with 'canary' tags
         run: |
           yarn changeset version --snapshot canary
+
+          git config user.email "support@hash.ai"
+          git config user.name "hashdotai"
           git commit -am "temporarily convert changesets to canary releases"
           git revert `git rev-parse HEAD` --no-edit
           git push
           git checkout `git rev-parse HEAD~1`
+
           yarn changeset publish --tag canary
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fix an issue with the canary release workflow where it needs a git author set to commit.

<img width="992" alt="Screenshot 2023-01-30 at 16 24 30" src="https://user-images.githubusercontent.com/37743469/215534842-1fe5df26-bd8f-4c7d-b6b4-e5e982069acc.png">
