### PR TITLE
Hotfix `no space left on device` by cleaning Yarn cache

### DIFF
--- a/apps/site/scripts/prepare-blocks.ts
+++ b/apps/site/scripts/prepare-blocks.ts
@@ -522,7 +522,11 @@ const script = async () => {
 
       const currentYarnCacheChecksum = calculateYarnCacheChecksum(blockInfo);
       if (yarnCacheChecksum !== currentYarnCacheChecksum) {
-        await execa("yarn", ["cache", "clean"], { cwd: monorepoRoot });
+        console.log("Cleaning global Yarn cache...");
+        await execa("yarn", ["cache", "clean"], {
+          cwd: monorepoRoot,
+          stdio: "inherit",
+        });
         yarnCacheChecksum = currentYarnCacheChecksum;
       }
 


### PR DESCRIPTION
<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
## 🌟 What is the purpose of this PR?

This PR contributes to avoiding errors some Vercel builds, e.g. https://vercel.com/hashintel/blockprotocol/AAPj5Vcj4TrXJEgBkyVDeCtaNksz. It runs `yarn cache clean` between block builds, thus reducing the chances of running out of disk space.


<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203623179643281/1203903843802405/f) _(internal)_
- [Slack thread](https://hashintel.slack.com/archives/C02TWBTT3ED/p1675086373319199) _(internal)_

## 🐾 Next steps

- https://github.com/blockprotocol/blockprotocol/pull/936

## 🛡 What tests cover this?

CI

## ❓ How to test this?

Run Vercel build without cache and see if it fails

## Demo

- [Build with Vercel cache (blocks are ready)](https://vercel.com/hashintel/blockprotocol/5ZzTuYggyQN9KtvbbjQvyfz89n6L)
- [Build without Vercel cache (blocks need preparing)](https://vercel.com/hashintel/blockprotocol/KYS8oT4ohcpxcAY2NTU2gWNoRe2p)