### PR TITLE
Ignore @infra/ packages in changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,7 +9,7 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@apps/*", "@local/*"],
+  "ignore": ["@apps/*", "@infra/*", "@local/*"],
   "snapshot": {
     "useCalculatedVersion": true
   },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`@infra/*` packages are not for publishing, so we don't want them suggested when creating changeset files.