### PR TITLE
Fix `compareBounds`

### DIFF
--- a/libs/@blockprotocol/graph/src/stdlib/bound.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/bound.ts
@@ -14,7 +14,25 @@ export const compareBounds = (
     }
   }
 
-  if (left.kind === right.kind && leftType === rightType) {
+  if (
+    (left.kind === "unbounded" &&
+      right.kind === "unbounded" &&
+      leftType === "start" &&
+      rightType === "start") ||
+    (left.kind === "unbounded" &&
+      right.kind === "unbounded" &&
+      leftType === "end" &&
+      rightType === "end") ||
+    (left.kind === "exclusive" &&
+      right.kind === "exclusive" &&
+      leftType === "start" &&
+      rightType === "start") ||
+    (left.kind === "exclusive" &&
+      right.kind === "exclusive" &&
+      leftType === "end" &&
+      rightType === "end") ||
+    (left.kind === "inclusive" && right.kind === "inclusive")
+  ) {
     return 0;
   }
 
@@ -54,7 +72,9 @@ export const compareBounds = (
   throw new Error(
     `Implementation error, failed to compare bounds.\nLHS: ${JSON.stringify(
       left,
-    )}\nRHS: ${JSON.stringify(right)}`,
+    )}\nLHS Type: ${leftType}\nRHS: ${JSON.stringify(
+      right,
+    )}\nRHS Type: ${rightType}`,
   );
 };
 

--- a/libs/mock-block-dock/src/mock-block-dock.tsx
+++ b/libs/mock-block-dock/src/mock-block-dock.tsx
@@ -6,6 +6,7 @@ import {
   QueryTemporalAxes,
 } from "@blockprotocol/graph";
 import { useGraphEmbedderService } from "@blockprotocol/graph/react";
+import { compareBounds } from "@blockprotocol/graph/stdlib";
 import { EmbedderHookMessageCallbacks, HookData } from "@blockprotocol/hook/.";
 import { useHookEmbedderService } from "@blockprotocol/hook/react";
 import {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When translating the `compareBounds` implementation from Rust to TS we missed a few cases, this fixes a bug that occurs in an edge-case when the `kind` and `limit`s are the same, but the "type" (start or end) is different.