### PR TITLE
Fix problematic typings in `Subgraph`

### DIFF
--- a/libs/@blockprotocol/graph/src/internal/mutate-subgraph.ts
+++ b/libs/@blockprotocol/graph/src/internal/mutate-subgraph.ts
@@ -2,7 +2,7 @@ import { unionOfIntervals } from "../stdlib/interval.js";
 import {
   Entity,
   EntityId,
-  EntityValidInterval,
+  EntityIdWithInterval,
   EntityVertex,
   isTemporalSubgraph,
   KnowledgeGraphOutwardEdge,
@@ -84,14 +84,14 @@ export const addEntitiesToSubgraphByMutation = <Temporal extends boolean>(
     {
       leftEntityId: EntityId;
       rightEntityId: EntityId;
-      validIntervals: EntityValidInterval["validInterval"][];
+      edgeIntervals: EntityIdWithInterval["interval"][];
     }
   > = {};
 
   for (const entity of entities) {
     const entityId = entity.metadata.recordId.entityId;
 
-    const entityRevisionValidInterval: EntityValidInterval["validInterval"] =
+    const entityRevisionValidInterval: EntityIdWithInterval["interval"] =
       isTemporalSubgraph(subgraph)
         ? /*
          these casts should be safe as we have just checked if the Subgraph has temporal information, in which case the
@@ -111,10 +111,10 @@ export const addEntitiesToSubgraphByMutation = <Temporal extends boolean>(
         linkMap[entityId] = {
           leftEntityId: entity.linkData.leftEntityId,
           rightEntityId: entity.linkData.rightEntityId,
-          validIntervals: [entityRevisionValidInterval],
+          edgeIntervals: [entityRevisionValidInterval],
         };
       } else {
-        linkInfo.validIntervals.push(entityRevisionValidInterval);
+        linkInfo.edgeIntervals.push(entityRevisionValidInterval);
       }
     }
 
@@ -137,51 +137,51 @@ export const addEntitiesToSubgraphByMutation = <Temporal extends boolean>(
 
   for (const [
     linkEntityId,
-    { leftEntityId, rightEntityId, validIntervals },
+    { leftEntityId, rightEntityId, edgeIntervals },
   ] of Object.entries(linkMap)) {
     // If the list of entities is comprehensive, and link destinations cannot change, the result of this should be an
     // array with a single interval that spans the full lifespan of the link entity.
-    const unionedIntervals = unionOfIntervals(...validIntervals);
+    const unionedIntervals = unionOfIntervals(...edgeIntervals);
 
-    for (const validInterval of unionedIntervals) {
+    for (const edgeInterval of unionedIntervals) {
       addKnowledgeGraphEdgeToSubgraphByMutation(
         subgraph,
         linkEntityId,
-        validInterval.start.limit,
+        edgeInterval.start.limit,
         {
           kind: "HAS_LEFT_ENTITY",
           reversed: false,
-          rightEndpoint: { entityId: leftEntityId, validInterval },
+          rightEndpoint: { entityId: leftEntityId, interval: edgeInterval },
         },
       );
       addKnowledgeGraphEdgeToSubgraphByMutation(
         subgraph,
         leftEntityId,
-        validInterval.start.limit,
+        edgeInterval.start.limit,
         {
           kind: "HAS_LEFT_ENTITY",
           reversed: true,
-          rightEndpoint: { entityId: linkEntityId, validInterval },
+          rightEndpoint: { entityId: linkEntityId, interval: edgeInterval },
         },
       );
       addKnowledgeGraphEdgeToSubgraphByMutation(
         subgraph,
         linkEntityId,
-        validInterval.start.limit,
+        edgeInterval.start.limit,
         {
           kind: "HAS_RIGHT_ENTITY",
           reversed: false,
-          rightEndpoint: { entityId: rightEntityId, validInterval },
+          rightEndpoint: { entityId: rightEntityId, interval: edgeInterval },
         },
       );
       addKnowledgeGraphEdgeToSubgraphByMutation(
         subgraph,
         rightEntityId,
-        validInterval.start.limit,
+        edgeInterval.start.limit,
         {
           kind: "HAS_RIGHT_ENTITY",
           reversed: true,
-          rightEndpoint: { entityId: linkEntityId, validInterval },
+          rightEndpoint: { entityId: linkEntityId, interval: edgeInterval },
         },
       );
     }

--- a/libs/@blockprotocol/graph/src/internal/mutate-subgraph.ts
+++ b/libs/@blockprotocol/graph/src/internal/mutate-subgraph.ts
@@ -8,6 +8,7 @@ import {
   KnowledgeGraphOutwardEdge,
   KnowledgeGraphRootedEdges,
   KnowledgeGraphVertices,
+  OutwardEdge,
   Subgraph,
   Timestamp,
 } from "../types.js";
@@ -41,9 +42,11 @@ export const addKnowledgeGraphEdgeToSubgraphByMutation = <
   } else if (!subgraph.edges[sourceEntityId]![atTime]) {
     subgraph.edges[sourceEntityId]![atTime] = [outwardEdge];
   } else {
-    const outwardEdgesAtTime = subgraph.edges[sourceEntityId]![atTime]!;
+    const outwardEdgesAtTime = subgraph.edges[sourceEntityId]![
+      atTime
+    ]! as KnowledgeGraphOutwardEdge[];
     if (
-      !outwardEdgesAtTime.find((otherOutwardEdge) =>
+      !outwardEdgesAtTime.find((otherOutwardEdge: OutwardEdge) =>
         isEqual(otherOutwardEdge, outwardEdge),
       )
     ) {

--- a/libs/@blockprotocol/graph/src/shared.ts
+++ b/libs/@blockprotocol/graph/src/shared.ts
@@ -42,3 +42,26 @@ export const typedKeys = <T extends {}>(object: T): Entry<T>[0][] => {
 export const typedValues = <T extends {}>(object: T): Entry<T>[1][] => {
   return Object.values(object);
 };
+
+/**
+ * Checks if a given string is exactly a non-negative integer.
+ *
+ * For example, it will accept strings such as:
+ * - "0"
+ * - "1"
+ * - "94818981"
+ *
+ * And it will not accept strings such as:
+ * - "0.0"
+ * - "1.0"
+ * - "-1"
+ * - "foo"
+ * - "0foo"
+ * - "1.1"
+ *
+ * @param {string} input
+ */
+export const stringIsNonNegativeInteger = (input: string) => {
+  const asInteger = Number.parseInt(input, 10);
+  return asInteger.toString() === input && asInteger >= 0;
+};

--- a/libs/@blockprotocol/graph/src/shared.ts
+++ b/libs/@blockprotocol/graph/src/shared.ts
@@ -27,6 +27,18 @@ type Entry<T extends {}> = T extends readonly [unknown, ...unknown[]]
  *
  * Source: https://dev.to/harry0000/a-bit-convenient-typescript-type-definitions-for-objectentries-d6g
  */
-export function typedEntries<T extends {}>(object: T): ReadonlyArray<Entry<T>> {
+export const typedEntries = <T extends {}>(
+  object: T,
+): ReadonlyArray<Entry<T>> => {
   return Object.entries(object) as unknown as ReadonlyArray<Entry<T>>;
-}
+};
+
+/** `Object.values` analogue which returns a well-typed array */
+export const typedKeys = <T extends {}>(object: T): Entry<T>[0][] => {
+  return Object.keys(object) as Entry<T>[0][];
+};
+
+/** `Object.values` analogue which returns a well-typed array */
+export const typedValues = <T extends {}>(object: T): Entry<T>[1][] => {
+  return Object.values(object);
+};

--- a/libs/@blockprotocol/graph/src/shared.ts
+++ b/libs/@blockprotocol/graph/src/shared.ts
@@ -61,7 +61,9 @@ export const typedValues = <T extends {}>(object: T): Entry<T>[1][] => {
  *
  * @param {string} input
  */
-export const stringIsNonNegativeInteger = (input: string) => {
+export const stringIsNonNegativeInteger = (
+  input: string,
+): input is `${number}` => {
   const asInteger = Number.parseInt(input, 10);
   return asInteger.toString() === input && asInteger >= 0;
 };

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/entity-type.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/entity-type.ts
@@ -7,6 +7,8 @@ import {
 
 import {
   isConstrainsPropertiesOnEdge,
+  OntologyOutwardEdge,
+  OntologyTypeRevisionId,
   OntologyTypeVertexId,
   Subgraph,
 } from "../../../types/subgraph.js";
@@ -24,19 +26,19 @@ export const getPropertyTypesReferencedByEntityType = (
   entityTypeId: OntologyTypeVertexId | VersionedUri,
 ): OntologyTypeVertexId[] => {
   let baseUri: BaseUri;
-  let version: number;
+  let revisionId: OntologyTypeRevisionId;
 
   if (typeof entityTypeId === "string") {
-    [baseUri, version] = [
-      extractBaseUri(entityTypeId),
-      extractVersion(entityTypeId),
-    ];
+    baseUri = extractBaseUri(entityTypeId);
+    revisionId = extractVersion(entityTypeId).toString();
   } else {
     baseUri = entityTypeId.baseId;
-    version = entityTypeId.revisionId;
+    revisionId = entityTypeId.revisionId;
   }
 
-  const outwardEdges = subgraph.edges[baseUri]?.[version];
+  const outwardEdges = subgraph.edges[baseUri]?.[
+    revisionId
+  ] as OntologyOutwardEdge[];
 
   if (outwardEdges === undefined) {
     return [];

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/link-entity.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/link-entity.ts
@@ -85,14 +85,14 @@ export const getOutgoingLinksForEntity = <Temporal extends boolean>(
     ) {
       for (const outwardEdge of outwardEdges) {
         if (isOutgoingLinkEdge(outwardEdge)) {
-          const { entityId: linkEntityId, validInterval } =
+          const { entityId: linkEntityId, interval: edgeInterval } =
             outwardEdge.rightEndpoint;
 
           if (isTemporalSubgraph(subgraph)) {
             // Find the revisions of the link at the intersection of the search interval and the edge's valid interval
             const intersection = intervalIntersectionWithInterval(
               searchInterval,
-              validInterval,
+              edgeInterval,
             );
 
             if (intersection === null) {
@@ -100,7 +100,7 @@ export const getOutgoingLinksForEntity = <Temporal extends boolean>(
                 `No entity revision was found which overlapped the given edge, subgraph was likely malformed.\n` +
                   `EntityId: ${linkEntityId}\n` +
                   `Search Interval: ${JSON.stringify(searchInterval)}\n` +
-                  `Edge Valid Interval: ${JSON.stringify(validInterval)}`,
+                  `Edge Valid Interval: ${JSON.stringify(edgeInterval)}`,
               );
             }
 
@@ -170,14 +170,14 @@ export const getIncomingLinksForEntity = <Temporal extends boolean>(
     ) {
       for (const outwardEdge of outwardEdges) {
         if (isIncomingLinkEdge(outwardEdge)) {
-          const { entityId: linkEntityId, validInterval } =
+          const { entityId: linkEntityId, interval: edgeInterval } =
             outwardEdge.rightEndpoint;
 
           if (isTemporalSubgraph(subgraph)) {
             // Find the revisions of the link at the intersection of the search interval and the edge's valid interval
             const intersection = intervalIntersectionWithInterval(
               searchInterval,
-              validInterval,
+              edgeInterval,
             );
 
             if (intersection === null) {
@@ -185,7 +185,7 @@ export const getIncomingLinksForEntity = <Temporal extends boolean>(
                 `No entity revision was found which overlapped the given edge, subgraph was likely malformed.\n` +
                   `EntityId: ${linkEntityId}\n` +
                   `Search Interval: ${JSON.stringify(searchInterval)}\n` +
-                  `Edge Valid Interval: ${JSON.stringify(validInterval)}`,
+                  `Edge Valid Interval: ${JSON.stringify(edgeInterval)}`,
               );
             }
 
@@ -249,10 +249,10 @@ export const getLeftEntityForLinkEntity = <Temporal extends boolean>(
   const leftEntityId = outwardEdge.rightEndpoint.entityId;
 
   if (isTemporalSubgraph(subgraph)) {
-    const { validInterval } = outwardEdge.rightEndpoint;
+    const { interval: edgeInterval } = outwardEdge.rightEndpoint;
     const intersection = intervalIntersectionWithInterval(
       searchInterval,
-      validInterval,
+      edgeInterval,
     );
 
     if (intersection === null) {
@@ -260,7 +260,7 @@ export const getLeftEntityForLinkEntity = <Temporal extends boolean>(
         `No entity revision was found which overlapped the given edge, subgraph was likely malformed.\n` +
           `EntityId: ${leftEntityId}\n` +
           `Search Interval: ${JSON.stringify(searchInterval)}\n` +
-          `Edge Valid Interval: ${JSON.stringify(validInterval)}`,
+          `Edge Valid Interval: ${JSON.stringify(edgeInterval)}`,
       );
     }
 
@@ -310,10 +310,10 @@ export const getRightEntityForLinkEntity = <Temporal extends boolean>(
   const rightEntityId = outwardEdge.rightEndpoint.entityId;
 
   if (isTemporalSubgraph(subgraph)) {
-    const { validInterval } = outwardEdge.rightEndpoint;
+    const { interval: edgeInterval } = outwardEdge.rightEndpoint;
     const intersection = intervalIntersectionWithInterval(
       searchInterval,
-      validInterval,
+      edgeInterval,
     );
 
     if (intersection === null) {
@@ -321,7 +321,7 @@ export const getRightEntityForLinkEntity = <Temporal extends boolean>(
         `No entity revision was found which overlapped the given edge, subgraph was likely malformed.\n` +
           `EntityId: ${rightEntityId}\n` +
           `Search Interval: ${JSON.stringify(searchInterval)}\n` +
-          `Edge Valid Interval: ${JSON.stringify(validInterval)}`,
+          `Edge Valid Interval: ${JSON.stringify(edgeInterval)}`,
       );
     }
 

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/link-entity.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/link-entity.ts
@@ -22,7 +22,9 @@ import { mustBeDefined } from "../../must-be-defined.js";
 import { getEntityRevisionsByEntityId } from "../element/entity.js";
 import { getLatestInstantIntervalForSubgraph } from "../temporal-axes.js";
 
-const convertTimeToStringWithDefault = (timestamp?: Date | Timestamp) => {
+const convertTimeToTimestampWithDefault = (
+  timestamp?: Date | Timestamp,
+): Timestamp => {
   return timestamp === undefined
     ? new Date().toISOString()
     : typeof timestamp === "string"
@@ -356,7 +358,7 @@ export const getOutgoingLinkAndTargetEntities = <
 ): LinkAndRightEntities => {
   const searchInterval =
     timestamp !== undefined
-      ? intervalForTimestamp(convertTimeToStringWithDefault(timestamp))
+      ? intervalForTimestamp(convertTimeToTimestampWithDefault(timestamp))
       : getLatestInstantIntervalForSubgraph(subgraph);
 
   if (isTemporalSubgraph(subgraph)) {

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/element/data-type.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/element/data-type.ts
@@ -5,6 +5,7 @@ import {
   VersionedUri,
 } from "@blockprotocol/type-system/slim";
 
+import { typedValues } from "../../../shared.js";
 import { DataTypeWithMetadata } from "../../../types/ontology/data-type.js";
 import { OntologyTypeVertexId, Subgraph } from "../../../types/subgraph.js";
 import { isDataTypeVertex } from "../../../types/subgraph/vertices.js";
@@ -17,12 +18,10 @@ import { isDataTypeVertex } from "../../../types/subgraph/vertices.js";
 export const getDataTypes = (
   subgraph: Subgraph<boolean>,
 ): DataTypeWithMetadata[] => {
-  return Object.values(
-    Object.values(subgraph.vertices).flatMap((versionObject) =>
-      Object.values(versionObject)
-        .filter(isDataTypeVertex)
-        .map((vertex) => vertex.inner),
-    ),
+  return typedValues(subgraph.vertices).flatMap((versionObject) =>
+    typedValues(versionObject)
+      .filter(isDataTypeVertex)
+      .map((vertex) => vertex.inner),
   );
 };
 

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/element/entity-type.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/element/entity-type.ts
@@ -5,6 +5,7 @@ import {
   VersionedUri,
 } from "@blockprotocol/type-system/slim";
 
+import { typedValues } from "../../../shared.js";
 import { EntityTypeWithMetadata } from "../../../types/ontology/entity-type.js";
 import { OntologyTypeVertexId, Subgraph } from "../../../types/subgraph.js";
 import { isEntityTypeVertex } from "../../../types/subgraph/vertices.js";
@@ -17,12 +18,10 @@ import { isEntityTypeVertex } from "../../../types/subgraph/vertices.js";
 export const getEntityTypes = (
   subgraph: Subgraph<boolean>,
 ): EntityTypeWithMetadata[] => {
-  return Object.values(
-    Object.values(subgraph.vertices).flatMap((versionObject) =>
-      Object.values(versionObject)
-        .filter(isEntityTypeVertex)
-        .map((vertex) => vertex.inner),
-    ),
+  return typedValues(subgraph.vertices).flatMap((versionObject) =>
+    typedValues(versionObject)
+      .filter(isEntityTypeVertex)
+      .map((vertex) => vertex.inner),
   );
 };
 

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/element/entity.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/element/entity.ts
@@ -1,4 +1,4 @@
-import { typedEntries } from "../../../shared.js";
+import { typedEntries, typedValues } from "../../../shared.js";
 import { Entity, EntityId, EntityRevisionId } from "../../../types/entity.js";
 import { Subgraph } from "../../../types/subgraph.js";
 import { isEntityVertex } from "../../../types/subgraph/vertices.js";
@@ -20,7 +20,7 @@ export const getEntities = <Temporal extends boolean>(
   subgraph: Subgraph<Temporal>,
   latest: boolean = false,
 ): Entity<Temporal>[] => {
-  return Object.values(subgraph.vertices).flatMap((revisions) => {
+  return typedValues(subgraph.vertices).flatMap((revisions) => {
     if (latest) {
       const revisionVersions = Object.keys(revisions).sort();
 
@@ -28,7 +28,7 @@ export const getEntities = <Temporal extends boolean>(
       const vertex = revisions[revisionVersions[lastIndex]!]!;
       return isEntityVertex(vertex) ? [vertex.inner] : [];
     } else {
-      return Object.values(revisions)
+      return typedValues(revisions)
         .filter(isEntityVertex)
         .map((vertex) => vertex.inner);
     }
@@ -162,7 +162,7 @@ export const getEntityRevisionsByEntityId = <Temporal extends boolean>(
 
     return filteredEntities;
   } else {
-    const entityVertices = Object.values(versionObject);
+    const entityVertices = typedValues(versionObject);
     return entityVertices.filter(isEntityVertex).map((vertex) => {
       return vertex.inner;
     });

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/element/property-type.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/element/property-type.ts
@@ -5,6 +5,7 @@ import {
   VersionedUri,
 } from "@blockprotocol/type-system/slim";
 
+import { typedValues } from "../../../shared.js";
 import { PropertyTypeWithMetadata } from "../../../types/ontology/property-type.js";
 import { OntologyTypeVertexId, Subgraph } from "../../../types/subgraph.js";
 import { isPropertyTypeVertex } from "../../../types/subgraph/vertices.js";
@@ -17,12 +18,10 @@ import { isPropertyTypeVertex } from "../../../types/subgraph/vertices.js";
 export const getPropertyTypes = (
   subgraph: Subgraph<boolean>,
 ): PropertyTypeWithMetadata[] => {
-  return Object.values(
-    Object.values(subgraph.vertices).flatMap((versionObject) =>
-      Object.values(versionObject)
-        .filter(isPropertyTypeVertex)
-        .map((vertex) => vertex.inner),
-    ),
+  return typedValues(subgraph.vertices).flatMap((versionObject) =>
+    typedValues(versionObject)
+      .filter(isPropertyTypeVertex)
+      .map((vertex) => vertex.inner),
   );
 };
 

--- a/libs/@blockprotocol/graph/src/types/ontology.ts
+++ b/libs/@blockprotocol/graph/src/types/ontology.ts
@@ -31,3 +31,12 @@ export const isOntologyTypeRecordId = (
     typeof recordId.version === "number"
   );
 };
+
+/**
+ * The second component of the [{@link BaseUri}, RevisionId] tuple needed to identify a specific ontology type vertex
+ * within a {@link Subgraph}. This should be the version number as a string.
+ *
+ * Although it would be possible to create a template literal type, this confuses TypeScript when traversing the
+ * {@link Subgraph} in generic contexts, whereby it then thinks any string must relate to a {@link EntityVertex}.
+ */
+export type OntologyTypeRevisionId = string; // we explicitly opt not to use `${number}`

--- a/libs/@blockprotocol/graph/src/types/ontology.ts
+++ b/libs/@blockprotocol/graph/src/types/ontology.ts
@@ -25,7 +25,6 @@ export const isOntologyTypeRecordId = (
     typeof recordId === "object" &&
     "baseUri" in recordId &&
     typeof recordId.baseUri === "string" &&
-    /** @todo - This means we need to have initialized the type system */
     validateBaseUri(recordId.baseUri).type === "Ok" &&
     "version" in recordId &&
     typeof recordId.version === "number"

--- a/libs/@blockprotocol/graph/src/types/subgraph/edges.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/edges.ts
@@ -9,18 +9,14 @@ export * from "./edges/kind.js";
 export * from "./edges/outward-edge.js";
 export * from "./edges/variants.js";
 
-/** @todo - Re-express these and `Vertices` as `Record`s? */
+export type OntologyRootedEdges = Record<
+  BaseUri,
+  Record<number, OntologyOutwardEdge[]>
+>;
 
-export type OntologyRootedEdges = {
-  [typeBaseUri: BaseUri]: {
-    [typeVersion: number]: OntologyOutwardEdge[];
-  };
-};
-
-export type KnowledgeGraphRootedEdges = {
-  [entityId: EntityId]: {
-    [edgeFirstCreatedAt: Timestamp]: KnowledgeGraphOutwardEdge[];
-  };
-};
+export type KnowledgeGraphRootedEdges = Record<
+  EntityId,
+  Record<Timestamp, KnowledgeGraphOutwardEdge[]>
+>;
 
 export type Edges = OntologyRootedEdges & KnowledgeGraphRootedEdges;

--- a/libs/@blockprotocol/graph/src/types/subgraph/edges.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/edges.ts
@@ -1,6 +1,7 @@
 import { BaseUri } from "@blockprotocol/type-system/slim";
 
 import { EntityId } from "../entity.js";
+import { OntologyTypeRevisionId } from "../ontology";
 import { Timestamp } from "../temporal-versioning.js";
 import { KnowledgeGraphOutwardEdge } from "./edges/variants/knowledge.js";
 import { OntologyOutwardEdge } from "./edges/variants/ontology.js";
@@ -11,7 +12,7 @@ export * from "./edges/variants.js";
 
 export type OntologyRootedEdges = Record<
   BaseUri,
-  Record<number, OntologyOutwardEdge[]>
+  Record<OntologyTypeRevisionId, OntologyOutwardEdge[]>
 >;
 
 export type KnowledgeGraphRootedEdges = Record<

--- a/libs/@blockprotocol/graph/src/types/subgraph/edges.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/edges.ts
@@ -20,4 +20,7 @@ export type KnowledgeGraphRootedEdges = Record<
   Record<Timestamp, KnowledgeGraphOutwardEdge[]>
 >;
 
-export type Edges = OntologyRootedEdges & KnowledgeGraphRootedEdges;
+// We technically want to intersect (`&`) the types here, but as their property keys overlap it confuses things and we
+// end up with unsatisfiable values like `EntityVertex & DataTypeVertex`. While the union (`|`) is semantically
+// incorrect, it structurally matches the types we want.
+export type Edges = OntologyRootedEdges | KnowledgeGraphRootedEdges;

--- a/libs/@blockprotocol/graph/src/types/subgraph/edges/outward-edge.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/edges/outward-edge.ts
@@ -20,14 +20,20 @@ import { OntologyOutwardEdge } from "./variants/ontology.js";
  * When using this to query a {@link Subgraph}, along its variable axis, this should identify a single unique revision
  * of an {@link Entity} or possibly refer to nothing.
  */
-export type EntityIdAndTimestamp = {
+export type EntityIdWithTimestamp = {
   baseId: EntityId;
   timestamp: Timestamp;
 };
 
-export type EntityValidInterval = {
+/**
+ * A simple tuple type which identifies an {@link Entity} by its {@link EntityId}, over a given {@link TimeInterval}.
+ *
+ * When using this to query a {@link Subgraph}, along its variable axis, this could return any number of revisions
+ * of an {@link Entity} (including possibly returning none).
+ */
+export type EntityIdWithInterval = {
   entityId: EntityId;
-  validInterval: TimeInterval<LimitedTemporalBound, TemporalBound>;
+  interval: TimeInterval<LimitedTemporalBound, TemporalBound>;
 };
 
 export type OutwardEdge = OntologyOutwardEdge | KnowledgeGraphOutwardEdge;

--- a/libs/@blockprotocol/graph/src/types/subgraph/edges/variants/knowledge.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/edges/variants/knowledge.ts
@@ -2,14 +2,14 @@ import { Subtype } from "../../../../util.js";
 import { OntologyTypeVertexId } from "../../vertices.js";
 import { GenericOutwardEdge } from "../generic-outward-edge.js";
 import { KnowledgeGraphEdgeKind, SharedEdgeKind } from "../kind.js";
-import { EntityValidInterval, OutwardEdge } from "../outward-edge.js";
+import { EntityIdWithInterval, OutwardEdge } from "../outward-edge.js";
 
 export type OutgoingLinkEdge = Subtype<
   GenericOutwardEdge,
   {
     reversed: true;
     kind: "HAS_LEFT_ENTITY";
-    rightEndpoint: EntityValidInterval;
+    rightEndpoint: EntityIdWithInterval;
   }
 >;
 
@@ -24,7 +24,7 @@ export type HasLeftEntityEdge = Subtype<
   {
     reversed: false;
     kind: "HAS_LEFT_ENTITY";
-    rightEndpoint: EntityValidInterval;
+    rightEndpoint: EntityIdWithInterval;
   }
 >;
 
@@ -39,7 +39,7 @@ export type HasRightEntityEdge = Subtype<
   {
     reversed: false;
     kind: "HAS_RIGHT_ENTITY";
-    rightEndpoint: EntityValidInterval;
+    rightEndpoint: EntityIdWithInterval;
   }
 >;
 
@@ -54,7 +54,7 @@ export type IncomingLinkEdge = Subtype<
   {
     reversed: true;
     kind: "HAS_RIGHT_ENTITY";
-    rightEndpoint: EntityValidInterval;
+    rightEndpoint: EntityIdWithInterval;
   }
 >;
 
@@ -94,6 +94,6 @@ export type KnowledgeGraphOutwardEdge =
  */
 type _CheckKnowledgeGraphOutwardEdge = Subtype<
   KnowledgeGraphOutwardEdge,
-  | GenericOutwardEdge<KnowledgeGraphEdgeKind, boolean, EntityValidInterval>
+  | GenericOutwardEdge<KnowledgeGraphEdgeKind, boolean, EntityIdWithInterval>
   | GenericOutwardEdge<SharedEdgeKind, false, OntologyTypeVertexId>
 >;

--- a/libs/@blockprotocol/graph/src/types/subgraph/edges/variants/ontology.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/edges/variants/ontology.ts
@@ -2,7 +2,7 @@ import { Subtype } from "../../../../util.js";
 import { OntologyTypeVertexId } from "../../vertices.js";
 import { GenericOutwardEdge } from "../generic-outward-edge.js";
 import { OntologyEdgeKind, SharedEdgeKind } from "../kind.js";
-import { EntityValidInterval, OutwardEdge } from "../outward-edge.js";
+import { EntityIdWithInterval, OutwardEdge } from "../outward-edge.js";
 
 export type InheritsFromEdge = Subtype<
   GenericOutwardEdge,
@@ -169,7 +169,7 @@ export type IsTypeOfEdge = Subtype<
   {
     reversed: true;
     kind: "IS_OF_TYPE";
-    rightEndpoint: EntityValidInterval;
+    rightEndpoint: EntityIdWithInterval;
   }
 >;
 
@@ -201,5 +201,5 @@ export type OntologyOutwardEdge =
 type _CheckOntologyOutwardEdge = Subtype<
   OntologyOutwardEdge,
   | GenericOutwardEdge<OntologyEdgeKind, boolean, OntologyTypeVertexId>
-  | GenericOutwardEdge<SharedEdgeKind, true, EntityValidInterval>
+  | GenericOutwardEdge<SharedEdgeKind, true, EntityIdWithInterval>
 >;

--- a/libs/@blockprotocol/graph/src/types/subgraph/element-mappings.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/element-mappings.ts
@@ -7,8 +7,8 @@ import {
   OntologyTypeRecordId,
   PropertyTypeWithMetadata,
 } from "../ontology.js";
-import { EntityValidInterval } from "./edges.js";
-import { EntityIdAndTimestamp } from "./edges/outward-edge.js";
+import { EntityIdWithInterval } from "./edges.js";
+import { EntityIdWithTimestamp } from "./edges/outward-edge.js";
 import {
   DataTypeVertex,
   EntityTypeVertex,
@@ -42,12 +42,12 @@ export type GraphElementIdentifiers<Temporal extends boolean> =
       vertex: DataTypeVertex[] | PropertyTypeVertex[] | EntityTypeVertex[];
     }
   | {
-      identifier: EntityIdAndTimestamp | EntityVertexId | EntityRecordId;
+      identifier: EntityIdWithTimestamp | EntityVertexId | EntityRecordId;
       element: Entity<Temporal>;
       vertex: EntityVertex<Temporal>;
     }
   | {
-      identifier: EntityId | EntityValidInterval;
+      identifier: EntityId | EntityIdWithInterval;
       element: Entity<Temporal>[];
       vertex: EntityVertex<Temporal>[];
     };

--- a/libs/@blockprotocol/graph/src/types/subgraph/vertices.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/vertices.ts
@@ -1,5 +1,6 @@
 import { BaseUri, validateBaseUri } from "@blockprotocol/type-system/slim";
 
+import { stringIsNonNegativeInteger } from "../../shared.js";
 import {
   Entity,
   EntityId,
@@ -98,7 +99,8 @@ export const isOntologyTypeVertexId = (
     typeof vertexId.baseId === "string" &&
     validateBaseUri(vertexId.baseId).type === "Ok" &&
     "revisionId" in vertexId &&
-    !Number.isNaN(Number(vertexId.revisionId))
+    typeof vertexId.revisionId === "string" &&
+    stringIsNonNegativeInteger(vertexId.revisionId)
   );
 };
 

--- a/libs/@blockprotocol/graph/src/types/subgraph/vertices.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/vertices.ts
@@ -7,7 +7,7 @@ import {
   EntityPropertyValue,
   EntityRevisionId,
 } from "../entity.js";
-import { isOntologyTypeRecordId } from "../ontology.js";
+import { OntologyTypeRevisionId } from "../ontology.js";
 import { DataTypeWithMetadata } from "../ontology/data-type.js";
 import { EntityTypeWithMetadata } from "../ontology/entity-type.js";
 import { PropertyTypeWithMetadata } from "../ontology/property-type.js";
@@ -99,7 +99,7 @@ export const isOntologyTypeVertexId = (
     /** @todo - This means we need to have initialized the type system */
     validateBaseUri(vertexId.baseId).type === "Ok" &&
     "revisionId" in vertexId &&
-    typeof vertexId.revisionId === "number"
+    !Number.isNaN(Number(vertexId.revisionId))
   );
 };
 
@@ -114,7 +114,7 @@ export const isEntityVertexId = (
     /** @todo - is it fine to just check that versionId is string, maybe timestamp if we want to lock it into being a
      *    timestamp?
      */
-    !isOntologyTypeRecordId(vertexId)
+    !isOntologyTypeVertexId(vertexId)
   );
 };
 

--- a/libs/@blockprotocol/graph/src/types/subgraph/vertices.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/vertices.ts
@@ -96,7 +96,6 @@ export const isOntologyTypeVertexId = (
     typeof vertexId === "object" &&
     "baseId" in vertexId &&
     typeof vertexId.baseId === "string" &&
-    /** @todo - This means we need to have initialized the type system */
     validateBaseUri(vertexId.baseId).type === "Ok" &&
     "revisionId" in vertexId &&
     !Number.isNaN(Number(vertexId.revisionId))

--- a/libs/@blockprotocol/graph/src/types/subgraph/vertices.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/vertices.ts
@@ -128,5 +128,9 @@ export type KnowledgeGraphVertices<Temporal extends boolean> = Record<
   Record<EntityRevisionId, KnowledgeGraphVertex<Temporal>>
 >;
 
-export type Vertices<Temporal extends boolean> = OntologyVertices &
-  KnowledgeGraphVertices<Temporal>;
+// We technically want to intersect (`&`) the types here, but as their property keys overlap it confuses things and we
+// end up with unsatisfiable values like `EntityVertex & DataTypeVertex`. While the union (`|`) is semantically
+// incorrect, it structurally matches the types we want.
+export type Vertices<Temporal extends boolean> =
+  | OntologyVertices
+  | KnowledgeGraphVertices<Temporal>;

--- a/libs/@blockprotocol/graph/src/types/subgraph/vertices.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/vertices.ts
@@ -118,17 +118,12 @@ export const isEntityVertexId = (
   );
 };
 
-export type OntologyVertices = {
-  [typeBaseUri: BaseUri]: {
-    [typeVersion: number]: OntologyVertex;
-  };
-};
+export type OntologyVertices = Record<BaseUri, Record<number, OntologyVertex>>;
 
-export type KnowledgeGraphVertices<Temporal extends boolean> = {
-  [entityId: EntityId]: {
-    [entityVersion: EntityRevisionId]: KnowledgeGraphVertex<Temporal>;
-  };
-};
+export type KnowledgeGraphVertices<Temporal extends boolean> = Record<
+  EntityId,
+  Record<EntityRevisionId, KnowledgeGraphVertex<Temporal>>
+>;
 
 export type Vertices<Temporal extends boolean> = OntologyVertices &
   KnowledgeGraphVertices<Temporal>;

--- a/libs/@blockprotocol/graph/src/types/subgraph/vertices.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph/vertices.ts
@@ -85,7 +85,7 @@ export type VertexId<BaseId, RevisionId> = {
   revisionId: RevisionId;
 };
 export type EntityVertexId = VertexId<EntityId, EntityRevisionId>;
-export type OntologyTypeVertexId = VertexId<BaseUri, number>;
+export type OntologyTypeVertexId = VertexId<BaseUri, OntologyTypeRevisionId>;
 export type GraphElementVertexId = EntityVertexId | OntologyTypeVertexId;
 
 export const isOntologyTypeVertexId = (
@@ -118,7 +118,10 @@ export const isEntityVertexId = (
   );
 };
 
-export type OntologyVertices = Record<BaseUri, Record<number, OntologyVertex>>;
+export type OntologyVertices = Record<
+  BaseUri,
+  Record<OntologyTypeRevisionId, OntologyVertex>
+>;
 
 export type KnowledgeGraphVertices<Temporal extends boolean> = Record<
   EntityId,

--- a/libs/mock-block-dock/src/datastore/traverse.ts
+++ b/libs/mock-block-dock/src/datastore/traverse.ts
@@ -50,12 +50,13 @@ export type TraversalSubgraph<
   RootType extends SubgraphRootType<Temporal> = SubgraphRootType<Temporal>,
 > = Omit<Subgraph<Temporal, RootType>, "edges"> & {
   edges: DeepOmitValidInterval<
-    OntologyRootedEdges & {
-      [entityId: EntityId]: Record<
-        typeof TIMESTAMP_PLACEHOLDER,
-        KnowledgeGraphOutwardEdge[]
-      >;
-    }
+    | OntologyRootedEdges
+    | {
+        [entityId: EntityId]: Record<
+          typeof TIMESTAMP_PLACEHOLDER,
+          KnowledgeGraphOutwardEdge[]
+        >;
+      }
   >;
 };
 

--- a/libs/mock-block-dock/src/datastore/traverse.ts
+++ b/libs/mock-block-dock/src/datastore/traverse.ts
@@ -1,6 +1,6 @@
 import {
   EntityId,
-  EntityValidInterval,
+  EntityIdWithInterval,
   GraphElementVertexId,
   GraphResolveDepths,
   HasLeftEntityEdge,
@@ -37,12 +37,12 @@ import {
 const TIMESTAMP_PLACEHOLDER = "TIMESTAMP_PLACEHOLDER" as const;
 
 /**
- * Advanced type to recursively search a type for `EntityValidInterval` and patch those occurrences by removing the
- * definition of the "validInterval" property.
+ * Advanced type to recursively search a type for `EntityIdWithInterval` and patch those occurrences by removing the
+ * definition of the "interval" property.
  */
 type DeepOmitValidInterval<ToPatch extends unknown> = ToPatch extends object
-  ? ToPatch extends EntityValidInterval
-    ? Omit<ToPatch, "validInterval">
+  ? ToPatch extends EntityIdWithInterval
+    ? Omit<ToPatch, "interval">
     : { [key in keyof ToPatch]: DeepOmitValidInterval<ToPatch[key]> }
   : ToPatch;
 
@@ -325,17 +325,17 @@ export const traverseElementTemporal = ({
 
         if (isEntityVertex(neighborVertex)) {
           // get from temporal data of the neighbor vertex
-          const entityValidInterval =
+          const entityInterval =
             neighborVertex.inner.metadata.temporalVersioning[
               traversalSubgraph.temporalAxes.resolved.variable.axis
             ];
           newIntersection = intervalIntersectionWithInterval(
             interval,
-            entityValidInterval,
+            entityInterval,
           );
           neighborVertexId = {
             baseId: neighborVertex.inner.metadata.recordId.entityId,
-            revisionId: entityValidInterval.start.limit,
+            revisionId: entityInterval.start.limit,
           };
         } else {
           newIntersection = interval;
@@ -496,7 +496,7 @@ export const finalizeSubgraph = <
                 ...outwardEdge,
                 rightEndpoint: {
                   ...outwardEdge.rightEndpoint,
-                  validInterval: {
+                  interval: {
                     start: { kind: "inclusive", limit: edgeFirstCreatedAt },
                     end: endLimit
                       ? { kind: "exclusive", limit: endLimit as string }

--- a/libs/mock-block-dock/src/datastore/use-mock-datastore.ts
+++ b/libs/mock-block-dock/src/datastore/use-mock-datastore.ts
@@ -247,7 +247,7 @@ export const useMockDatastore = (
                 currentEntity.metadata.temporalVersioning[
                   currentGraph.temporalAxes.resolved.variable.axis
                 ].start.limit
-              ]?.inner,
+              ]?.inner as Entity<true>,
             );
 
             newCurrentEntity.metadata.temporalVersioning.decisionTime.end =

--- a/libs/mock-block-dock/src/debug-view/dev-tools/datastore-graph-visualization.tsx
+++ b/libs/mock-block-dock/src/debug-view/dev-tools/datastore-graph-visualization.tsx
@@ -220,7 +220,7 @@ const getSubgraphEdgesAsEChartEdges = (
                 );
               }
               return intervalOverlapsInterval(
-                outwardEdge.rightEndpoint.validInterval,
+                outwardEdge.rightEndpoint.interval,
                 vertex.inner.metadata.temporalVersioning[
                   subgraph.temporalAxes.resolved.variable.axis
                 ],

--- a/libs/mock-block-dock/src/debug-view/dev-tools/datastore-graph-visualization.tsx
+++ b/libs/mock-block-dock/src/debug-view/dev-tools/datastore-graph-visualization.tsx
@@ -23,7 +23,7 @@ import { SVGRenderer } from "echarts/renderers";
 import { useEffect, useRef, useState } from "react";
 
 import { useMockBlockDockContext } from "../../mock-block-dock-context";
-import { typedEntries } from "../../util";
+import { typedEntries, typedKeys } from "../../util";
 
 const parseLabelFromEntity = (
   entityToLabel: Entity<true>,
@@ -198,7 +198,7 @@ const getSubgraphEdgesAsEChartEdges = (
   typedEntries(subgraph.edges).flatMap(([sourceBaseId, inner]) => {
     return typedEntries(inner).flatMap(([revisionId, outwardEdges]) => {
       return outwardEdges.flatMap((outwardEdge) => {
-        const sourceRevisions = Object.keys(
+        const sourceRevisions = typedKeys(
           subgraph.vertices[sourceBaseId]!,
         ).filter((sourceRevisionId) => {
           return sourceRevisionId >= revisionId;
@@ -226,9 +226,7 @@ const getSubgraphEdgesAsEChartEdges = (
                 ],
               );
             } else {
-              return (
-                Number(targetRevisionId) >= outwardEdge.rightEndpoint.revisionId
-              );
+              return targetRevisionId >= outwardEdge.rightEndpoint.revisionId;
             }
           })
           .map(([targetRevisionId, _vertex]) => targetRevisionId);

--- a/libs/mock-block-dock/src/util.ts
+++ b/libs/mock-block-dock/src/util.ts
@@ -47,9 +47,21 @@ export type Entry<T extends {}> = T extends readonly [unknown, ...unknown[]]
   : ObjectEntry<T>;
 
 /** `Object.entries` analogue which returns a well-typed array */
-export function typedEntries<T extends {}>(object: T): ReadonlyArray<Entry<T>> {
+export const typedEntries = <T extends {}>(
+  object: T,
+): ReadonlyArray<Entry<T>> => {
   return Object.entries(object) as unknown as ReadonlyArray<Entry<T>>;
-}
+};
+
+/** `Object.values` analogue which returns a well-typed array */
+export const typedKeys = <T extends {}>(object: T): Entry<T>[0][] => {
+  return Object.keys(object) as Entry<T>[0][];
+};
+
+/** `Object.values` analogue which returns a well-typed array */
+export const typedValues = <T extends {}>(object: T): Entry<T>[1][] => {
+  return Object.values(object);
+};
 
 type FilterEntitiesFn = {
   <Temporal extends boolean>(params: {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `Subgraph` object contains correct information about the keys used as identifiers for `vertices` and `edges`. Namely, that elements are identified by the following pairs 
- `(EntityId, TimestampString)`, 
- `(BaseUri, number)`

In an ideal world, this would encapsulate quite a lot more information about a correctly formed `Subgraph`. It would greatly reduce the number of type guards that would need to be called in TS, for example (`isEntityVertex`), as the code path would know if it's dealing with an ontology element or a knowledge-graph one.

Unfortunately, the `number` type confuses the heck out of TypeScript and it actually can cause code to be completely incorrect at the worst of times.

This is because when the `number` type is used as a key in an object, it is inferred as being equivalent to the string `` `${number}` `` which overlaps the string type used for entity related things. But when seeing a plain string index, TS will assume it's an entity-related thing, rather than correctly inferring it could be either as it _could_ overlap the `number` string.

As part of this PR, I investigated trying to have keys that completely do not overlap (either through additional template strings, or some form of type branding), but eventually needed to opt for removing the helpful type information. 

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203543026679380/1203904064506712/f) _(internal)_

## 🚫 Blocked by

- [x] #931 

## 🔍 What does this change?

As usual, see commits, I will open comments directly on code that needs specific attention.

## 📜 Does this require a change to the docs?

These changes are mostly internal, and as we haven't published the `Subgraph` type yet, this _change_ shouldn't need additional documentation besides the in-code one added.

## ⚠️ Known issues

Will open comments on specific parts of the code which posed known issues, otherwise N/A

## 🐾 Next steps

N/A

## 🛡 What tests cover this?

- `tsc`
- `eslint`
- Manually running MBD

## ❓ How to test this?

1.  See CI
2. Checkout the branch and ensure `yarn` works
3. Try running MBD and ensure it all behaves as expected (noting that a few of the blocks are broken on this branch)

## 📹 Demo

<img width="587" alt="image" src="https://user-images.githubusercontent.com/25749103/216953397-5fc3127c-d744-4f57-8cc0-269339f2eef6.png">
<img width="1187" alt="image" src="https://user-images.githubusercontent.com/25749103/216953615-cd107574-d6c1-42ee-8d82-8cc28bb32386.png">

