### PR TITLE
Fix bugs in the Graph service stdlib

### DIFF
--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/link-entity.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/link-entity.ts
@@ -220,7 +220,7 @@ export const getIncomingLinksForEntity = <Temporal extends boolean>(
     }
   }
 
-  return entities.filter(uniqueEntitiesFilter);
+  return entities;
 };
 
 /**

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/link-entity.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/link-entity.ts
@@ -18,7 +18,6 @@ import {
   intervalIntersectionWithInterval,
   intervalIsStrictlyAfterInterval,
 } from "../../interval.js";
-import { mustBeDefined } from "../../must-be-defined.js";
 import { getEntityRevisionsByEntityId } from "../element/entity.js";
 import { getLatestInstantIntervalForSubgraph } from "../temporal-axes.js";
 
@@ -54,6 +53,10 @@ const getUniqueEntitiesFilter = <Temporal extends boolean>() => {
  *  {@link Subgraph} that supports temporal versioning, will constrain the results to links that were present during
  *  that interval. If the parameter is omitted then results will default to only returning results that are active in
  *  the latest instant of time in the {@link Subgraph}
+ *
+ * @returns {Entity[]} - A flat list of all {@link Entity}s associated with {@link OutgoingLinkEdge}s from the specified
+ *   {@link Entity}. This list may contain multiple revisions of the same {@link Entity}s, and it might be beneficial to
+ *   pair the output with {@link mapElementsIntoRevisions}.
  */
 export const getOutgoingLinksForEntity = <Temporal extends boolean>(
   subgraph: Subgraph<Temporal>,
@@ -140,6 +143,10 @@ export const getOutgoingLinksForEntity = <Temporal extends boolean>(
  *  {@link Subgraph} that supports temporal versioning, will constrain the results to links that were present during
  *  that interval. If the parameter is omitted then results will default to only returning results that are active in
  *  the latest instant of time in the {@link Subgraph}
+ *
+ * @returns {Entity[]} - A flat list of all {@link Entity}s associated with {@link IncomingLinkEdge}s from the specified
+ *   {@link Entity}. This list may contain multiple revisions of the same {@link Entity}s, and it might be beneficial to
+ *   pair the output with {@link mapElementsIntoRevisions}.
  */
 export const getIncomingLinksForEntity = <Temporal extends boolean>(
   subgraph: Subgraph<Temporal>,
@@ -225,26 +232,28 @@ export const getIncomingLinksForEntity = <Temporal extends boolean>(
  *  {@link Subgraph} that supports temporal versioning, will constrain the results to links that were present during
  *  that interval. If the parameter is omitted then results will default to only returning results that are active in
  *  the latest instant of time in the {@link Subgraph}
+ *
+ * @returns {Entity[] | undefined} - all revisions of the left {@link Entity} which was associated with a
+ *   {@link HasLeftEntityEdge}, if found, from the given {@link EntityId} within the {@link Subgraph}, otherwise
+ *   `undefined`.
  */
 export const getLeftEntityForLinkEntity = <Temporal extends boolean>(
   subgraph: Subgraph<Temporal>,
   entityId: EntityId,
   interval?: Temporal extends true ? TimeInterval : undefined,
-): Entity<Temporal>[] => {
+): Entity<Temporal>[] | undefined => {
   const searchInterval =
     interval !== undefined
       ? interval
       : getLatestInstantIntervalForSubgraph(subgraph);
 
-  const linkEntityEdges = mustBeDefined(
-    subgraph.edges[entityId],
-    "link entities must have left endpoints and therefore must have edges",
-  );
+  const outwardEdge = Object.values(subgraph.edges[entityId] ?? {})
+    .flat()
+    .find(isHasLeftEntityEdge);
 
-  const outwardEdge = mustBeDefined(
-    Object.values(linkEntityEdges).flat().find(isHasLeftEntityEdge),
-    "link entities must have left endpoints",
-  );
+  if (!outwardEdge) {
+    return undefined;
+  }
 
   const leftEntityId = outwardEdge.rightEndpoint.entityId;
 
@@ -286,26 +295,28 @@ export const getLeftEntityForLinkEntity = <Temporal extends boolean>(
  *  {@link Subgraph} that supports temporal versioning, will constrain the results to links that were present during
  *  that interval. If the parameter is omitted then results will default to only returning results that are active in
  *  the latest instant of time in the {@link Subgraph}
+ *
+ * @returns {Entity[] | undefined} - all revisions of the right {@link Entity} which was associated with a
+ *   {@link HasRightEntityEdge}, if found, from the given {@link EntityId} within the {@link Subgraph}, otherwise
+ *   `undefined`.
  */
 export const getRightEntityForLinkEntity = <Temporal extends boolean>(
   subgraph: Subgraph<Temporal>,
   entityId: EntityId,
   interval?: Temporal extends true ? TimeInterval : undefined,
-): Entity<Temporal>[] => {
+): Entity<Temporal>[] | undefined => {
   const searchInterval =
     interval !== undefined
       ? interval
       : getLatestInstantIntervalForSubgraph(subgraph);
 
-  const linkEntityEdges = mustBeDefined(
-    subgraph.edges[entityId],
-    "link entities must have right endpoints and therefore must have edges",
-  );
+  const outwardEdge = Object.values(subgraph.edges[entityId] ?? {})
+    .flat()
+    .find(isHasRightEntityEdge);
 
-  const outwardEdge = mustBeDefined(
-    Object.values(linkEntityEdges).flat().find(isHasRightEntityEdge),
-    "link entities must have right endpoints",
-  );
+  if (!outwardEdge) {
+    return undefined;
+  }
 
   const rightEntityId = outwardEdge.rightEndpoint.entityId;
 
@@ -339,8 +350,8 @@ export const getRightEntityForLinkEntity = <Temporal extends boolean>(
 };
 
 /**
- * For a given moment in time, get all outgoing link entities, and their "target" entities (by default this is the
- * "right entity"), from a given entity.
+ * For a given moment in time, get all outgoing link {@link Entity} revisions, and their "target" {@link Entity}
+ * revisions (by default this is the "right entity"), from a given {@link Entity}.
  *
  * @param subgraph
  * @param {EntityId} entityId - The ID of the source entity to search for outgoing links from
@@ -395,10 +406,12 @@ export const getOutgoingLinkAndTargetEntities = <
   } else {
     return getOutgoingLinksForEntity(subgraph as Subgraph<false>, entityId).map(
       (linkEntity) => {
-        const rightEntityRevisions = getRightEntityForLinkEntity(
-          subgraph as Subgraph<false>,
-          linkEntity.metadata.recordId.entityId,
-        );
+        const rightEntityRevisions =
+          getRightEntityForLinkEntity(
+            subgraph as Subgraph<false>,
+            linkEntity.metadata.recordId.entityId,
+          ) ??
+          []; /** @todo - Are we comfortable hiding the `undefined` value here with an empty array? */
 
         if (rightEntityRevisions.length !== 1) {
           throw new Error(

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/element/entity.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/element/entity.ts
@@ -5,6 +5,8 @@ import { isEntityVertex } from "../../../types/subgraph/vertices.js";
 import { TimeInterval, Timestamp } from "../../../types/temporal-versioning.js";
 import {
   intervalContainsTimestamp,
+  intervalForTimestamp,
+  intervalIsStrictlyAfterInterval,
   intervalOverlapsInterval,
 } from "../../interval.js";
 import { mustBeDefined } from "../../must-be-defined.js";
@@ -135,8 +137,12 @@ export const getEntityRevisionsByEntityId = <Temporal extends boolean>(
     const filteredEntities = [];
 
     for (const [startTime, vertex] of typedEntries(versionObject)) {
+      // Only look at vertices that were created before or within the search interval
       if (
-        intervalContainsTimestamp(interval, startTime) &&
+        !intervalIsStrictlyAfterInterval(
+          intervalForTimestamp(startTime),
+          interval,
+        ) &&
         isEntityVertex(vertex)
       ) {
         if (

--- a/libs/@blockprotocol/graph/src/types/entity.ts
+++ b/libs/@blockprotocol/graph/src/types/entity.ts
@@ -10,7 +10,7 @@ import {
   InclusiveLimitedTemporalBound,
   QueryTemporalAxesUnresolved,
   Subgraph,
-  TemporalAxes,
+  TemporalAxis,
   TimeInterval,
   Timestamp,
   Unbounded,
@@ -58,7 +58,7 @@ type HalfClosedInterval = TimeInterval<
 >;
 
 export type EntityTemporalVersioningMetadata = Record<
-  TemporalAxes,
+  TemporalAxis,
   HalfClosedInterval
 >;
 

--- a/libs/@blockprotocol/graph/src/types/subgraph.ts
+++ b/libs/@blockprotocol/graph/src/types/subgraph.ts
@@ -13,6 +13,7 @@ import {
 
 export * from "./ontology.js";
 export * from "./subgraph/edges.js";
+export * from "./subgraph/element-mappings.js";
 export * from "./subgraph/graph-resolve-depths.js";
 export * from "./subgraph/temporal-axes.js";
 export * from "./subgraph/vertices.js";

--- a/libs/@blockprotocol/graph/src/types/temporal-versioning.ts
+++ b/libs/@blockprotocol/graph/src/types/temporal-versioning.ts
@@ -12,7 +12,7 @@ export type Timestamp = string;
 /**
  * @todo - doc
  */
-export type TemporalAxes = "transactionTime" | "decisionTime";
+export type TemporalAxis = "transactionTime" | "decisionTime";
 
 /**
  * The bound of a time-interval that is either exclusively or inclusively limited by a `Timestamp`
@@ -91,7 +91,7 @@ export type BoundedTimeInterval = TimeInterval<
  * {@link PinnedTemporalAxisUnresolved}.
  */
 export type VariableTemporalAxisUnresolved<
-  Axis extends TemporalAxes,
+  Axis extends TemporalAxis,
   StartBound extends TemporalBound | null = TemporalBound | null,
   EndBound extends LimitedTemporalBound | null = LimitedTemporalBound | null,
 > = {
@@ -107,7 +107,7 @@ export type VariableTemporalAxisUnresolved<
  * {@link PinnedTemporalAxis}.
  */
 export type VariableTemporalAxis<
-  Axis extends TemporalAxes,
+  Axis extends TemporalAxis,
   StartBound extends TemporalBound = TemporalBound,
   EndBound extends LimitedTemporalBound = LimitedTemporalBound,
 > = {
@@ -124,7 +124,7 @@ export type VariableTemporalAxis<
  * {@link VariableTemporalAxisUnresolved}.
  */
 export type PinnedTemporalAxisUnresolved<
-  Axis extends TemporalAxes,
+  Axis extends TemporalAxis,
   PinnedTime extends Timestamp | null = Timestamp | null,
 > = {
   axis: Axis;
@@ -139,7 +139,7 @@ export type PinnedTemporalAxisUnresolved<
  * {@link VariableTemporalAxis}.
  */
 export type PinnedTemporalAxis<
-  Axis extends TemporalAxes,
+  Axis extends TemporalAxis,
   PinnedTime extends Timestamp = Timestamp,
 > = {
   axis: Axis;

--- a/libs/mock-block-dock/src/datastore/traverse.ts
+++ b/libs/mock-block-dock/src/datastore/traverse.ts
@@ -162,10 +162,9 @@ export const getNeighbors = <
         sourceEntity.linkData?.leftEntityId !== undefined &&
         sourceEntity.linkData?.rightEntityId !== undefined
       ) {
-        const leftEntityRevisions = getLeftEntityForLinkEntity(
-          datastore,
-          sourceEntityId,
-          interval,
+        const leftEntityRevisions = mustBeDefined(
+          getLeftEntityForLinkEntity(datastore, sourceEntityId, interval),
+          `links must have left entities in the datastore, ${sourceEntityId} did not`,
         );
         const hasLeftEntityEdge: PatchedHasLeftEntityEdge = {
           kind: "HAS_LEFT_ENTITY",
@@ -237,10 +236,9 @@ export const getNeighbors = <
         sourceEntity.linkData?.leftEntityId !== undefined &&
         sourceEntity.linkData?.rightEntityId !== undefined
       ) {
-        const rightEntityRevisions = getRightEntityForLinkEntity(
-          datastore,
-          sourceEntityId,
-          interval,
+        const rightEntityRevisions = mustBeDefined(
+          getRightEntityForLinkEntity(datastore, sourceEntityId, interval),
+          `links must have right entities in the datastore, ${sourceEntityId} did not`,
         );
         const hasRightEntityEdge: PatchedHasRightEntityEdge = {
           kind: "HAS_RIGHT_ENTITY",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A few sneaky bugs slipped by in previous PRs that introduced temporal versioning code for the stdlib. As identified in those PRs, testing has been deferred to unblock other work in the immediate term, and we were going to discover bugs through development usage, that has happened, and this PR fixes those bugs.

A follow-up will add a block that will make testing these things more easy, although where to put that block is currently unclear, that in-dev block was used to check that the fixes here were correct.

Furthermore,  previously, when traversing a subgraph, the subgraph lib expected there to be left and right entities for all link entities. This was largely based on the reasoning that it's impossible to create a link entity that does not have a left or right endpoint. However, depending on your depths (e.g. `hasLeftEntity: { incoming: 0, outgoing: 0 }`) you will not get back that vertex within the `Subgraph`. This broke an invariant in the stdlib code. This PR removes that incorrect invariant, and hoists it to the EA (mock-block-dock) where that invariant still _is_ an invariant.

There are still some unresolved questions about if we want to treat missing things as `undefined` or `[]` return values, or if we should throw errors like "NOT_FOUND".

This also drive-by renames a typo.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203623179643281/1203928892175779/f) _(internal)_

## 🚫 Blocked by

N/A

## 🔍 What does this change?

See commits

## 📜 Does this require a change to the docs?

Not as of yet.

## ⚠️ Known issues

N/A

## 🐾 Next steps

Make the block that uses all of the BP graph methods available somewhere

## 🛡 What tests cover this?

`tsc`, `eslint`, etc.

## ❓ How to test this?

Try loading a block in MBD that creates and gets links.

## 📹 Demo

Example from the block that's currently in-dev. Previously querying this link entity would result in an error and 0 edges.
<img width="652" alt="image" src="https://user-images.githubusercontent.com/25749103/217544227-2a907d92-ac36-47d9-a5c3-b357d31ec26b.png">

