### PR TITLE
Revert "Remove export paths from core"

### DIFF
--- a/libs/@blockprotocol/core/package.json
+++ b/libs/@blockprotocol/core/package.json
@@ -21,9 +21,31 @@
     "name": "HASH",
     "url": "https://hash.ai"
   },
-  "main": "./dist/cjs/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "default": "./dist/esm/index.js"
+    },
+    "./react": {
+      "import": "./dist/esm/react.js",
+      "require": "./dist/cjs/react.js",
+      "default": "./dist/esm/react.js"
+    }
+  },
+  "main": "./dist/esm/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/esm/index.d.ts",
+  "typesVersions": {
+    "*": {
+      ".": [
+        "./dist/esm/index.d.ts"
+      ],
+      "react": [
+        "./dist/esm/react.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/libs/@blockprotocol/graph/src/react.ts
+++ b/libs/@blockprotocol/graph/src/react.ts
@@ -1,4 +1,4 @@
-import { useServiceConstructor } from "@blockprotocol/core/dist/esm/react.js";
+import { useServiceConstructor } from "@blockprotocol/core/react";
 import { FunctionComponent, RefObject, useMemo } from "react";
 
 import {

--- a/libs/@blockprotocol/hook/src/react.ts
+++ b/libs/@blockprotocol/hook/src/react.ts
@@ -1,4 +1,4 @@
-import { useServiceConstructor } from "@blockprotocol/core/dist/esm/react.js";
+import { useServiceConstructor } from "@blockprotocol/core/react";
 import { EntityId } from "@blockprotocol/graph";
 import { RefObject, useLayoutEffect, useRef, useState } from "react";
 

--- a/libs/@local/eslint-config/index.js
+++ b/libs/@local/eslint-config/index.js
@@ -48,11 +48,14 @@ module.exports = {
         ignore: [
           "^https?://",
           // These packages uses 'exports' field in package.json https://github.com/import-js/eslint-plugin-import/issues/1810
+          "^@blockprotocol/core",
           "^@blockprotocol/graph",
           "^@blockprotocol/hook",
         ],
       },
     ],
+    // this causes a false positive importing from @blockprotocol/core and is redundant for TypeScript code
+    "import/named": "off",
     "import/prefer-default-export": "off",
     "no-console": "error",
     "no-dupe-class-members": "off",


### PR DESCRIPTION
Reverts blockprotocol/blockprotocol#959 – this did not fix the error described in #957, but adding `@blockprotocol/core` and its dependents to transpiled modules in NextJS for `hash-frontend` did.

The long-term fix is to do one or both of 

(a) make `@blockprotocol/core` an ESM package (i.e. type: "module" and associated updates)
(b) make `hash-frontend` an ESM package

