### PR TITLE
Introduce primitives for bi-temporal versioning

### DIFF
--- a/libs/@blockprotocol/graph/src/codegen/entity-type-to-typescript.ts
+++ b/libs/@blockprotocol/graph/src/codegen/entity-type-to-typescript.ts
@@ -7,6 +7,7 @@ import {
 import { compile, Options } from "json-schema-to-typescript";
 
 import { fetchAndValidateEntityType } from "../codegen.js";
+import { typedEntries } from "../shared.js";
 import { deduplicateTypeScriptStrings } from "./entity-type-to-typescript/deduplicate-ts-strings.js";
 import {
   generateEntityDefinition,
@@ -15,7 +16,7 @@ import {
   generateLinkEntityAndRightEntityDefinition,
 } from "./entity-type-to-typescript/type-definition-generators.js";
 import { hardcodedBpTypes } from "./hardcoded-bp-types.js";
-import { fetchTypeAsJson, typedEntries } from "./shared.js";
+import { fetchTypeAsJson } from "./shared.js";
 
 const bannerComment = (uri: string, depth: number) => `/**
  * This file was automatically generated – do not edit it.

--- a/libs/@blockprotocol/graph/src/codegen/shared.ts
+++ b/libs/@blockprotocol/graph/src/codegen/shared.ts
@@ -6,34 +6,3 @@ export const fetchTypeAsJson = (versionedUri: string) =>
       accept: "application/json",
     },
   }).then((resp) => resp.json());
-
-type TupleEntry<
-  T extends readonly unknown[],
-  I extends unknown[] = [],
-  R = never,
-> = T extends readonly [infer Head, ...infer Tail]
-  ? TupleEntry<Tail, [...I, unknown], R | [`${I["length"]}`, Head]>
-  : R;
-
-type ObjectEntry<T extends {}> = T extends object
-  ? { [K in keyof T]: [K, Required<T>[K]] }[keyof T] extends infer E
-    ? E extends [infer K, infer V]
-      ? K extends string | number
-        ? [`${K}`, V]
-        : never
-      : never
-    : never
-  : never;
-
-// Source: https://dev.to/harry0000/a-bit-convenient-typescript-type-definitions-for-objectentries-d6g
-type Entry<T extends {}> = T extends readonly [unknown, ...unknown[]]
-  ? TupleEntry<T>
-  : T extends ReadonlyArray<infer U>
-  ? [`${number}`, U]
-  : ObjectEntry<T>;
-
-// @todo deduplicate this and packages/mock-block-dock/src/util.ts
-/** `Object.entries` analogue which returns a well-typed array */
-export function typedEntries<T extends {}>(object: T): ReadonlyArray<Entry<T>> {
-  return Object.entries(object) as unknown as ReadonlyArray<Entry<T>>;
-}

--- a/libs/@blockprotocol/graph/src/shared.ts
+++ b/libs/@blockprotocol/graph/src/shared.ts
@@ -1,0 +1,28 @@
+type TupleEntry<
+  T extends readonly unknown[],
+  I extends unknown[] = [],
+  R = never,
+> = T extends readonly [infer Head, ...infer Tail]
+  ? TupleEntry<Tail, [...I, unknown], R | [`${I["length"]}`, Head]>
+  : R;
+type ObjectEntry<T extends {}> = T extends object
+  ? { [K in keyof T]: [K, Required<T>[K]] }[keyof T] extends infer E
+    ? E extends [infer K, infer V]
+      ? K extends string | number
+        ? [`${K}`, V]
+        : never
+      : never
+    : never
+  : never;
+// Source: https://dev.to/harry0000/a-bit-convenient-typescript-type-definitions-for-objectentries-d6g
+type Entry<T extends {}> = T extends readonly [unknown, ...unknown[]]
+  ? TupleEntry<T>
+  : T extends ReadonlyArray<infer U>
+  ? [`${number}`, U]
+  : ObjectEntry<T>;
+
+// @todo deduplicate this and packages/mock-block-dock/src/util.ts
+/** `Object.entries` analogue which returns a well-typed array */
+export function typedEntries<T extends {}>(object: T): ReadonlyArray<Entry<T>> {
+  return Object.entries(object) as unknown as ReadonlyArray<Entry<T>>;
+}

--- a/libs/@blockprotocol/graph/src/shared.ts
+++ b/libs/@blockprotocol/graph/src/shared.ts
@@ -5,6 +5,7 @@ type TupleEntry<
 > = T extends readonly [infer Head, ...infer Tail]
   ? TupleEntry<Tail, [...I, unknown], R | [`${I["length"]}`, Head]>
   : R;
+
 type ObjectEntry<T extends {}> = T extends object
   ? { [K in keyof T]: [K, Required<T>[K]] }[keyof T] extends infer E
     ? E extends [infer K, infer V]
@@ -14,7 +15,7 @@ type ObjectEntry<T extends {}> = T extends object
       : never
     : never
   : never;
-// Source: https://dev.to/harry0000/a-bit-convenient-typescript-type-definitions-for-objectentries-d6g
+
 type Entry<T extends {}> = T extends readonly [unknown, ...unknown[]]
   ? TupleEntry<T>
   : T extends ReadonlyArray<infer U>
@@ -22,7 +23,10 @@ type Entry<T extends {}> = T extends readonly [unknown, ...unknown[]]
   : ObjectEntry<T>;
 
 // @todo deduplicate this and packages/mock-block-dock/src/util.ts
-/** `Object.entries` analogue which returns a well-typed array */
+/** `Object.entries` analogue which returns a well-typed array
+ *
+ * Source: https://dev.to/harry0000/a-bit-convenient-typescript-type-definitions-for-objectentries-d6g
+ */
 export function typedEntries<T extends {}>(object: T): ReadonlyArray<Entry<T>> {
   return Object.entries(object) as unknown as ReadonlyArray<Entry<T>>;
 }

--- a/libs/@blockprotocol/graph/src/stdlib/bound.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/bound.ts
@@ -4,58 +4,60 @@ import {
 } from "../types/temporal-versioning.js";
 
 export const compareBounds = (
-  lhs: TemporalBound,
-  rhs: TemporalBound,
-  lhsType: keyof NonNullTimeInterval,
-  rhsType: keyof NonNullTimeInterval,
+  left: TemporalBound,
+  right: TemporalBound,
+  leftType: keyof NonNullTimeInterval,
+  rightType: keyof NonNullTimeInterval,
 ): number => {
   // If the bound values are not equal, then the bound with the lower value is less than the bound with the higher
   // value.
-  if (lhs.kind !== "unbounded" && rhs.kind !== "unbounded") {
-    if (lhs.limit !== rhs.limit) {
-      return lhs.limit.localeCompare(rhs.limit);
+  if (left.kind !== "unbounded" && right.kind !== "unbounded") {
+    if (left.limit !== right.limit) {
+      return left.limit.localeCompare(right.limit);
     }
   }
 
-  if (lhs.kind === rhs.kind && lhsType === rhsType) {
+  if (left.kind === right.kind && leftType === rightType) {
     return 0;
   }
 
   if (
-    (lhs.kind === "unbounded" && lhsType === "start") ||
-    (rhs.kind === "unbounded" && rhsType === "end") ||
-    (lhs.kind === "exclusive" &&
-      rhs.kind === "exclusive" &&
-      lhsType === "end" &&
-      rhsType === "start") ||
-    (lhs.kind === "exclusive" &&
-      rhs.kind === "inclusive" &&
-      lhsType === "end") ||
-    (lhs.kind === "inclusive" &&
-      rhs.kind === "exclusive" &&
-      rhsType === "start")
+    (left.kind === "unbounded" && leftType === "start") ||
+    (right.kind === "unbounded" && rightType === "end") ||
+    (left.kind === "exclusive" &&
+      right.kind === "exclusive" &&
+      leftType === "end" &&
+      rightType === "start") ||
+    (left.kind === "exclusive" &&
+      right.kind === "inclusive" &&
+      leftType === "end") ||
+    (left.kind === "inclusive" &&
+      right.kind === "exclusive" &&
+      rightType === "start")
   ) {
     return -1;
   }
 
   if (
-    (lhs.kind === "unbounded" && lhsType === "end") ||
-    (rhs.kind === "unbounded" && rhsType === "start") ||
-    (lhs.kind === "exclusive" &&
-      rhs.kind === "exclusive" &&
-      lhsType === "start" &&
-      rhsType === "end") ||
-    (lhs.kind === "exclusive" &&
-      rhs.kind === "inclusive" &&
-      lhsType === "start") ||
-    (lhs.kind === "inclusive" && rhs.kind === "exclusive" && rhsType === "end")
+    (left.kind === "unbounded" && leftType === "end") ||
+    (right.kind === "unbounded" && rightType === "start") ||
+    (left.kind === "exclusive" &&
+      right.kind === "exclusive" &&
+      leftType === "start" &&
+      rightType === "end") ||
+    (left.kind === "exclusive" &&
+      right.kind === "inclusive" &&
+      leftType === "start") ||
+    (left.kind === "inclusive" &&
+      right.kind === "exclusive" &&
+      rightType === "end")
   ) {
     return 1;
   }
   throw new Error(
     `Implementation error, failed to compare bounds.\nLHS: ${JSON.stringify(
-      lhs,
-    )}\nRHS: ${JSON.stringify(rhs)}`,
+      left,
+    )}\nRHS: ${JSON.stringify(right)}`,
   );
 };
 
