### PR TITLE
Temporarily remove pagination from `aggregate*` methods

### DIFF
--- a/libs/@blockprotocol/graph/src/types/entity.ts
+++ b/libs/@blockprotocol/graph/src/types/entity.ts
@@ -152,8 +152,6 @@ export type Sort = {
 export type MultiSort = Sort[];
 
 export type AggregateOperationInput = {
-  pageNumber?: number | null;
-  itemsPerPage?: number | null;
   multiSort?: MultiSort | null;
   multiFilter?: MultiFilter | null;
 };
@@ -170,11 +168,7 @@ export type AggregateEntitiesResult<
   T extends Subgraph<Temporal, EntityRootType<Temporal>>,
 > = {
   results: T;
-  operation: AggregateOperationInput &
-    Required<Pick<AggregateOperationInput, "pageNumber" | "itemsPerPage">> & {
-      pageCount?: number | null;
-      totalCount?: number | null;
-    };
+  operation: AggregateOperationInput;
 };
 
 /**

--- a/libs/@blockprotocol/graph/src/types/ontology/entity-type.ts
+++ b/libs/@blockprotocol/graph/src/types/ontology/entity-type.ts
@@ -26,11 +26,7 @@ export type AggregateEntityTypesResult<
   T extends Subgraph<boolean, EntityTypeRootType>,
 > = {
   results: T[];
-  operation: AggregateOperationInput &
-    Required<Pick<AggregateOperationInput, "pageNumber" | "itemsPerPage">> & {
-      pageCount?: number | null;
-      totalCount?: number | null;
-    };
+  operation: AggregateOperationInput;
 };
 
 export type GetEntityTypeData = {

--- a/libs/mock-block-dock/src/util.ts
+++ b/libs/mock-block-dock/src/util.ts
@@ -241,20 +241,13 @@ export function filterAndSortEntitiesOrTypes<
 ): FilterResult<Temporal> {
   const { operation } = payload;
 
-  const pageNumber = operation?.pageNumber || 1;
-  const itemsPerPage = operation?.itemsPerPage || 10;
   const multiSort = operation?.multiSort ?? [{ field: "updatedAt" }];
   const multiFilter = operation?.multiFilter;
 
   const appliedOperation = {
-    pageNumber,
-    itemsPerPage,
     multiFilter,
     multiSort,
   };
-
-  const startIndex = pageNumber === 1 ? 0 : (pageNumber - 1) * itemsPerPage;
-  const endIndex = Math.min(startIndex + itemsPerPage, elements.length);
 
   let results = [...elements] as Elements;
   if (multiFilter) {
@@ -264,18 +257,14 @@ export function filterAndSortEntitiesOrTypes<
     }) as Elements;
   }
 
-  const totalCount = results.length;
-  const pageCount = Math.ceil(totalCount / itemsPerPage);
   results = sortEntitiesOrTypes({
     elements: results,
     multiSort,
-  }).slice(startIndex, endIndex) as Elements;
+  });
   return {
     results,
     operation: {
       ...appliedOperation,
-      totalCount,
-      pageCount,
     },
   };
 }

--- a/libs/mock-block-dock/src/util.ts
+++ b/libs/mock-block-dock/src/util.ts
@@ -263,8 +263,6 @@ export function filterAndSortEntitiesOrTypes<
   });
   return {
     results,
-    operation: {
-      ...appliedOperation,
-    },
+    operation: appliedOperation,
   };
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With the introduction of the `Subgraph` type, the previous implementation of paginated results for "aggregate" queries no longer makes sense. 

Paginating a graph is a difficult task, as there isn't a discrete index one can use in a stable-ordered _list_ of items, and a cursor needs to contain a potentially unbounded size of information that is yet to be resolved for future queries.

We intend to revisit this, potentially just allowing cursor-based pagination over the `roots` of a `Subgraph`, although ideally with a different solution that will be better suited to blocks that need control over the message sizes.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203358502199087/1203919127849757/f) _(internal)_

## 🚫 Blocked by

N/A

## 🔍 What does this change?

- Removes all `page` related fields
- Removes the pagination implementation in `mock-block-dock`

## 📜 Does this require a change to the docs?

- The spec will need to be updated to identify this change. This will happen prior to the merge of #880.

## ⚠️ Known issues

N/A

## 🐾 Next steps

- N/A at this time

## 🛡 What tests cover this?

- Unknown aside from `tsc` and `eslint`, blocks using aggregations should continue to work
