### PR TITLE
Set .npmrc in canary release flow

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -16,6 +16,9 @@ jobs:
           git revert `git rev-parse HEAD` --no-edit
           git push
           git checkout `git rev-parse HEAD~1`
+
+          echo "//registry.npmjs.org/:_authToken=${{ env.NPM_TOKEN }}" >> .npmrc
+
           yarn changeset publish --tag canary
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -17,7 +17,9 @@ jobs:
           git push
           git checkout `git rev-parse HEAD~1`
 
-          echo "//registry.npmjs.org/:_authToken=${{ env.NPM_TOKEN }}" >> .npmrc
+          cat << EOF > "$HOME/.npmrc"
+            //registry.npmjs.org/:_authToken=$NPM_TOKEN
+          EOF
 
           yarn changeset publish --tag canary
         env:


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Following on from #920 – we need to actually use the `NPM_TOKEN` to set the `.npmrc` file so that publishing will succeed (as this [failed run](https://github.com/blockprotocol/blockprotocol/actions/runs/4046289991/jobs/6958890309) demonstrates)