@@ -65,18 +67,18 @@ export const compareBounds = (
  *
  * As such, two inclusive (or two exclusive) bounds with the same limit are *not* adjacent.
  *
- * @param lhs - The first bound of the comparison (order is unimportant)
- * @param rhs - The second bound of the comparison
+ * @param left - The first bound of the comparison (order is unimportant)
+ * @param right - The second bound of the comparison
  */
 export const boundIsAdjacentTo = (
-  lhs: TemporalBound,
-  rhs: TemporalBound,
+  left: TemporalBound,
+  right: TemporalBound,
 ): boolean => {
   if (
-    (lhs.kind === "inclusive" && rhs.kind === "exclusive") ||
-    (lhs.kind === "exclusive" && rhs.kind === "inclusive")
+    (left.kind === "inclusive" && right.kind === "exclusive") ||
+    (left.kind === "exclusive" && right.kind === "inclusive")
   ) {
-    return lhs.limit === rhs.limit;
+    return left.limit === right.limit;
   } else {
     return false;
   }

--- a/libs/@blockprotocol/graph/src/stdlib/bound.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/bound.ts
@@ -1,0 +1,83 @@
+import {
+  NonNullTimeInterval,
+  TemporalBound,
+} from "../types/temporal-versioning.js";
+
+export const compareBounds = (
+  lhs: TemporalBound,
+  rhs: TemporalBound,
+  lhsType: keyof NonNullTimeInterval,
+  rhsType: keyof NonNullTimeInterval,
+): number => {
+  // If the bound values are not equal, then the bound with the lower value is less than the bound with the higher
+  // value.
+  if (lhs.kind !== "unbounded" && rhs.kind !== "unbounded") {
+    if (lhs.limit !== rhs.limit) {
+      return lhs.limit.localeCompare(rhs.limit);
+    }
+  }
+
+  if (lhs.kind === rhs.kind && lhsType === rhsType) {
+    return 0;
+  }
+
+  if (
+    (lhs.kind === "unbounded" && lhsType === "start") ||
+    (rhs.kind === "unbounded" && rhsType === "end") ||
+    (lhs.kind === "exclusive" &&
+      rhs.kind === "exclusive" &&
+      lhsType === "end" &&
+      rhsType === "start") ||
+    (lhs.kind === "exclusive" &&
+      rhs.kind === "inclusive" &&
+      lhsType === "end") ||
+    (lhs.kind === "inclusive" &&
+      rhs.kind === "exclusive" &&
+      rhsType === "start")
+  ) {
+    return -1;
+  }
+
+  if (
+    (lhs.kind === "unbounded" && lhsType === "end") ||
+    (rhs.kind === "unbounded" && rhsType === "start") ||
+    (lhs.kind === "exclusive" &&
+      rhs.kind === "exclusive" &&
+      lhsType === "start" &&
+      rhsType === "end") ||
+    (lhs.kind === "exclusive" &&
+      rhs.kind === "inclusive" &&
+      lhsType === "start") ||
+    (lhs.kind === "inclusive" && rhs.kind === "exclusive" && rhsType === "end")
+  ) {
+    return 1;
+  }
+  throw new Error(
+    `Implementation error, failed to compare bounds.\nLHS: ${JSON.stringify(
+      lhs,
+    )}\nRHS: ${JSON.stringify(rhs)}`,
+  );
+};
+
+/**
+ * Checks whether two given temporal bounds are adjacent to one another, where adjacency is defined as being next to one
+ * another on the timeline, without any points between, *and where they are not overlapping*.
+ *
+ * As such, two inclusive (or two exclusive) bounds with the same limit are *not* adjacent.
+ *
+ * @param lhs - The first bound of the comparison (order is unimportant)
+ * @param rhs - The second bound of the comparison
+ */
+export const boundIsAdjacentTo = (
+  lhs: TemporalBound,
+  rhs: TemporalBound,
+): boolean => {
+  if (
+    (lhs.kind === "inclusive" && rhs.kind === "exclusive") ||
+    (lhs.kind === "exclusive" && rhs.kind === "inclusive")
+  ) {
+    return lhs.limit === rhs.limit;
+  } else {
+    return false;
+  }
+};

--- a/libs/@blockprotocol/graph/src/stdlib/bound.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/bound.ts
@@ -70,7 +70,7 @@ export const compareBounds = (
  * @param left - The first bound of the comparison (order is unimportant)
  * @param right - The second bound of the comparison
  */
-export const boundIsAdjacentTo = (
+export const boundIsAdjacentToBound = (
   left: TemporalBound,
   right: TemporalBound,
 ): boolean => {

--- a/libs/@blockprotocol/graph/src/stdlib/interval.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/interval.ts
@@ -11,12 +11,12 @@ import { boundIsAdjacentTo, compareBounds } from "./bound.js";
  * being next to one another on the timeline, without any points between, *and where they are not overlapping*. Thus,
  * if adjacent, the two intervals should span another given interval.
  *
- * @param lhs - The first interval of the comparison (order is unimportant)
- * @param rhs - The second interval of the comparison
+ * @param left - The first interval of the comparison (order is unimportant)
+ * @param right - The second interval of the comparison
  */
 export const intervalIsAdjacentToInterval = (
-  lhs: NonNullTimeInterval,
-  rhs: NonNullTimeInterval,
+  left: NonNullTimeInterval,
+  right: NonNullTimeInterval,
 ): boolean => {
   /*
    Examples           |     1     |     2     |     3     |     4     |     5
@@ -27,21 +27,21 @@ export const intervalIsAdjacentToInterval = (
    Contains Interval  |   true    |   true    |   false   |   false   |   false
    */
   return (
-    boundIsAdjacentTo(lhs.end, rhs.start) ||
-    boundIsAdjacentTo(lhs.start, rhs.end)
+    boundIsAdjacentTo(left.end, right.start) ||
+    boundIsAdjacentTo(left.start, right.end)
   );
 };
 
 /**
- * Returns whether or not the `rhs` {@link NonNullTimeInterval} is *completely contained* within the `lhs`
+ * Returns whether or not the `right` {@link NonNullTimeInterval} is *completely contained* within the `left`
  * {@link NonNullTimeInterval}.
  *
- * @param {NonNullTimeInterval} lhs - Checked if it contains the other
- * @param {NonNullTimeInterval} rhs - Checked if it's contained _within_ the other
+ * @param {NonNullTimeInterval} left - Checked if it contains the other
+ * @param {NonNullTimeInterval} right - Checked if it's contained _within_ the other
  */
 export const intervalContainsInterval = (
-  lhs: NonNullTimeInterval,
-  rhs: NonNullTimeInterval,
+  left: NonNullTimeInterval,
+  right: NonNullTimeInterval,
 ): boolean => {
   /*
    Examples           |     1     |     2     |     3     |     4     |     5     |     6
@@ -52,8 +52,8 @@ export const intervalContainsInterval = (
    Contains Interval  |   true    |   true    |   true    |   true    |   false   |   false
    */
   return (
-    compareBounds(lhs.start, rhs.start, "start", "start") <= 0 &&
-    compareBounds(lhs.end, rhs.end, "end", "end") >= 0
+    compareBounds(left.start, right.start, "start", "start") <= 0 &&
+    compareBounds(left.end, right.end, "end", "end") >= 0
   );
 };
 
@@ -88,12 +88,12 @@ export const intervalContainsTimestamp = (
 /**
  * Checks whether there is *any* overlap between two {@link NonNullTimeInterval}
  *
- * @param lhs
- * @param rhs
+ * @param left
+ * @param right
  */
 export const intervalOverlapsInterval = (
-  lhs: NonNullTimeInterval,
-  rhs: NonNullTimeInterval,
+  left: NonNullTimeInterval,
+  right: NonNullTimeInterval,
 ): boolean => {
   /*
    Examples |     1     |     2     |     3     |     4
@@ -104,10 +104,10 @@ export const intervalOverlapsInterval = (
    Overlaps |   true    |   true    |   false   |   false
    */
   return (
-    (compareBounds(lhs.start, rhs.start, "start", "start") >= 0 &&
-      compareBounds(lhs.start, rhs.end, "start", "end") <= 0) ||
-    (compareBounds(rhs.start, lhs.start, "start", "start") >= 0 &&
-      compareBounds(rhs.start, lhs.end, "start", "end") <= 0)
+    (compareBounds(left.start, right.start, "start", "start") >= 0 &&
+      compareBounds(left.start, right.end, "start", "end") <= 0) ||
+    (compareBounds(right.start, left.start, "start", "start") >= 0 &&
+      compareBounds(right.start, left.end, "start", "end") <= 0)
   );
 };
 
@@ -118,17 +118,17 @@ export const intervalOverlapsInterval = (
  * be bounded, same goes for `end` {@link TemporalBound}s respectively
  */
 type IntersectionReturn<
-  LhsInterval extends NonNullTimeInterval,
-  RhsInterval extends NonNullTimeInterval,
-> = [LhsInterval, RhsInterval] extends [
-  NonNullTimeInterval<infer LhsStartBound, infer LhsEndBound>,
-  NonNullTimeInterval<infer RhsStartBound, infer RhsEndBound>,
+  LeftInterval extends NonNullTimeInterval,
+  RightInterval extends NonNullTimeInterval,
+> = [LeftInterval, RightInterval] extends [
+  NonNullTimeInterval<infer LeftStartBound, infer LeftEndBound>,
+  NonNullTimeInterval<infer RightStartBound, infer RightEndBound>,
 ]
   ? NonNullTimeInterval<
-      LhsStartBound | RhsStartBound extends TimestampLimitedTemporalBound
+      LeftStartBound | RightStartBound extends TimestampLimitedTemporalBound
         ? TimestampLimitedTemporalBound
         : TemporalBound,
-      LhsEndBound | RhsEndBound extends TimestampLimitedTemporalBound
+      LeftEndBound | RightEndBound extends TimestampLimitedTemporalBound
         ? TimestampLimitedTemporalBound
         : TemporalBound
     >
@@ -138,16 +138,16 @@ type IntersectionReturn<
  * Returns the intersection (overlapping range) of two given {@link NonNullTimeInterval}s, returning `null` if there
  * isn't any.
  *
- * @param {NonNullTimeInterval} lhs
- * @param {NonNullTimeInterval} rhs
+ * @param {NonNullTimeInterval} left
+ * @param {NonNullTimeInterval} right
  */
 export const intervalIntersectionWithInterval = <
-  LhsInterval extends NonNullTimeInterval = NonNullTimeInterval,
-  RhsInterval extends NonNullTimeInterval = NonNullTimeInterval,
+  LeftInterval extends NonNullTimeInterval = NonNullTimeInterval,
+  RightInterval extends NonNullTimeInterval = NonNullTimeInterval,
 >(
-  lhs: LhsInterval,
-  rhs: RhsInterval,
-): IntersectionReturn<LhsInterval, RhsInterval> | null => {
+  left: LeftInterval,
+  right: RightInterval,
+): IntersectionReturn<LeftInterval, RightInterval> | null => {
   /*
    Examples     |     1     |     2
    =============|===========|===========
@@ -156,17 +156,19 @@ export const intervalIntersectionWithInterval = <
    -------------|-----------|-----------
    Intersection |   [---]   |   [---]
    */
-  if (!intervalOverlapsInterval(lhs, rhs)) {
+  if (!intervalOverlapsInterval(left, right)) {
     return null;
   } else {
     return {
       start:
-        compareBounds(lhs.start, rhs.start, "start", "start") <= 0
-          ? rhs.start
-          : lhs.start,
+        compareBounds(left.start, right.start, "start", "start") <= 0
+          ? right.start
+          : left.start,
       end:
-        compareBounds(lhs.end, rhs.end, "end", "end") <= 0 ? lhs.end : rhs.end,
-    } as IntersectionReturn<LhsInterval, RhsInterval>;
+        compareBounds(left.end, right.end, "end", "end") <= 0
+          ? left.end
+          : right.end,
+    } as IntersectionReturn<LeftInterval, RightInterval>;
   }
 };
 
@@ -177,20 +179,20 @@ export const intervalIntersectionWithInterval = <
  * bounded, same goes for end respectively
  */
 type MergeReturn<
-  LhsInterval extends NonNullTimeInterval,
-  RhsInterval extends NonNullTimeInterval,
-> = [LhsInterval, RhsInterval] extends [
-  NonNullTimeInterval<infer LhsStartBound, infer LhsEndBound>,
-  NonNullTimeInterval<infer RhsStartBound, infer RhsEndBound>,
+  LeftInterval extends NonNullTimeInterval,
+  RightInterval extends NonNullTimeInterval,
+> = [LeftInterval, RightInterval] extends [
+  NonNullTimeInterval<infer LeftStartBound, infer LeftEndBound>,
+  NonNullTimeInterval<infer RightStartBound, infer RightEndBound>,
 ]
   ? NonNullTimeInterval<
-      LhsStartBound extends TimestampLimitedTemporalBound
-        ? RhsStartBound extends TimestampLimitedTemporalBound
+      LeftStartBound extends TimestampLimitedTemporalBound
+        ? RightStartBound extends TimestampLimitedTemporalBound
           ? TimestampLimitedTemporalBound
           : TemporalBound
         : TemporalBound,
-      LhsEndBound extends TimestampLimitedTemporalBound
-        ? RhsEndBound extends TimestampLimitedTemporalBound
+      LeftEndBound extends TimestampLimitedTemporalBound
+        ? RightEndBound extends TimestampLimitedTemporalBound
           ? TimestampLimitedTemporalBound
           : TemporalBound
         : TemporalBound
@@ -204,16 +206,16 @@ type MergeReturn<
  * If the intervals do not overlap and are not adjacent, the resultant interval will span _more_ space than that spanned
  * by the given intervals. _This is different behavior compared to {@link intervalUnionWithInterval}._
  *
- * @param {NonNullTimeInterval} lhs
- * @param {NonNullTimeInterval} rhs
+ * @param {NonNullTimeInterval} left
+ * @param {NonNullTimeInterval} right
  */
 export const intervalMergeWithInterval = <
-  LhsInterval extends NonNullTimeInterval = NonNullTimeInterval,
-  RhsInterval extends NonNullTimeInterval = NonNullTimeInterval,
+  LeftInterval extends NonNullTimeInterval = NonNullTimeInterval,
+  RightInterval extends NonNullTimeInterval = NonNullTimeInterval,
 >(
-  lhs: LhsInterval,
-  rhs: RhsInterval,
-): MergeReturn<LhsInterval, RhsInterval> => {
+  left: LeftInterval,
+  right: RightInterval,
+): MergeReturn<LeftInterval, RightInterval> => {
   /*
    Examples   |      1      |      2      |       3       |        4        |      5
    ===========|=============|=============|===============|=================|=============
@@ -224,20 +226,23 @@ export const intervalMergeWithInterval = <
    */
   return {
     start:
-      compareBounds(lhs.start, rhs.start, "start", "start") <= 0
-        ? lhs.start
-        : rhs.start,
-    end: compareBounds(lhs.end, rhs.end, "end", "end") >= 0 ? lhs.end : rhs.end,
-  } as MergeReturn<LhsInterval, RhsInterval>;
+      compareBounds(left.start, right.start, "start", "start") <= 0
+        ? left.start
+        : right.start,
+    end:
+      compareBounds(left.end, right.end, "end", "end") >= 0
+        ? left.end
+        : right.end,
+  } as MergeReturn<LeftInterval, RightInterval>;
 };
 
 type UnionReturn<
-  LhsInterval extends NonNullTimeInterval,
-  RhsInterval extends NonNullTimeInterval,
+  LeftInterval extends NonNullTimeInterval,
+  RightInterval extends NonNullTimeInterval,
 > =
-  | [MergeReturn<LhsInterval, RhsInterval>]
-  | [LhsInterval, RhsInterval]
-  | [RhsInterval, LhsInterval];
+  | [MergeReturn<LeftInterval, RightInterval>]
+  | [LeftInterval, RightInterval]
+  | [RightInterval, LeftInterval];
 
 /**
  * Given two {@link NonNullTimeInterval}s, this returns a list of non-adjacent, non-overlapping
@@ -246,16 +251,16 @@ type UnionReturn<
  * In other words, if the intervals _are_ adjacent, or overlap, then this returns the result of calling
  * {@link intervalMergeWithInterval} on the intervals, otherwise it returns the two intervals back.
  *
- * @param {NonNullTimeInterval}  lhs
- * @param {NonNullTimeInterval}  rhs
+ * @param {NonNullTimeInterval}  left
+ * @param {NonNullTimeInterval}  right
  */
 export const intervalUnionWithInterval = <
-  LhsInterval extends NonNullTimeInterval = NonNullTimeInterval,
-  RhsInterval extends NonNullTimeInterval = NonNullTimeInterval,
+  LeftInterval extends NonNullTimeInterval = NonNullTimeInterval,
+  RightInterval extends NonNullTimeInterval = NonNullTimeInterval,
 >(
-  lhs: LhsInterval,
-  rhs: RhsInterval,
-): UnionReturn<LhsInterval, RhsInterval> => {
+  left: LeftInterval,
+  right: RightInterval,
+): UnionReturn<LeftInterval, RightInterval> => {
   /*
    Examples   |      1      |      2      |       3       |        4        |      5
    ===========|=============|=============|===============|=================|=============
@@ -265,14 +270,14 @@ export const intervalUnionWithInterval = <
    Union      |  [-------]  |  [-------]  | [---]   [---) | (-----] [-----] | [---------]
    */
   if (
-    intervalOverlapsInterval(lhs, rhs) ||
-    intervalIsAdjacentToInterval(lhs, rhs)
+    intervalOverlapsInterval(left, right) ||
+    intervalIsAdjacentToInterval(left, right)
   ) {
-    return [intervalMergeWithInterval(lhs, rhs)];
-  } else if (compareBounds(lhs.start, rhs.start, "start", "start") < 0) {
-    return [lhs, rhs];
+    return [intervalMergeWithInterval(left, right)];
+  } else if (compareBounds(left.start, right.start, "start", "start") < 0) {
+    return [left, right];
   } else {
-    return [rhs, lhs];
+    return [right, left];
   }
 };
 

--- a/libs/@blockprotocol/graph/src/stdlib/interval.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/interval.ts
@@ -1,0 +1,333 @@
+import {
+  NonNullTimeInterval,
+  TemporalBound,
+  Timestamp,
+  TimestampLimitedTemporalBound,
+} from "../types/temporal-versioning.js";
+import { boundIsAdjacentTo, compareBounds } from "./bound.js";
+
+/**
+ * Checks whether two given {@link NonNullTimeInterval}s are adjacent to one another, where adjacency is defined as
+ * being next to one another on the timeline, without any points between, *and where they are not overlapping*. Thus,
+ * if adjacent, the two intervals should span another given interval.
+ *
+ * @param lhs - The first interval of the comparison (order is unimportant)
+ * @param rhs - The second interval of the comparison
+ */
+export const intervalIsAdjacentToInterval = (
+  lhs: NonNullTimeInterval,
+  rhs: NonNullTimeInterval,
+): boolean => {
+  /*
+   Examples           |     1     |     2     |     3     |     4     |     5
+   ===================|===========|===========|===========|===========|===========
+   Interval A         | [---]     | [---)     | [---]     | [---)     | [-]
+   Interval B         |     (---] |     [---] |     [---] |     (---] |      [--]
+   -------------------|-----------|-----------|-----------|-----------|-----------
+   Contains Interval  |   true    |   true    |   false   |   false   |   false
+   */
+  return (
+    boundIsAdjacentTo(lhs.end, rhs.start) ||
+    boundIsAdjacentTo(lhs.start, rhs.end)
+  );
+};
+
+/**
+ * Returns whether or not the `rhs` {@link NonNullTimeInterval} is *completely contained* within the `lhs`
+ * {@link NonNullTimeInterval}.
+ *
+ * @param {NonNullTimeInterval} lhs - Checked if it contains the other
+ * @param {NonNullTimeInterval} rhs - Checked if it's contained _within_ the other
+ */
+export const intervalContainsInterval = (
+  lhs: NonNullTimeInterval,
+  rhs: NonNullTimeInterval,
+): boolean => {
+  /*
+   Examples           |     1     |     2     |     3     |     4     |     5     |     6
+   ===================|===========|===========|===========|===========|===========|===========
+   Interval A         |  [------] |   [----]  |   [----]  |   (----]  |   (----]  | [--]
+   Interval B         |    [--]   |   [---]   |   (---]   |   (---]   |   [---]   |   [---]
+   -------------------|-----------|-----------|-----------|-----------|-----------|-----------
+   Contains Interval  |   true    |   true    |   true    |   true    |   false   |   false
+   */
+  return (
+    compareBounds(lhs.start, rhs.start, "start", "start") <= 0 &&
+    compareBounds(lhs.end, rhs.end, "end", "end") >= 0
+  );
+};
+
+/**
+ * Returns whether or not the given {@link Timestamp} falls within the span of a given {@link NonNullTimeInterval}.
+ *
+ * @param {NonNullTimeInterval} interval
+ * @param {Timestamp} timestamp
+ */
+export const intervalContainsTimestamp = (
+  interval: NonNullTimeInterval,
+  timestamp: Timestamp,
+): boolean => {
+  /*
+   Examples            |     1     |     2     |     3     |     4
+   ====================|===========|===========|===========|===========
+   Interval            |    [----] |   (--]    |  [--)     | [--]
+   Timestamp           |      .    |      .    |     .     |       .
+   --------------------|-----------|-----------|-----------|-----------
+   Contains Timestamp  |   true    |   true    |   false   |   false
+   */
+  return (
+    compareBounds(
+      interval.start,
+      { kind: "inclusive", limit: timestamp },
+      "start",
+      "start",
+    ) <= 0 &&
+    compareBounds(
+      interval.end,
+      { kind: "inclusive", limit: timestamp },
+      "end",
+      "end",
+    ) >= 0
+  );
+};
+
+/**
+ * Checks whether there is *any* overlap between two {@link NonNullTimeInterval}
+ *
+ * @param lhs
+ * @param rhs
+ */
+export const intervalOverlapsInterval = (
+  lhs: NonNullTimeInterval,
+  rhs: NonNullTimeInterval,
+): boolean => {
+  /*
+   Examples |     1     |     2     |     3     |     4
+   =========|===========|===========|===========|===========
+   Range A  |    [----] | [--]      | [--]      | [--]
+   Range B  | [-----]   |    [--]   |    (--]   |       (--]
+   ---------|-----------|-----------|-----------|-----------
+   Overlaps |   true    |   true    |   false   |   false
+   */
+  return (
+    (compareBounds(lhs.start, rhs.start, "start", "start") >= 0 &&
+      compareBounds(lhs.start, rhs.end, "start", "end") <= 0) ||
+    (compareBounds(rhs.start, lhs.start, "start", "start") >= 0 &&
+      compareBounds(rhs.start, lhs.end, "start", "end") <= 0)
+  );
+};
+
+/**
+ * Advanced type to provide stronger type information when using {@link intervalIntersectionWithInterval}.
+ *
+ * If *either* of the `start` {@link TemporalBound}s is bounded, then the resultant `start` {@link TemporalBound} will
+ * be bounded, same goes for `end` {@link TemporalBound}s respectively
+ */
+type IntersectionReturn<
+  LhsInterval extends NonNullTimeInterval,
+  RhsInterval extends NonNullTimeInterval,
+> = [LhsInterval, RhsInterval] extends [
+  NonNullTimeInterval<infer LhsStartBound, infer LhsEndBound>,
+  NonNullTimeInterval<infer RhsStartBound, infer RhsEndBound>,
+]
+  ? NonNullTimeInterval<
+      LhsStartBound | RhsStartBound extends TimestampLimitedTemporalBound
+        ? TimestampLimitedTemporalBound
+        : TemporalBound,
+      LhsEndBound | RhsEndBound extends TimestampLimitedTemporalBound
+        ? TimestampLimitedTemporalBound
+        : TemporalBound
+    >
+  : never;
+
+/**
+ * Returns the intersection (overlapping range) of two given {@link NonNullTimeInterval}s, returning `null` if there
+ * isn't any.
+ *
+ * @param {NonNullTimeInterval} lhs
+ * @param {NonNullTimeInterval} rhs
+ */
+export const intervalIntersectionWithInterval = <
+  LhsInterval extends NonNullTimeInterval = NonNullTimeInterval,
+  RhsInterval extends NonNullTimeInterval = NonNullTimeInterval,
+>(
+  lhs: LhsInterval,
+  rhs: RhsInterval,
+): IntersectionReturn<LhsInterval, RhsInterval> | null => {
+  /*
+   Examples     |     1     |     2
+   =============|===========|===========
+   Interval A   |   [-----] | [-----]
+   Interval B   | [-----]   |   [-----]
+   -------------|-----------|-----------
+   Intersection |   [---]   |   [---]
+   */
+  if (!intervalOverlapsInterval(lhs, rhs)) {
+    return null;
+  } else {
+    return {
+      start:
+        compareBounds(lhs.start, rhs.start, "start", "start") <= 0
+          ? rhs.start
+          : lhs.start,
+      end:
+        compareBounds(lhs.end, rhs.end, "end", "end") <= 0 ? lhs.end : rhs.end,
+    } as IntersectionReturn<LhsInterval, RhsInterval>;
+  }
+};
+
+/**
+ * Advanced type to provide stronger type information when using {@link intervalMergeWithInterval}.
+ *
+ * If *both* of the `start` {@link TemporalBound}s are bounded, then the resultant `start` {@link TemporalBound} will be
+ * bounded, same goes for end respectively
+ */
+type MergeReturn<
+  LhsInterval extends NonNullTimeInterval,
+  RhsInterval extends NonNullTimeInterval,
+> = [LhsInterval, RhsInterval] extends [
+  NonNullTimeInterval<infer LhsStartBound, infer LhsEndBound>,
+  NonNullTimeInterval<infer RhsStartBound, infer RhsEndBound>,
+]
+  ? NonNullTimeInterval<
+      LhsStartBound extends TimestampLimitedTemporalBound
+        ? RhsStartBound extends TimestampLimitedTemporalBound
+          ? TimestampLimitedTemporalBound
+          : TemporalBound
+        : TemporalBound,
+      LhsEndBound extends TimestampLimitedTemporalBound
+        ? RhsEndBound extends TimestampLimitedTemporalBound
+          ? TimestampLimitedTemporalBound
+          : TemporalBound
+        : TemporalBound
+    >
+  : never;
+
+/**
+ * Returns the {@link NonNullTimeInterval} which fully spans the space between the `start` {@link TemporalBound}s and
+ * end {@link TemporalBound}s of two provided {@link NonNullTimeInterval}s.
+ *
+ * If the intervals do not overlap and are not adjacent, the resultant interval will span _more_ space than that spanned
+ * by the given intervals. _This is different behavior compared to {@link intervalUnionWithInterval}._
+ *
+ * @param {NonNullTimeInterval} lhs
+ * @param {NonNullTimeInterval} rhs
+ */
+export const intervalMergeWithInterval = <
+  LhsInterval extends NonNullTimeInterval = NonNullTimeInterval,
+  RhsInterval extends NonNullTimeInterval = NonNullTimeInterval,
+>(
+  lhs: LhsInterval,
+  rhs: RhsInterval,
+): MergeReturn<LhsInterval, RhsInterval> => {
+  /*
+   Examples   |      1      |      2      |       3       |        4        |      5
+   ===========|=============|=============|===============|=================|=============
+   Interval A |    [-----]  |  [-----]    | [---]         |         [-----] | [---------]
+   Interval B |  [-----]    |    [-----]  |         [---) | (-----]         |   [-----]
+   -----------|-------------|-------------|---------------|-----------------|-------------
+   Merge      |  [-------]  |  [-------]  | [-----------) | (-------------] | [---------]
+   */
+  return {
+    start:
+      compareBounds(lhs.start, rhs.start, "start", "start") <= 0
+        ? lhs.start
+        : rhs.start,
+    end: compareBounds(lhs.end, rhs.end, "end", "end") >= 0 ? lhs.end : rhs.end,
+  } as MergeReturn<LhsInterval, RhsInterval>;
+};
+
+type UnionReturn<
+  LhsInterval extends NonNullTimeInterval,
+  RhsInterval extends NonNullTimeInterval,
+> =
+  | [MergeReturn<LhsInterval, RhsInterval>]
+  | [LhsInterval, RhsInterval]
+  | [RhsInterval, LhsInterval];
+
+/**
+ * Given two {@link NonNullTimeInterval}s, this returns a list of non-adjacent, non-overlapping
+ * {@link NonNullTimeInterval}s which span the space spanned by the input intervals.
+ *
+ * In other words, if the intervals _are_ adjacent, or overlap, then this returns the result of calling
+ * {@link intervalMergeWithInterval} on the intervals, otherwise it returns the two intervals back.
+ *
+ * @param {NonNullTimeInterval}  lhs
+ * @param {NonNullTimeInterval}  rhs
+ */
+export const intervalUnionWithInterval = <
+  LhsInterval extends NonNullTimeInterval = NonNullTimeInterval,
+  RhsInterval extends NonNullTimeInterval = NonNullTimeInterval,
+>(
+  lhs: LhsInterval,
+  rhs: RhsInterval,
+): UnionReturn<LhsInterval, RhsInterval> => {
+  /*
+   Examples   |      1      |      2      |       3       |        4        |      5
+   ===========|=============|=============|===============|=================|=============
+   Interval A |    [-----]  |  [-----]    | [---]         |         [-----] | [---------]
+   Interval B |  [-----]    |    [-----]  |         [---) | (-----]         |   [-----]
+   -----------|-------------|-------------|---------------|-----------------|-------------
+   Union      |  [-------]  |  [-------]  | [---]   [---) | (-----] [-----] | [---------]
+   */
+  if (
+    intervalOverlapsInterval(lhs, rhs) ||
+    intervalIsAdjacentToInterval(lhs, rhs)
+  ) {
+    return [intervalMergeWithInterval(lhs, rhs)];
+  } else if (compareBounds(lhs.start, rhs.start, "start", "start") < 0) {
+    return [lhs, rhs];
+  } else {
+    return [rhs, lhs];
+  }
+};
+
+/**
+ * Given a collection of {@link NonNullTimeInterval}s, this returns a list of non-adjacent, non-overlapping
+ * {@link NonNullTimeInterval}'s which span the space spanned by the input intervals.
+ *
+ * Conceptually this recursively calls {@link intervalUnionWithInterval} pairwise until all intervals have been unioned
+ * with one another. The space spanned by the result will not necessarily be contiguous (may contain gaps).
+ *
+ * @param {NonNullTimeInterval[]} intervals
+ */
+export const unionOfIntervals = <IntervalsType extends NonNullTimeInterval>(
+  ...intervals: IntervalsType[]
+): UnionReturn<IntervalsType, IntervalsType>[number][] => {
+  /*
+   Examples   |       1       |       2       |       3
+   ===========|===============|===============|===============
+   Interval A | [--]          | (--]          | [--]
+   Interval B |      [-]      |      [-)      |      [-)
+   Interval C |  [--]         |  [--]         |  [---]
+   Interval D |           [-] |           [-] |        [----]
+   -----------|---------------|---------------|---------------
+   Union      | [------]  [-] | (------)  [-] | [-----------]
+   */
+  intervals.sort((intervalA, intervalB) => {
+    const startComparison = compareBounds(
+      intervalA.start,
+      intervalB.start,
+      "start",
+      "start",
+    );
+
+    return startComparison !== 0
+      ? startComparison
+      : compareBounds(intervalA.end, intervalB.end, "end", "end");
+  });
+
+  return intervals.reduce((union, currentInterval) => {
+    if (union.length === 0) {
+      return [currentInterval];
+    } else {
+      // The intervals were sorted above, it's only necessary to check the union of this with the last interval, if it
+      // overlaps two of the previous ones (which would make it necessary to check the union with more than just the
+      // last) then those would have been merged into one in the previous iteration (again because they are sorted).
+      return [
+        ...union.slice(0, -1),
+        ...intervalUnionWithInterval(union.at(-1)!, currentInterval),
+      ];
+    }
+  }, [] as UnionReturn<IntervalsType, IntervalsType>[number][]);
+};

--- a/libs/@blockprotocol/graph/src/stdlib/interval.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/interval.ts
@@ -4,7 +4,7 @@ import {
   Timestamp,
   TimestampLimitedTemporalBound,
 } from "../types/temporal-versioning.js";
-import { boundIsAdjacentTo, compareBounds } from "./bound.js";
+import { boundIsAdjacentToBound, compareBounds } from "./bound.js";
 
 /**
  * Checks whether two given {@link NonNullTimeInterval}s are adjacent to one another, where adjacency is defined as
@@ -27,8 +27,8 @@ export const intervalIsAdjacentToInterval = (
    Contains Interval  |   true    |   true    |   false   |   false   |   false
    */
   return (
-    boundIsAdjacentTo(left.end, right.start) ||
-    boundIsAdjacentTo(left.start, right.end)
+    boundIsAdjacentToBound(left.end, right.start) ||
+    boundIsAdjacentToBound(left.start, right.end)
   );
 };
 

--- a/libs/@blockprotocol/graph/src/stdlib/interval.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/interval.ts
@@ -1,8 +1,8 @@
 import {
+  LimitedTemporalBound,
   NonNullTimeInterval,
   TemporalBound,
   Timestamp,
-  TimestampLimitedTemporalBound,
 } from "../types/temporal-versioning.js";
 import { boundIsAdjacentToBound, compareBounds } from "./bound.js";
 
@@ -67,7 +67,7 @@ export const intervalContainsTimestamp = (
   interval: NonNullTimeInterval,
   timestamp: Timestamp,
 ): boolean => {
-  const timestampAsBound: TimestampLimitedTemporalBound = {
+  const timestampAsBound: LimitedTemporalBound = {
     kind: "inclusive",
     limit: timestamp,
   };
@@ -125,11 +125,11 @@ type IntersectionReturn<
   NonNullTimeInterval<infer RightStartBound, infer RightEndBound>,
 ]
   ? NonNullTimeInterval<
-      LeftStartBound | RightStartBound extends TimestampLimitedTemporalBound
-        ? TimestampLimitedTemporalBound
+      LeftStartBound | RightStartBound extends LimitedTemporalBound
+        ? LimitedTemporalBound
         : TemporalBound,
-      LeftEndBound | RightEndBound extends TimestampLimitedTemporalBound
-        ? TimestampLimitedTemporalBound
+      LeftEndBound | RightEndBound extends LimitedTemporalBound
+        ? LimitedTemporalBound
         : TemporalBound
     >
   : never;
@@ -186,14 +186,14 @@ type MergeReturn<
   NonNullTimeInterval<infer RightStartBound, infer RightEndBound>,
 ]
   ? NonNullTimeInterval<
-      LeftStartBound extends TimestampLimitedTemporalBound
-        ? RightStartBound extends TimestampLimitedTemporalBound
-          ? TimestampLimitedTemporalBound
+      LeftStartBound extends LimitedTemporalBound
+        ? RightStartBound extends LimitedTemporalBound
+          ? LimitedTemporalBound
           : TemporalBound
         : TemporalBound,
-      LeftEndBound extends TimestampLimitedTemporalBound
-        ? RightEndBound extends TimestampLimitedTemporalBound
-          ? TimestampLimitedTemporalBound
+      LeftEndBound extends LimitedTemporalBound
+        ? RightEndBound extends LimitedTemporalBound
+          ? LimitedTemporalBound
           : TemporalBound
         : TemporalBound
     >

--- a/libs/@blockprotocol/graph/src/stdlib/interval.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/interval.ts
@@ -67,6 +67,10 @@ export const intervalContainsTimestamp = (
   interval: NonNullTimeInterval,
   timestamp: Timestamp,
 ): boolean => {
+  const timestampAsBound: TimestampLimitedTemporalBound = {
+    kind: "inclusive",
+    limit: timestamp,
+  };
   /*
    Examples            |     1     |     2     |     3     |     4
    ====================|===========|===========|===========|===========
@@ -76,18 +80,8 @@ export const intervalContainsTimestamp = (
    Contains Timestamp  |   true    |   true    |   false   |   false
    */
   return (
-    compareBounds(
-      interval.start,
-      { kind: "inclusive", limit: timestamp },
-      "start",
-      "start",
-    ) <= 0 &&
-    compareBounds(
-      interval.end,
-      { kind: "inclusive", limit: timestamp },
-      "end",
-      "end",
-    ) >= 0
+    compareBounds(interval.start, timestampAsBound, "start", "start") <= 0 &&
+    compareBounds(interval.end, timestampAsBound, "end", "end") >= 0
   );
 };
 

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/element/entity.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/element/entity.ts
@@ -1,7 +1,7 @@
 import { Entity, EntityId, EntityRevisionId } from "../../../types/entity.js";
 import { Subgraph } from "../../../types/subgraph.js";
-import { Timestamp } from "../../../types/subgraph/time.js";
 import { isEntityVertex } from "../../../types/subgraph/vertices.js";
+import { Timestamp } from "../../../types/temporal-versioning.js";
 
 /**
  * Returns all `Entity`s within the vertices of the subgraph, optionally filtering to only get their latest revisions.

--- a/libs/@blockprotocol/graph/src/types.ts
+++ b/libs/@blockprotocol/graph/src/types.ts
@@ -4,3 +4,4 @@ export * from "./types/file.js";
 export * from "./types/linked-aggregation.js";
 export * from "./types/ontology.js";
 export * from "./types/subgraph.js";
+export * from "./types/temporal-versioning.js";

--- a/libs/@blockprotocol/graph/src/types/subgraph.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph.ts
@@ -13,7 +13,6 @@ import {
 export * from "./ontology.js";
 export * from "./subgraph/edges.js";
 export * from "./subgraph/graph-resolve-depths.js";
-export * from "./subgraph/time.js";
 export * from "./subgraph/vertices.js";
 
 export type DataTypeRootType = {

--- a/libs/@blockprotocol/graph/src/types/subgraph/edges.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/edges.ts
@@ -1,11 +1,11 @@
 import { BaseUri } from "@blockprotocol/type-system/slim";
 
 import { EntityId } from "../entity.js";
+import { Timestamp } from "../temporal-versioning.js";
 import {
   KnowledgeGraphOutwardEdge,
   OntologyOutwardEdge,
 } from "./edges/outward-edge.js";
-import { Timestamp } from "./time.js";
 
 export * from "./edges/kind.js";
 export * from "./edges/outward-edge.js";

--- a/libs/@blockprotocol/graph/src/types/subgraph/edges/outward-edge.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/edges/outward-edge.ts
@@ -1,6 +1,6 @@
 import { EntityId, isEntityRecordId } from "../../entity.js";
 import { isOntologyTypeRecordId } from "../../ontology.js";
-import { Timestamp } from "../time.js";
+import { Timestamp } from "../../temporal-versioning.js";
 import { EntityVertexId, OntologyTypeVertexId } from "../vertices";
 import {
   isKnowledgeGraphEdgeKind,

--- a/libs/@blockprotocol/graph/src/types/subgraph/time.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/time.ts
@@ -1,5 +1,0 @@
-// Comment to capture intention of this file, this can hold types related to time and versioning. This could include
-// Timestamps, intervals, possibly different dimensions of time, depending on how the BP grows.
-
-/** @todo - Consider branding this */
-export type Timestamp = string;

--- a/libs/@blockprotocol/graph/src/types/temporal-versioning.ts
+++ b/libs/@blockprotocol/graph/src/types/temporal-versioning.ts
@@ -1,0 +1,5 @@
+/**
+ * Types used in embedding applications and blocks that support multi-axis temporal versioning schemes.
+ */
+
+export type Timestamp = string;

--- a/libs/@blockprotocol/graph/src/types/temporal-versioning.ts
+++ b/libs/@blockprotocol/graph/src/types/temporal-versioning.ts
@@ -17,21 +17,21 @@ export type TemporalAxes = "transactionTime" | "decisionTime";
 /**
  * The bound of a time-interval that is either exclusively or inclusively limited by a `Timestamp`
  */
-export type TimestampLimitedTemporalBound = {
+export type LimitedTemporalBound = {
   kind: "inclusive" | "exclusive";
   limit: Timestamp;
 };
 
-export type InclusiveTimestampLimitedTemporalBound = Subtype<
-  TimestampLimitedTemporalBound,
+export type InclusiveLimitedTemporalBound = Subtype<
+  LimitedTemporalBound,
   {
     kind: "inclusive";
     limit: Timestamp;
   }
 >;
 
-export type ExclusiveTimestampLimitedTemporalBound = Subtype<
-  TimestampLimitedTemporalBound,
+export type ExclusiveLimitedTemporalBound = Subtype<
+  LimitedTemporalBound,
   {
     kind: "exclusive";
     limit: Timestamp;
@@ -43,7 +43,7 @@ export type Unbounded = { kind: "unbounded" };
 /**
  * The bound (or explicit lack of a bound) of a time-interval
  */
-export type TemporalBound = Unbounded | TimestampLimitedTemporalBound;
+export type TemporalBound = Unbounded | LimitedTemporalBound;
 
 export type TimeInterval<
   StartBound extends TemporalBound | null,
@@ -59,8 +59,8 @@ export type NonNullTimeInterval<
 > = TimeInterval<StartBound, EndBound>;
 
 export type BoundedTimeInterval = TimeInterval<
-  TimestampLimitedTemporalBound,
-  TimestampLimitedTemporalBound
+  LimitedTemporalBound,
+  LimitedTemporalBound
 >;
 
 /**
@@ -72,7 +72,7 @@ export type BoundedTimeInterval = TimeInterval<
 export type VariableTemporalAxis<
   Axis extends TemporalAxes,
   StartBound extends TemporalBound | null,
-  EndBound extends TimestampLimitedTemporalBound | null,
+  EndBound extends LimitedTemporalBound | null,
 > = {
   axis: Axis;
   interval: TimeInterval<StartBound, EndBound>;

--- a/libs/@blockprotocol/graph/src/types/temporal-versioning.ts
+++ b/libs/@blockprotocol/graph/src/types/temporal-versioning.ts
@@ -2,4 +2,90 @@
  * Types used in embedding applications and blocks that support multi-axis temporal versioning schemes.
  */
 
+import { Subtype } from "../util.js";
+
+/**
+ * An ISO 8601 formatted timestamp string
+ */
 export type Timestamp = string;
+
+/**
+ * @todo - doc
+ */
+export type TemporalAxes = "transactionTime" | "decisionTime";
+
+/**
+ * The bound of a time-interval that is either exclusively or inclusively limited by a `Timestamp`
+ */
+export type TimestampLimitedTemporalBound = {
+  kind: "inclusive" | "exclusive";
+  limit: Timestamp;
+};
+
+export type InclusiveTimestampLimitedTemporalBound = Subtype<
+  TimestampLimitedTemporalBound,
+  {
+    kind: "inclusive";
+    limit: Timestamp;
+  }
+>;
+
+export type ExclusiveTimestampLimitedTemporalBound = Subtype<
+  TimestampLimitedTemporalBound,
+  {
+    kind: "exclusive";
+    limit: Timestamp;
+  }
+>;
+
+export type Unbounded = { kind: "unbounded" };
+
+/**
+ * The bound (or explicit lack of a bound) of a time-interval
+ */
+export type TemporalBound = Unbounded | TimestampLimitedTemporalBound;
+
+export type TimeInterval<
+  StartBound extends TemporalBound | null,
+  EndBound extends TemporalBound | null,
+> = {
+  start: StartBound;
+  end: EndBound;
+};
+
+export type NonNullTimeInterval<
+  StartBound extends TemporalBound = TemporalBound,
+  EndBound extends TemporalBound = TemporalBound,
+> = TimeInterval<StartBound, EndBound>;
+
+export type BoundedTimeInterval = TimeInterval<
+  TimestampLimitedTemporalBound,
+  TimestampLimitedTemporalBound
+>;
+
+/**
+ * A representation of a "variable" temporal axis, which is optionally bounded to a given {@link TimeInterval}.
+ *
+ * In a bitemporal system, a {@link VariableTemporalAxis} should almost always be accompanied by a
+ * {@link PinnedTemporalAxis}.
+ */
+export type VariableTemporalAxis<
+  Axis extends TemporalAxes,
+  StartBound extends TemporalBound | null,
+  EndBound extends TemporalBound | null,
+> = {
+  axis: Axis;
+  interval: TimeInterval<StartBound, EndBound>;
+};
+
+/**
+ * A representation of a "pinned" temporal axis, used to project another temporal axis along the given
+ * {@link Timestamp}.
+ *
+ * In a bitemporal system, a {@link PinnedTemporalAxis} should almost always be accompanied by a
+ * {@link VariableTemporalAxis}.
+ */
+export type PinnedTemporalAxis<Axis extends TemporalAxes> = {
+  axis: Axis;
+  timestamp: Timestamp;
+};

--- a/libs/@blockprotocol/graph/src/types/temporal-versioning.ts
+++ b/libs/@blockprotocol/graph/src/types/temporal-versioning.ts
@@ -72,7 +72,7 @@ export type BoundedTimeInterval = TimeInterval<
 export type VariableTemporalAxis<
   Axis extends TemporalAxes,
   StartBound extends TemporalBound | null,
-  EndBound extends TemporalBound | null,
+  EndBound extends TimestampLimitedTemporalBound | null,
 > = {
   axis: Axis;
   interval: TimeInterval<StartBound, EndBound>;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

As expressed in previous PRs, we intend to add the foundations of support for bitemporal datastores within the BP as part of the 0.3 release. This PR introduces relevant primitives that will be used to expand the `Subgraph` type and associated queries.

Notably, performing queries across a temporal datastore requires a lot of interfacing with `Interval`s of time. That is the focus of this PR.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/0/1203765721937276/f) _(internal)_

## 🚫 Blocked by

- [x] #899 

## 🔍 What does this change?

See commits and in-code documentation, effort has been made to keep them self-contained and explanatory.

## 📜 Does this require a change to the docs?

- This PR does not expose these types on the package's public API, that will need to be done, and we will need to think about how to appropriately write user documentation to introduce them to these concepts. The stdlib on the intervals has (hopefully) comprehensive documentation however.

## ⚠️ Known issues

N/A

## 🐾 Next steps

- Extend `Entity` and the `Subgraph` type to support temporal axes
- Migrate the stdlib and mock-block-dock to handle temporal versioning

## 🛡 What tests cover this?

- I'm unsure, at the very least `tsc` and `eslint`. It's also possible to check, through running it, that MBD has not been broken incidentally
- I wanted to write a proper suite of tests to check this, but made the uncomfortable compromise at the moment to defer that until later on, to unblock some further work. We intend to write a test suite for the `Subgraph` library, and I'd encourage us to write tests for temporal operations at the same time. 
 - It's worth noting that these temporal operations were ported from some logic we had implemented [for the HASH graph query layer ](https://github.com/hashintel/hash/blob/795bcf1e4f73c2c186da576b314d0a3ffc5bfa8d/apps/hash-graph/lib/interval-ops/src/interval.rs#L11), which are heavily tested, so confidence is fairly high that these will be correct.

## ❓ How to test this?

- Confirm that `lint:tsc` and `lint:eslint` pass for all packages _except_:
  - `site`
  - `block-scripts`
- Confirm that MBD still behaves as expected

## 📹 Demo

N/A, code is unused at present
