### PR TITLE
Update the aggregation query syntax to take the field in a filter as an array of components

### DIFF
--- a/libs/@blockprotocol/graph/src/types/entity.ts
+++ b/libs/@blockprotocol/graph/src/types/entity.ts
@@ -135,11 +135,11 @@ export type MultiFilterOperatorType = "AND" | "OR";
 export type MultiFilter = {
   filters: (
     | {
-        field: string;
+        field: string[];
         operator: FilterOperatorRequiringValue;
         value: string;
       }
-    | { field: string; operator: FilterOperatorWithoutValue }
+    | { field: string[]; operator: FilterOperatorWithoutValue }
   )[];
   operator: MultiFilterOperatorType;
 };
@@ -152,7 +152,6 @@ export type Sort = {
 export type MultiSort = Sort[];
 
 export type AggregateOperationInput = {
-  entityTypeId?: VersionedUri | null;
   pageNumber?: number | null;
   itemsPerPage?: number | null;
   multiSort?: MultiSort | null;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Previously the `aggregateEntities` and `aggregateEntityTypes` syntax took a singular string when filtering on a specific field. This wasn't fully specified, and generally only referred to a top-level key within the `properties` of an entity (or the schema of an entity type). Our local implementation within mock-block-dock might have worked if the user had written a nested field as `x.y.z`, but this wasn't fully intended.

This PR updates the `field` parameter to instead be a `string[]` where it takes the path in the JSON as a list of components, e.g. `["x", "y", "z"]`. This now also queries inside an `Entity` or an `EntityTypeWithMetadata`, rather than specifically within the `properties` blob or schema. This means that a user could filter on the type of an entity by using:
`["metadata", "entityTypeId"]`, as well as being able to filter link entities based on their left/right entity IDs, etc. As such this PR also removed the `entityTypeId` special-cased field in the aggregation syntax.

As a drive-by I believe I've implemented basic filtering for entity types too.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1202805690238892/1203181084817506/f) _(internal)_

## 🚫 Blocked by

- [ ] #940 

## 🔍 What does this change?

See description above, and commits, it's fairly constrained

## 📜 Does this require a change to the docs?

- This 100% will need a change in our incoming push to update the 0.3 spec. (See #880)

## ⚠️ Known issues

N/A

## 🐾 Next steps

- Publish new canary versions
- Confirm this works in MBD
- Potentially add aggregation queries for other ontology types
- Revisit linked aggregations

## 🛡 What tests cover this?

- Unsure if there are any besides `tsc` or `eslint`. We intend to check this over in the HASH EA soon (https://github.com/hashintel/hash/pull/1844), and also will be creating new blocks when canary versions are published after this branch, so we will be testing it soon.

## ❓ How to test this?

Code review for now is probably best.

## 📹 Demo

N/A
