### PR TITLE
Add statistics reporting to R2 block downloading

### DIFF
--- a/infra/cloudflare-r2-wrangler/blockprotocol-preview/wrangler.toml
+++ b/infra/cloudflare-r2-wrangler/blockprotocol-preview/wrangler.toml
@@ -5,6 +5,10 @@ compatibility_date = "2022-06-30"
 account_id = "c6499786332a3d2fb35419a7803ab7aa"
 workers_dev = true
 
+[vars]
+DATA_URL = ""
+DATA_WRITE_KEY = "something-probably-secret"
+
 [[r2_buckets]]
 binding = "BLOCKPROTOCOL_BUCKET"
 bucket_name = "blockprotocol-preview"

--- a/infra/cloudflare-r2-wrangler/blockprotocol/wrangler.toml
+++ b/infra/cloudflare-r2-wrangler/blockprotocol/wrangler.toml
@@ -5,6 +5,10 @@ compatibility_date = "2022-06-30"
 account_id = "c6499786332a3d2fb35419a7803ab7aa"
 workers_dev = true
 
+[vars]
+DATA_URL = ""
+DATA_WRITE_KEY = "something-probably-secret"
+
 [[r2_buckets]]
 binding = "BLOCKPROTOCOL_BUCKET"
 bucket_name = "blockprotocol-production"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This PR adds statistics reporting to our R2 worker. We still provide aggregate statistics in MongoDB as these are used to show download in the website. The new statistics reporting will be used for internal analytics.

The reporting is disabled until we set the environment variables in the workers control panel on CF.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1203657549452631/f) _(internal)_

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->


## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Adds disabled-by-default reporting for every block download enriched with specific block metadata.

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow-ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- None, I had to test by disabling everything to run locally. I tried using [miniflare](https://miniflare.dev/) to mock the storage server, but it isn't ideal still. We should look into setting up a jest test suite that uses miniflare so we can properly test this worker. 
- We can probably also use Cloudflare KV instead of MongoDB for the aggregate statistics, but since we're using MongoDB everywhere else, this isn't really useful at all right now.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->
I commented out all bucket/mongodb related things and made HTTP requests by hand. Not ideal. I used a HTTP request inspector/bin site to make sure the request was made and that the worker wouldn't crash if the request is erroneous

## 📹 Demo

