### PR TITLE
Add default to 'exports' paths in @blockprotocol/core

### DIFF
--- a/libs/@blockprotocol/core/package.json
+++ b/libs/@blockprotocol/core/package.json
@@ -24,11 +24,13 @@
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.js",
+      "default": "./dist/esm/index.js"
     },
     "./react": {
       "import": "./dist/esm/react.js",
-      "require": "./dist/cjs/react.js"
+      "require": "./dist/cjs/react.js",
+      "default": "./dist/esm/react.js"
     }
   },
   "main": "./dist/cjs/index.js",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR? 

I'm encountering an issue when attempting to run HASH with the latest version of `@blockprotocol/` packages which I think is related to https://github.com/vercel/next.js/issues/39375

#926 introduced `exports` to `@blockprotocol/core` recently.

Adding `default` to see if it makes any difference.
```
[dev:frontend] file:///Users/ciaran/dev/hash/apps/hash-frontend/node_modules/@blockprotocol/hook/dist/hook-block-handler.js:1
[dev:frontend] import { ServiceHandler } from "@blockprotocol/core";
[dev:frontend]          ^^^^^^^^^^^^^^
[dev:frontend] SyntaxError: Named export 'ServiceHandler' not found. The requested module '@blockprotocol/core' is a CommonJS module, which may not support all module.exports as named exports.
[dev:frontend] CommonJS modules can always be imported via the default export, for example using:
[dev:frontend] 
[dev:frontend] import pkg from '@blockprotocol/core';
[dev:frontend] const { ServiceHandler } = pkg;
[dev:frontend] 
[dev:frontend]     at ModuleJob._instantiate (node:internal/modules/esm/module_job:123:21)
[dev:frontend]     at async ModuleJob.run (node:internal/modules/esm/module_job:189:5)
[dev:frontend]     at async Promise.all (index 0)
[dev:frontend]     at async ESMLoader.import (node:internal/modules/esm/loader:541:24)
[dev:frontend]     at async importModuleDynamicallyWrapper (node:internal/vm/module:438:15) {
[dev:frontend]   page: '/'
[dev:frontend] }
```