### PR TITLE
Add `"additionalProperties": false` to Entity Types and fix broken links definition

### DIFF
--- a/.changeset/loud-chicken-count.md
+++ b/.changeset/loud-chicken-count.md
@@ -1,0 +1,5 @@
+---
+"@blockprotocol/type-system": patch
+---
+
+Require `"additionalProperties": false` on entity types

--- a/.changeset/silver-dogs-march.md
+++ b/.changeset/silver-dogs-march.md
@@ -1,0 +1,5 @@
+---
+"@blockprotocol/type-system": patch
+---
+
+Fix empty object in links definition inside EntityType

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/error.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/error.rs
@@ -26,4 +26,6 @@ pub enum ParseEntityTypeError {
     InvalidVersionedUri(ParseVersionedUriError),
     #[error("error in JSON: `{0}`")]
     InvalidJson(String),
+    #[error("additional properties was set to `true` but must be `false`")]
+    InvalidAdditionalPropertiesValue,
 }

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/links/wasm.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/links/wasm.rs
@@ -7,5 +7,5 @@ use tsify::Tsify;
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
 #[serde(rename = "MaybeOneOfEntityTypeReference")]
 pub struct MaybeOneOfEntityTypeReferencePatch(
-    #[tsify(type = "OneOf<EntityTypeReference> | {}")] String,
+    #[tsify(type = "OneOf<EntityTypeReference> | Record<string, never>")] String,
 );

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/repr.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/repr.rs
@@ -46,6 +46,8 @@ pub struct EntityType {
     property_object: repr::Object<repr::ValueOrArray<repr::PropertyTypeReference>>,
     #[serde(flatten)]
     links: repr::Links,
+    #[cfg_attr(target_arch = "wasm32", tsify(type = "false"))]
+    additional_properties: bool,
 }
 
 impl TryFrom<EntityType> for super::EntityType {
@@ -99,6 +101,10 @@ impl TryFrom<EntityType> for super::EntityType {
             .try_into()
             .map_err(ParseEntityTypeError::InvalidLinks)?;
 
+        if entity_type_repr.additional_properties == true {
+            return Err(ParseEntityTypeError::InvalidAdditionalPropertiesValue);
+        }
+
         Ok(Self::new(
             id,
             entity_type_repr.title,
@@ -141,6 +147,7 @@ impl From<super::EntityType> for EntityType {
             default,
             examples,
             links: entity_type.links.into(),
+            additional_properties: false,
         }
     }
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/address.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/address.json
@@ -18,5 +18,6 @@
     "https://blockprotocol.org/@alice/types/property-type/address-line-1/",
     "https://blockprotocol.org/@alice/types/property-type/postcode/",
     "https://blockprotocol.org/@alice/types/property-type/city/"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/block.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/block.json
@@ -8,5 +8,6 @@
       "$ref": "https://blockprotocol.org/@alice/types/property-type/name/v/1"
     }
   },
-  "required": ["https://blockprotocol.org/@alice/types/property-type/name/"]
+  "required": ["https://blockprotocol.org/@alice/types/property-type/name/"],
+  "additionalProperties": false
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/book.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/book.json
@@ -33,5 +33,6 @@
   },
   "requiredLinks": [
     "https://blockprotocol.org/@alice/types/entity-type/written-by/v/1"
-  ]
+  ],
+  "additionalProperties": false
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/building.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/building.json
@@ -28,5 +28,6 @@
       },
       "ordered": false
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/organization.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/organization.json
@@ -8,5 +8,6 @@
     "https://blockprotocol.org/@alice/types/property-type/name/": {
       "$ref": "https://blockprotocol.org/@alice/types/property-type/name/v/1"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/page.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/page.json
@@ -31,5 +31,6 @@
       },
       "ordered": true
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/person.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/person.json
@@ -25,5 +25,6 @@
       "items": {},
       "ordered": false
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/playlist.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/playlist.json
@@ -20,5 +20,6 @@
       },
       "ordered": true
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/song.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/song.json
@@ -7,5 +7,6 @@
     "https://blockprotocol.org/@alice/types/property-type/name/": {
       "$ref": "https://blockprotocol.org/@alice/types/property-type/name/v/1"
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/libs/@blockprotocol/type-system/test/entity-type.test.ts
+++ b/libs/@blockprotocol/type-system/test/entity-type.test.ts
@@ -27,6 +27,7 @@ const entityTypes: EntityType[] = [
       "https://blockprotocol.org/@alice/types/property-type/postcode/",
       "https://blockprotocol.org/@alice/types/property-type/city/",
     ],
+    additionalProperties: false,
   },
   {
     kind: "entityType",
@@ -52,6 +53,7 @@ const entityTypes: EntityType[] = [
           "YourBlock",
       },
     ],
