### PR TITLE
Remove export paths from core

### DIFF
--- a/libs/@blockprotocol/core/package.json
+++ b/libs/@blockprotocol/core/package.json
@@ -21,31 +21,9 @@
     "name": "HASH",
     "url": "https://hash.ai"
   },
-  "exports": {
-    ".": {
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "default": "./dist/esm/index.js"
-    },
-    "./react": {
-      "import": "./dist/esm/react.js",
-      "require": "./dist/cjs/react.js",
-      "default": "./dist/esm/react.js"
-    }
-  },
-  "main": "./dist/esm/index.js",
+  "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
-  "typesVersions": {
-    "*": {
-      ".": [
-        "./dist/esm/index.d.ts"
-      ],
-      "react": [
-        "./dist/esm/react.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist"
   ],

--- a/libs/@blockprotocol/graph/src/react.ts
+++ b/libs/@blockprotocol/graph/src/react.ts
@@ -1,4 +1,4 @@
-import { useServiceConstructor } from "@blockprotocol/core/react";
+import { useServiceConstructor } from "@blockprotocol/core/dist/esm/react.js";
 import { FunctionComponent, RefObject, useMemo } from "react";
 
 import {

--- a/libs/@blockprotocol/hook/src/react.ts
+++ b/libs/@blockprotocol/hook/src/react.ts
@@ -1,4 +1,4 @@
-import { useServiceConstructor } from "@blockprotocol/core/react";
+import { useServiceConstructor } from "@blockprotocol/core/dist/esm/react.js";
 import { EntityId } from "@blockprotocol/graph";
 import { RefObject, useLayoutEffect, useRef, useState } from "react";
 

--- a/libs/@local/eslint-config/index.js
+++ b/libs/@local/eslint-config/index.js
@@ -48,14 +48,11 @@ module.exports = {
         ignore: [
           "^https?://",
           // These packages uses 'exports' field in package.json https://github.com/import-js/eslint-plugin-import/issues/1810
-          "^@blockprotocol/core",
           "^@blockprotocol/graph",
           "^@blockprotocol/hook",
         ],
       },
     ],
-    // this causes a false positive importing from @blockprotocol/core and is redundant for TypeScript code
-    "import/named": "off",
     "import/prefer-default-export": "off",
     "no-console": "error",
     "no-dupe-class-members": "off",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#957 describes an issue where NextJS is erroring on attempting to load a file in `@blockprotocol/core`. I think this is because of the addition of `exports` paths in #926, so I'm removing them to see if it fixes it.

Longer-term we should probably update `@blockprotocol/core` to be ESM only (this may have other knock-on effects which is why I don't want to do it now).