### PR TITLE
Track block downloads, expose last week's count via API

### DIFF
--- a/apps/site/src/lib/api/blocks/shared.ts
+++ b/apps/site/src/lib/api/blocks/shared.ts
@@ -1,1 +1,5 @@
+// If updating these, also update the references in infra/cloudflare-r2-wrangler
+
 export const blocksDbCollectionName = "bp-blocks";
+
+export const blockDownloadsCollectionName = "bp-block-downloads";

--- a/apps/site/src/lib/blocks.ts
+++ b/apps/site/src/lib/blocks.ts
@@ -34,6 +34,12 @@ export type ExpandedBlockMetadata = BlockMetadata & {
   // the folder where the block's assets are stored, currently doubling up as a unique identifier for the block
   // @todo this needs rethinking when we introduce versions, as there will be multiple asset folders
   componentId: string;
+
+  downloads?: {
+    // minimum number of downloads of a block's source in the last 7 days (excludes cached results)
+    weekly: number;
+  };
+
   // an absolute URL to example-graph.json, if it exists
   exampleGraph?: string | null;
   lastUpdated?: string | null;

--- a/infra/cloudflare-r2-wrangler/index.js
+++ b/infra/cloudflare-r2-wrangler/index.js
@@ -1,5 +1,9 @@
+import * as Realm from "realm-web";
+
+let App;
+
 export default {
-  async fetch(request, env) {
+  async fetch(request, env, context) {
     const url = new URL(request.url);
     const key = url.pathname.slice(1);
 
@@ -14,6 +18,56 @@ export default {
       object.writeHttpMetadata(headers);
       headers.set("etag", object.httpEtag);
       headers.set("Access-Control-Allow-Origin", "*");
+
+      const requestContext = {
+        ip: request.headers.get("CF-Connecting-IP"),
+        origin: request.headers.get("Origin"),
+        userAgent: request.headers.get("User-Agent"),
+        city: request.cf.city,
+        region: request.cf.region,
+      };
+
+      // Non-blocking function to register a download when a block's source requested
+      context.waitUntil(
+        (async () => {
+          try {
+            // @see https://www.mongodb.com/developer/products/atlas/cloudflare-worker-rest-api/
+            App = App || new Realm.App(env.MONGO_APP_SERVICE_ID);
+            const credentials = Realm.Credentials.apiKey(
+              env.MONGO_APP_SERVICE_API_KEY,
+            );
+            const user = await App.logIn(credentials);
+            const client = user.mongoClient("mongodb-atlas");
+
+            const blocks = client.db(env.MONGO_DB_NAME).collection("bp-blocks");
+
+            const stringifiedUrl = url.toString();
+
+            // @todo update when multiple block versions are maintained in db
+            const block = await blocks.findOne({ source: stringifiedUrl });
+
+            if (!block) {
+              // this isn't a source entry point
+              return;
+            }
+
+            const blockDownloads = client
+              .db(env.MONGO_DB_NAME)
+              .collection("bp-block-downloads");
+
+            await blockDownloads.insertOne({
+              author: block.author,
+              name: block.name,
+              blockId: block._id,
+              source: url.toString(),
+              downloadedAt: new Date().toISOString(),
+              context: requestContext,
+            });
+          } catch (err) {
+            console.error(`Error counting block download: ${err}`);
+          }
+        })(),
+      );
 
       return new Response(object.body, {
         headers,

--- a/infra/cloudflare-r2-wrangler/package.json
+++ b/infra/cloudflare-r2-wrangler/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cloudflare-r2-wrangler",
+  "version": "0.0.0-private",
+  "private": true,
+  "dependencies": {
+    "realm-web": "1.7.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
       "libs/@blockprotocol/*",
       "libs/@local/*",
       "libs/@local/internal-api-client-generator/typescript",
-      "libs/*"
+      "libs/*",
+      "infra/*"
     ],
     "nohoist": [
       "**/@types/css-font-loading-module",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3312,6 +3312,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
   integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
 
+"@realm.io/common@^0.1.4":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@realm.io/common/-/common-0.1.5.tgz#4285c8142d5024a0876318cdfd28f23ea98ebf4f"
+  integrity sha512-Y+UnICLvsPFpe2WOXWIdJUaV3G2qDocN8al/Yz13mYMkjODXHL4VhyfEKR2hvcAubv+7isdegEyYNdo3zQzbFA==
+
 "@rollup/plugin-sucrase@4.0.4":
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-sucrase/-/plugin-sucrase-4.0.4.tgz#0a3b3d97cdc239ec3399f5a10711f751e9f95d98"
@@ -4536,6 +4541,13 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -5227,10 +5239,10 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-bson@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/bson/-/bson-4.6.0.tgz#15c3b39ba3940c3d915a0c44d51459f4b4fbf1b2"
-  integrity sha512-8jw1NU1hglS+Da1jDOUYuNcBJ4cNHCFIqzlwoFNnsTOg2R/ox0aTYcTiBN4dzRa9q7Cvy6XErh3L8ReTEb9AQQ==
+bson@^4.5.4, bson@^4.6.0:
+  version "4.7.2"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-4.7.2.tgz#320f4ad0eaf5312dd9b45dc369cc48945e2a5f2e"
+  integrity sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==
   dependencies:
     buffer "^5.6.0"
 
@@ -6261,6 +6273,11 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
+detect-browser@^5.2.1:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/detect-browser/-/detect-browser-5.3.0.tgz#9705ef2bddf46072d0f7265a1fe300e36fe7ceca"
+  integrity sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==
+
 detect-indent@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
@@ -7176,6 +7193,11 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 eventemitter3@^4.0.0:
   version "4.0.7"
@@ -9342,6 +9364,11 @@ joi@^17.6.0:
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
 
+js-base64@^3.7.2:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.4.tgz#af95b20f23efc8034afd2d1cc5b9d0adf7419037"
+  integrity sha512-wpM/wi20Tl+3ifTyi0RdDckS4YTD4Lf953mBRrpG8547T7hInHNPEj8+ck4gB8VDcGyeAWFK++Wb/fU1BeavKQ==
+
 js-sdsl@^4.1.4:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.1.5.tgz#1ff1645e6b4d1b028cd3f862db88c9d887f26e2a"
@@ -11020,7 +11047,7 @@ node-domexception@1.0.0, node-domexception@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
   integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
 
-node-fetch@2.6.7, node-fetch@^2.5.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@2.6.7, node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
@@ -12457,6 +12484,19 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+realm-web@1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/realm-web/-/realm-web-1.7.1.tgz#5eb5c039221715a542881be8716f087e1b5af871"
+  integrity sha512-FQ7sjJ/HkzuF/QLD0AQxUi1Vzd49pKUFCc3UuvHQIoH62eHh8JotG6ZatTldlx+KY+vyW252ygxnorWGL+4dDw==
+  dependencies:
+    "@realm.io/common" "^0.1.4"
+    bson "^4.5.4"
+    detect-browser "^5.2.1"
+    js-base64 "^3.7.2"
+  optionalDependencies:
+    abort-controller "^3.0.0"
+    node-fetch "^2.6.0"
 
 rechoir@^0.8.0:
   version "0.8.0"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

1. Record download events for block source files when they go via the Cloudflare R2 worker
2. Expose a count of the last week's downloads via the API

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203543026679380/1203624210273373/f) _(internal)_

## 🔍 What does this change?

- Update the Cloudflare worker to record an event when a block's source entry point is requested
- Expose the last week's download count on the API return

## ⚠️ Known issues

- This only works for blocks which have been published via the CLI and are therefore (a) in the db and (b) served from R2, not those in the `hub/` folder which are served via Vercel (and whose metadata is in the repo, not the db)
- Even for blocks which are stored in R2, this will not count downloads which are cached in the browser (now) or at Cloudflare's edge (once we add caching in Cloudflare)

## 🐾 Next steps

- Deploy the production wrangler (only the development one deployed so far)
- Expose the weekly download count in the frontend

## ❓ How to test this?

1. Cumbersome as it involves publishing blocks to R2, hitting their source endpoint and then checking if the weekly download count has been incremented

## 📹 Demo

![Screenshot 2023-01-30 at 23 02 41](https://user-images.githubusercontent.com/37743469/215616489-18bcfffc-ea73-4e0b-8650-50297ac87d76.png)

