### PR TITLE
Remove type-system dependency from core

### DIFF
--- a/libs/@blockprotocol/core/package.json
+++ b/libs/@blockprotocol/core/package.json
@@ -57,7 +57,6 @@
     "lint:tsc": "tsc --noEmit"
   },
   "dependencies": {
-    "@blockprotocol/type-system": "0.0.3",
     "es-module-lexer": "^0.10.5",
     "uuid": "^8.3.2"
   },

--- a/libs/@blockprotocol/core/src/types.ts
+++ b/libs/@blockprotocol/core/src/types.ts
@@ -1,5 +1,3 @@
-import { VersionedUri } from "@blockprotocol/type-system/slim";
-
 import { CoreHandler } from "./core-handler";
 import { ServiceHandler } from "./service-handler";
 
@@ -102,7 +100,7 @@ export type BlockMetadata = {
   /**
    * The path or URL to the block's schema (e.g. block-schema.json)
    */
-  schema: VersionedUri;
+  schema: string;
   /**
    * The path or URL to the entrypoint source file (e.g. index.html, index.js).
    */


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
I started getting a module import error from `@blockprotocol/core` and I'm checking if it's the new presence of `@blockprotocol/graph` that might cause it (core hasn't changed much otherwise).