+    additionalProperties: false,
   },
   {
     kind: "entityType",
@@ -90,6 +92,7 @@ const entityTypes: EntityType[] = [
       "https://blockprotocol.org/@alice/types/entity-type/written-by/v/1",
     ],
     examples: [],
+    additionalProperties: false,
   },
   {
     kind: "entityType",
@@ -122,6 +125,7 @@ const entityTypes: EntityType[] = [
         ordered: false,
       },
     },
+    additionalProperties: false,
   },
   {
     kind: "entityType",
@@ -133,6 +137,7 @@ const entityTypes: EntityType[] = [
         $ref: "https://blockprotocol.org/@alice/types/property-type/name/v/1",
       },
     },
+    additionalProperties: false,
   },
   {
     kind: "entityType",
@@ -145,6 +150,7 @@ const entityTypes: EntityType[] = [
         $ref: "https://blockprotocol.org/@alice/types/property-type/name/v/1",
       },
     },
+    additionalProperties: false,
   },
   {
     kind: "entityType",
@@ -180,6 +186,7 @@ const entityTypes: EntityType[] = [
         ordered: true,
       },
     },
+    additionalProperties: false,
   },
   {
     kind: "entityType",
@@ -209,6 +216,7 @@ const entityTypes: EntityType[] = [
         ordered: false,
       },
     },
+    additionalProperties: false,
   },
   {
     kind: "entityType",
@@ -233,6 +241,7 @@ const entityTypes: EntityType[] = [
         ordered: true,
       },
     },
+    additionalProperties: false,
   },
   {
     kind: "entityType",
@@ -244,6 +253,7 @@ const entityTypes: EntityType[] = [
         $ref: "https://blockprotocol.org/@alice/types/property-type/name/v/1",
       },
     },
+    additionalProperties: false,
   },
   {
     kind: "entityType",
@@ -256,6 +266,7 @@ const entityTypes: EntityType[] = [
       },
     ],
     properties: {},
+    additionalProperties: false,
   },
 ];
 
@@ -275,6 +286,7 @@ const invalidEntityTypes: [string, EntityType, ParseEntityTypeError][] = [
             $ref: "https://blockprotocol.org/@alice/types/property-type/address-line-1/v/1",
           },
       },
+      additionalProperties: false,
     },
     {
       reason: "InvalidVersionedUri",
@@ -296,6 +308,7 @@ const invalidEntityTypes: [string, EntityType, ParseEntityTypeError][] = [
             $ref: "https://blockprotocol.org/@alice/types/property-type/address-line-1/v/1",
           },
       },
+      additionalProperties: false,
     },
     {
       reason: "InvalidVersionedUri",
@@ -321,6 +334,7 @@ const invalidEntityTypes: [string, EntityType, ParseEntityTypeError][] = [
             $ref: "im a broken ref haha /v/1",
           },
       },
+      additionalProperties: false,
     },
     {
       reason: "InvalidPropertyTypeObject",
@@ -349,6 +363,7 @@ const invalidEntityTypes: [string, EntityType, ParseEntityTypeError][] = [
             $ref: "https://blockprotocol.org/@alice/types/property-type/address-line-1/v/1",
           },
       },
