### PR TITLE
Remove drawing block from `/hub`

### DIFF
--- a/hub/@tldraw/drawing.json
+++ b/hub/@tldraw/drawing.json
@@ -1,7 +1,0 @@
-{
-  "repository": "https://github.com/hashintel/hash.git",
-  "commit": "09b559a2bc48973ab9a2cfa3be8bf28e84d2dd85",
-
-  "workspace": "@blocks/drawing",
-  "distDir": "dist"
-}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR complements https://github.com/hashintel/hash/pull/2053

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1203922830586240/f) _(internal)_

## ⚠️ Known issues

- Lack of `BLOCK_PROTOCOL_API_KEY_TLDRAW_PREVIEW` in https://github.com/hashdeps/tldraw-block  
   ↑ We can configure this later and start with publishing tldraw to prod only first.

## 🔍 What does this change?

Drawing block is stored in R2 and DB

## 🐾 Next steps

Repeat the same process for other blocks
