### PR TITLE
Miscellaneous updates to the Graph service

### DIFF
--- a/libs/@blockprotocol/graph/src/stdlib.ts
+++ b/libs/@blockprotocol/graph/src/stdlib.ts
@@ -3,6 +3,7 @@
  */
 export { compareBounds } from "./stdlib/bound.js";
 export {
+  intervalCompareWithInterval,
   intervalContainsInterval,
   intervalContainsTimestamp,
   intervalForTimestamp,
@@ -13,6 +14,7 @@ export {
   intervalMergeWithInterval,
   intervalOverlapsInterval,
   intervalUnionWithInterval,
+  sortIntervals,
   unionOfIntervals,
 } from "./stdlib/interval.js";
 export { buildSubgraph } from "./stdlib/subgraph/builder.js";

--- a/libs/@blockprotocol/graph/src/stdlib/interval.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/interval.ts
@@ -8,6 +8,39 @@ import {
 import { boundIsAdjacentToBound, compareBounds } from "./bound.js";
 
 /**
+ * Standard comparison function that returns whether `IntervalA` is before the `IntervalB`. Where "before"
+ * is defined by first comparing the start bounds, and if those are equal, then the end bounds are compared.
+ *
+ * @param {TimeInterval} intervalA
+ * @param {TimeInterval} intervalB
+ */
+export const intervalCompareWithInterval = (
+  intervalA: TimeInterval,
+  intervalB: TimeInterval,
+): number => {
+  const startComparison = compareBounds(
+    intervalA.start,
+    intervalB.start,
+    "start",
+    "start",
+  );
+
+  return startComparison !== 0
+    ? startComparison
+    : compareBounds(intervalA.end, intervalB.end, "end", "end");
+};
+
+/**
+ * Sorts a given collection of {@link TimeInterval} in place, sorted first from earliest to latest start bounds, and
+ * then earliest to latest end bounds.
+ *
+ * @param {TimeInterval[]} intervals
+ */
+export const sortIntervals = (intervals: TimeInterval[]) => {
+  intervals.sort(intervalCompareWithInterval);
+};
+
+/**
  * Creates a {@link BoundedTimeInterval} that represents the instant of time identified by the given {@link Timestamp}.
  *
  * This is an interval where both bounds are `inclusive`, with limit points at the given {@link Timestamp}. Having an
@@ -327,18 +360,7 @@ export const unionOfIntervals = <IntervalsType extends TimeInterval>(
    -----------|---------------|---------------|---------------
    Union      | [------]  [-] | (------)  [-] | [-----------]
    */
-  intervals.sort((intervalA, intervalB) => {
-    const startComparison = compareBounds(
-      intervalA.start,
-      intervalB.start,
-      "start",
-      "start",
-    );
-
-    return startComparison !== 0
-      ? startComparison
-      : compareBounds(intervalA.end, intervalB.end, "end", "end");
-  });
+  sortIntervals(intervals);
 
   return intervals.reduce((union, currentInterval) => {
     if (union.length === 0) {

--- a/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/link-entity.ts
+++ b/libs/@blockprotocol/graph/src/stdlib/subgraph/edge/link-entity.ts
@@ -12,7 +12,7 @@ import {
   isTemporalSubgraph,
   Subgraph,
 } from "../../../types/subgraph.js";
-import { TimeInterval, Timestamp } from "../../../types/temporal-versioning.js";
+import { TimeInterval } from "../../../types/temporal-versioning.js";
 import {
   intervalForTimestamp,
   intervalIntersectionWithInterval,
@@ -20,16 +20,6 @@ import {
 } from "../../interval.js";
 import { getEntityRevisionsByEntityId } from "../element/entity.js";
 import { getLatestInstantIntervalForSubgraph } from "../temporal-axes.js";
-
-const convertTimeToTimestampWithDefault = (
-  timestamp?: Date | Timestamp,
-): Timestamp => {
-  return timestamp === undefined
-    ? new Date().toISOString()
-    : typeof timestamp === "string"
-    ? timestamp
-    : timestamp.toISOString();
-};
 
 const getUniqueEntitiesFilter = <Temporal extends boolean>() => {
   const set = new Set();
@@ -350,14 +340,14 @@ export const getRightEntityForLinkEntity = <Temporal extends boolean>(
 };
 
 /**
- * For a given moment in time, get all outgoing link {@link Entity} revisions, and their "target" {@link Entity}
+ * For a given {@link TimeInterval}, get all outgoing link {@link Entity} revisions, and their "target" {@link Entity}
  * revisions (by default this is the "right entity"), from a given {@link Entity}.
  *
  * @param subgraph
  * @param {EntityId} entityId - The ID of the source entity to search for outgoing links from
- * @param {Date | Timestamp} [timestamp] - An optional `Date` or an ISO-formatted datetime string of the moment to
- *    search for. If the parameter is omitted then results will default to only returning results that are active in
- *    the latest instant of time in the {@link Subgraph}
+ * @param {TimeInterval} [interval] - An optional {@link TimeInterval} to constrain the period of time to search across.
+ * If the parameter is omitted then results will default to only returning results that are active in the latest instant
+ *   of time in the {@link Subgraph}
  */
 export const getOutgoingLinkAndTargetEntities = <
   Temporal extends boolean,
@@ -365,12 +355,10 @@ export const getOutgoingLinkAndTargetEntities = <
 >(
   subgraph: Subgraph<Temporal>,
   entityId: EntityId,
-  timestamp?: Temporal extends true ? Date | Timestamp : undefined,
+  interval?: Temporal extends true ? TimeInterval : undefined,
 ): LinkAndRightEntities => {
   const searchInterval =
-    timestamp !== undefined
-      ? intervalForTimestamp(convertTimeToTimestampWithDefault(timestamp))
-      : getLatestInstantIntervalForSubgraph(subgraph);
+    interval ?? getLatestInstantIntervalForSubgraph(subgraph);
 
   if (isTemporalSubgraph(subgraph)) {
     const outgoingLinkEntities = getOutgoingLinksForEntity(

--- a/libs/@blockprotocol/graph/src/types/ontology/metadata.ts
+++ b/libs/@blockprotocol/graph/src/types/ontology/metadata.ts
@@ -2,5 +2,4 @@ import { OntologyTypeRecordId } from "../ontology.js";
 
 export interface OntologyElementMetadata {
   recordId: OntologyTypeRecordId;
-  ownedById: string;
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

- In using the canary versions it became apparent that the library could benefit from hoisting and exposing its interval comparison function.
- the addition of an `ownedById` on ontology type records was an oversight, and doesn't make sense in a lot of contexts in EAs (a type may not be owned by any user of the system.
- `getOutgoingLinkAndTargetEntities` took a `Timestamp` instead of a `TimeInterval`, this was inconsistent with the other methods