+      additionalProperties: false,
     },
     {
       reason: "InvalidPropertyTypeObject",
@@ -377,6 +392,7 @@ const invalidEntityTypes: [string, EntityType, ParseEntityTypeError][] = [
         "https://blockprotocol.org/@alice/types/property-type/address-line-1/v/2.3":
           "My Address 32, My Street, Narnia",
       },
+      additionalProperties: false,
     },
     {
       reason: "InvalidDefaultKey",
@@ -411,6 +427,7 @@ const invalidEntityTypes: [string, EntityType, ParseEntityTypeError][] = [
           ordered: false,
         },
       },
+      additionalProperties: false,
     },
     {
       reason: "InvalidPropertyTypeObject",
@@ -448,6 +465,7 @@ const invalidEntityTypes: [string, EntityType, ParseEntityTypeError][] = [
           ordered: false,
         },
       },
+      additionalProperties: false,
     },
     {
       reason: "InvalidPropertyTypeObject",
@@ -472,6 +490,7 @@ const invalidEntityTypes: [string, EntityType, ParseEntityTypeError][] = [
         },
       ],
       properties: {},
+      additionalProperties: false,
     },
     {
       reason: "InvalidAllOf",

--- a/libs/@blockprotocol/type-system/test/entity-type.test.ts
+++ b/libs/@blockprotocol/type-system/test/entity-type.test.ts
@@ -521,6 +521,20 @@ const brokenTypes: [any, ParseEntityTypeError][] = [
       inner: "missing field `kind` at line 1 column 13",
     },
   ],
+  [
+    {
+      kind: "entityType",
+      $id: "https://blockprotocol.org/@alice/types/entity-type/foo/v/1",
+      type: "object",
+      title: "Foo",
+      allOf: [],
+      properties: {},
+      additionalProperties: true,
+    },
+    {
+      reason: "InvalidAdditionalPropertiesValue",
+    },
+  ],
 ];
 
 beforeAll(async () => {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Entity types should comprehensively define the contents of an Entity. This should be represented within the schema, but due to an oversight we had omitted specifying `"additionalProperties": false`, this modifies the Type System to enforce it.

The `links` definition inside `EntityType` allowed `| {}` inside it. This meant that TypeScript allowed any fields within the object due to quirks with how it handles the object type. This has also been fixed (see demo below for more explanation).

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1202805690238892/1203602044074391/f) _(internal)_
- [Asana task](https://app.asana.com/0/1202805690238892/1203466297702512/f) _(internal)_

## 🚫 Blocked by

N/A

## 🔍 What does this change?

- Requires `"additionalProperties": false` to be present in all Entity Types.
- Updates the parsing logic in the Type System crate to correctly return an error if this is not the case
- Fixes an empty object in the `links` object causing TS to allow anything.

## 📜 Does this require a change to the docs?

This crate/package at the moment is treated as the source of truth and spec, the types being updated therefore constitute a change to the docs for now.

## ⚠️ Known issues

N/A

## 🐾 Next steps

N/A

## 🛡 What tests cover this?

- Type System crate tests
- Type system node package tests

## ❓ How to test this?

1.  Checkout the branch / view the deployment
1.  `yarn` should pass, rebuilding the Type System crate
1.  `yarn workspace @blockprotocol/type-system test` should pass
1.  `cargo make test` should pass inside the `type-system/crate` directory 

## 📹 Demo

### Broken `links`

**Previously**
<img width="734" alt="image" src="https://user-images.githubusercontent.com/25749103/216635875-c3ea7789-e181-4542-aea7-b015b622efd0.png">
<img width="644" alt="image" src="https://user-images.githubusercontent.com/25749103/216635831-ec6c2141-51aa-4c31-93d0-6f31d97519db.png">

**After**
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/25749103/216635721-4189a770-da67-401b-90a7-1dbcd0062b62.png">
<img width="793" alt="image" src="https://user-images.githubusercontent.com/25749103/216635755-bd7c2f43-ea17-49d8-9a40-87c51a9752ba.png">


