### PR TITLE
Re-order tooling and rust cache in CI

### DIFF
--- a/.github/actions/warm-up-repo/action.yml
+++ b/.github/actions/warm-up-repo/action.yml
@@ -16,16 +16,16 @@ runs:
         node-version: 16 ## aligned with Node version on Vercel
         cache: yarn
 
-    - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
-      with:
-        workspaces: libs/@blockprotocol/type-system/crate
-
     - name: Install Cargo-Make
       shell: bash
       run: |
         cargo install cargo-quickinstall
         cargo quickinstall cargo-make --version 0.35.15
+
+    - name: Cache Rust dependencies
+      uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: libs/@blockprotocol/type-system/crate
 
     - run: yarn install
       shell: bash


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In various PRs some of the jobs fail as cargo make is supposed to be installed, but it's not. This PR tries to solve this by re-ordering the steps in the CI setup, installing cargo-make before using the Rust cache job.

## 🔗 Related links

- https://github.com/hashintel/hash/pull/1977

## 🚫 Blocked by

N/A
