### PR TITLE
Produce cjs bundle for the Graph

### DIFF
--- a/libs/@blockprotocol/graph/package.json
+++ b/libs/@blockprotocol/graph/package.json
@@ -23,41 +23,73 @@
   },
   "type": "module",
   "exports": {
-    ".": "./dist/index.js",
-    "./codegen": [
-      "./dist/codegen.js"
-    ],
-    "./custom-element": "./dist/custom-element.js",
-    "./graph-service-json": "./dist/graph-service-json.js",
-    "./internal": "./dist/internal.js",
-    "./react": "./dist/react.js",
-    "./stdlib": [
-      "./dist/stdlib.js"
-    ]
+    ".": {
+      "types": "./dist/cjs/index.d.ts",
+      "node": "./dist/cjs/index.cjs",
+      "import": "./dist/es/index.js",
+      "default": "./dist/cjs/index.cjs"
+    },
+    "./codegen": {
+      "types": "./dist/cjs/codegen.d.ts",
+      "node": "./dist/cjs/codegen.cjs",
+      "import": "./dist/es/codegen.js",
+      "default": "./dist/cjs/codegen.cjs"
+    },
+    "./custom-element": {
+      "types": "./dist/cjs/custom-element.d.ts",
+      "node": "./dist/cjs/custom-element.cjs",
+      "import": "./dist/es/custom-element.js",
+      "default": "./dist/cjs/custom-element.cjs"
+    },
+    "./graph-service-json": {
+      "types": "./dist/cjs/graph-service-json.d.ts",
+      "node": "./dist/cjs/graph-service-json.cjs",
+      "import": "./dist/es/graph-service-json.js",
+      "default": "./dist/cjs/graph-service-json.cjs"
+    },
+    "./internal": {
+      "types": "./dist/cjs/internal.d.ts",
+      "node": "./dist/cjs/internal.cjs",
+      "import": "./dist/es/internal.js",
+      "default": "./dist/cjs/internal.cjs"
+    },
+    "./react": {
+      "types": "./dist/cjs/react.d.ts",
+      "node": "./dist/cjs/react.cjs",
+      "import": "./dist/es/react.js",
+      "default": "./dist/cjs/react.cjs"
+    },
+    "./stdlib": {
+      "types": "./dist/cjs/stdlib.d.ts",
+      "node": "./dist/cjs/stdlib.cjs",
+      "import": "./dist/es/stdlib.js",
+      "default": "./dist/cjs/stdlib.cjs"
+    }
   },
-  "types": "./dist/index.d.ts",
+  "module": "./dist/es/index.js",
+  "types": "./dist/cjs/index.d.ts",
   "typesVersions": {
     "*": {
       ".": [
-        "./dist/index.d.ts"
+        "./dist/cjs/index.d.ts"
       ],
       "codegen": [
-        "./dist/codegen.d.ts"
+        "./dist/cjs/codegen.d.ts"
       ],
       "custom-element": [
-        "./dist/custom-element.d.ts"
+        "./dist/cjs/custom-element.d.ts"
       ],
       "graph-service-json": [
-        "./dist/graph-service-json.d.ts"
+        "./dist/cjs/graph-service-json.d.ts"
       ],
       "internal": [
-        "./dist/internal.d.ts"
+        "./dist/cjs/internal.d.ts"
       ],
       "react": [
-        "./dist/react.d.ts"
+        "./dist/cjs/react.d.ts"
       ],
       "stdlib": [
-        "./dist/stdlib.d.ts"
+        "./dist/cjs/stdlib.d.ts"
       ]
     }
   },
@@ -65,7 +97,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && tsc --skipLibCheck",
+    "build": "yarn clean && yarn build:bundle",
+    "build:bundle": "rollup -c --bundleConfigAsCjs",
     "clean": "rimraf ./dist/",
     "fix:eslint": "eslint --fix .",
     "lint:eslint": "eslint --report-unused-disable-directives .",
@@ -83,8 +116,12 @@
   "devDependencies": {
     "@local/eslint-config": "0.0.0-private",
     "@local/tsconfig": "0.0.0-private",
+    "@rollup/plugin-commonjs": "24.0.1",
+    "@rollup/plugin-json": "6.0.0",
+    "@rollup/plugin-typescript": "9.0.2",
     "eslint": "8.33.0",
     "rimraf": "^3.0.2",
+    "rollup": "3.5.1",
     "typescript": "4.9.4"
   },
   "peerDependencies": {

--- a/libs/@blockprotocol/graph/package.json
+++ b/libs/@blockprotocol/graph/package.json
@@ -25,45 +25,38 @@
   "exports": {
     ".": {
       "types": "./dist/cjs/index.d.ts",
-      "node": "./dist/cjs/index.cjs",
-      "import": "./dist/es/index.js",
-      "default": "./dist/cjs/index.cjs"
+      "require": "./dist/cjs/index.cjs",
+      "import": "./dist/es/index.js"
     },
     "./codegen": {
       "types": "./dist/cjs/codegen.d.ts",
-      "node": "./dist/cjs/codegen.cjs",
-      "import": "./dist/es/codegen.js",
-      "default": "./dist/cjs/codegen.cjs"
+      "require": "./dist/cjs/codegen.cjs",
+      "import": "./dist/es/codegen.js"
     },
     "./custom-element": {
       "types": "./dist/cjs/custom-element.d.ts",
-      "node": "./dist/cjs/custom-element.cjs",
-      "import": "./dist/es/custom-element.js",
-      "default": "./dist/cjs/custom-element.cjs"
+      "require": "./dist/cjs/custom-element.cjs",
+      "import": "./dist/es/custom-element.js"
     },
     "./graph-service-json": {
       "types": "./dist/cjs/graph-service-json.d.ts",
-      "node": "./dist/cjs/graph-service-json.cjs",
-      "import": "./dist/es/graph-service-json.js",
-      "default": "./dist/cjs/graph-service-json.cjs"
+      "require": "./dist/cjs/graph-service-json.cjs",
+      "import": "./dist/es/graph-service-json.js"
     },
     "./internal": {
       "types": "./dist/cjs/internal.d.ts",
-      "node": "./dist/cjs/internal.cjs",
-      "import": "./dist/es/internal.js",
-      "default": "./dist/cjs/internal.cjs"
+      "require": "./dist/cjs/internal.cjs",
+      "import": "./dist/es/internal.js"
     },
     "./react": {
       "types": "./dist/cjs/react.d.ts",
-      "node": "./dist/cjs/react.cjs",
-      "import": "./dist/es/react.js",
-      "default": "./dist/cjs/react.cjs"
+      "require": "./dist/cjs/react.cjs",
+      "import": "./dist/es/react.js"
     },
     "./stdlib": {
       "types": "./dist/cjs/stdlib.d.ts",
-      "node": "./dist/cjs/stdlib.cjs",
-      "import": "./dist/es/stdlib.js",
-      "default": "./dist/cjs/stdlib.cjs"
+      "require": "./dist/cjs/stdlib.cjs",
+      "import": "./dist/es/stdlib.js"
     }
   },
   "module": "./dist/es/index.js",

--- a/libs/@blockprotocol/graph/rollup.config.js
+++ b/libs/@blockprotocol/graph/rollup.config.js
@@ -1,0 +1,43 @@
+import commonjs from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json";
+import typescript from "@rollup/plugin-typescript";
+
+const production = !process.env.ROLLUP_WATCH;
+
+const outDir = (fmt) => `dist/${fmt}`;
+
+const rolls = (fmt, input) => ({
+  input,
+  output: {
+    dir: outDir(fmt),
+    format: fmt,
+    entryFileNames: `[name].${fmt === "cjs" ? "cjs" : "js"}`,
+    name: "graph",
+    sourcemap: !production,
+  },
+  plugins: [
+    typescript({
+      declaration: true,
+      declarationDir: outDir(fmt),
+      outDir: outDir(fmt),
+      rootDir: "src",
+      sourceMap: !production,
+      inlineSources: !production,
+      outputToFilesystem: false,
+    }),
+    json(),
+    commonjs(),
+  ],
+});
+
+export default ["es", "cjs"].flatMap((fmt) =>
+  [
+    "src/index.ts",
+    "src/codegen.ts",
+    "src/custom-element.ts",
+    "src/graph-service-json.ts",
+    "src/internal.ts",
+    "src/react.ts",
+    "src/stdlib.ts",
+  ].map((input) => rolls(fmt, input)),
+);

--- a/libs/@blockprotocol/graph/src/codegen.ts
+++ b/libs/@blockprotocol/graph/src/codegen.ts
@@ -14,8 +14,6 @@ import { fetchTypeAsJson } from "./codegen/shared.js";
 const ajv = new Ajv2020();
 addFormats(ajv);
 
-const entityTypeValidator = await ajv.compile<EntityType>(entityTypeMetaSchema);
-
 /**
  * Validates that the schema at a given URI is a valid Entity Type
  * @param versionedUri – the URI / $id of the schema
@@ -24,6 +22,10 @@ const entityTypeValidator = await ajv.compile<EntityType>(entityTypeMetaSchema);
 export const fetchAndValidateEntityType = async (
   versionedUri: VersionedUri,
 ) => {
+  const entityTypeValidator = await ajv.compile<EntityType>(
+    entityTypeMetaSchema,
+  );
+
   const entityTypeSchema = await fetchTypeAsJson(versionedUri);
 
   if (!entityTypeValidator(entityTypeSchema)) {

--- a/libs/mock-block-dock/src/mock-block-dock.tsx
+++ b/libs/mock-block-dock/src/mock-block-dock.tsx
@@ -6,7 +6,6 @@ import {
   QueryTemporalAxes,
 } from "@blockprotocol/graph";
 import { useGraphEmbedderService } from "@blockprotocol/graph/react";
-import { compareBounds } from "@blockprotocol/graph/stdlib";
 import { EmbedderHookMessageCallbacks, HookData } from "@blockprotocol/hook/.";
 import { useHookEmbedderService } from "@blockprotocol/hook/react";
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2877,7 +2877,7 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10":
+"@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.13":
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
@@ -3331,6 +3331,25 @@
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@realm.io/common/-/common-0.1.5.tgz#4285c8142d5024a0876318cdfd28f23ea98ebf4f"
   integrity sha512-Y+UnICLvsPFpe2WOXWIdJUaV3G2qDocN8al/Yz13mYMkjODXHL4VhyfEKR2hvcAubv+7isdegEyYNdo3zQzbFA==
+
+"@rollup/plugin-commonjs@24.0.1":
+  version "24.0.1"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-commonjs/-/plugin-commonjs-24.0.1.tgz#d54ba26a3e3c495dc332bd27a81f7e9e2df46f90"
+  integrity sha512-15LsiWRZk4eOGqvrJyu3z3DaBu5BhXIMeWnijSRvd8irrrg9SHpQ1pH+BUK4H6Z9wL9yOxZJMTLU+Au86XHxow==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
+    commondir "^1.0.1"
+    estree-walker "^2.0.2"
+    glob "^8.0.3"
+    is-reference "1.2.1"
+    magic-string "^0.27.0"
+
+"@rollup/plugin-json@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-6.0.0.tgz#199fea6670fd4dfb1f4932250569b14719db234a"
+  integrity sha512-i/4C5Jrdr1XUarRhVu27EEwjt4GObltD7c+MkCIpO2QIbojw8MUs+CCTqOphQi3Qtg1FLmYt+l+6YeoIf51J7w==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
 
 "@rollup/plugin-sucrase@4.0.4":
   version "4.0.4"
@@ -8020,6 +8039,17 @@ glob@^8.0.1, glob@~8.0.3:
     minimatch "^5.0.1"
     once "^1.3.0"
 
+glob@^8.0.3:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
 globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
@@ -8878,6 +8908,13 @@ is-promise@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
   integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
+
+is-reference@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.2.1.tgz#8b2dac0b371f4bc994fdeaba9eb542d03002d0b7"
+  integrity sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
+  dependencies:
+    "@types/estree" "*"
 
 is-reference@^3.0.0:
   version "3.0.0"
@@ -10072,6 +10109,13 @@ lru_map@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
   integrity sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ==
+
+magic-string@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.27.0.tgz#e4a3413b4bab6d98d2becffd48b4a257effdbbf3"
+  integrity sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.13"
 
 make-dir@^3.0.0, make-dir@^3.0.2:
   version "3.1.0"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Importing the Graph package from a service that runs using `ts-node` turned out to be difficult due to it being ESM. This PR applies a quick fix to produce a CJS bundle similar to how the `type-system` is built. 

It also driveby's a lint failure.

## 📜 Does this require a change to the docs?

No, `yarn` should work as before

## ⚠️ Known issues

- We can't use the same approach as we did in `/core` to produce two bundles, it can't handle some of the necessary transpilations we need for `cjs` stuff to do with imports, async, and assertions. (relevant issue https://github.com/microsoft/TypeScript/issues/51783)
- Top-level await isn't supported in `cjs` so I had to move some of the functionality in`codegen.ts`

## 🐾 Next steps

- Publish canary versions

## 🛡 What tests cover this?

- Generally static code analysis (`yarn lint`, etc.) and testing `mock-block-dock` manually

## ❓ How to test this?

1. Ensure `yarn` still passes
2. Make sure `mock-block-dock` still functions

## 📹 Demo

### `mock-block-dock`
<img width="1898" alt="image" src="https://user-images.githubusercontent.com/25749103/218737867-e3c07c86-1b5e-4805-8e67-7d317b77081a.png">

### Usage in HASH
- Previously we'd get `ts-node` resolution errors when running `yarn dev` for the API package.
- I locally built these packages, and copied them over into the respective `node_modules` folders, and then reran `yarn dev`

#### Before
```sh
[dev:backend] [api] Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/alfie/dev/hash/libs/@local/hash-subgraph/node_modules/@blockprotocol/graph/dist/stdlib.js from /Users/alfie/dev/hash/libs/@local/hash-subgraph/src/stdlib/bound.ts not supported.
[dev:backend] [api] Instead change the require of stdlib.js in /Users/alfie/dev/hash/libs/@local/hash-subgraph/src/stdlib/bound.ts to a dynamic import() which is available in all CommonJS modules.
```

#### After
```sh
> yarn dev
yarn run v1.22.17
$ concurrently "yarn:dev:backend" "yarn:dev:frontend"
$ yarn workspace @apps/hash-frontend dev
$ concurrently "yarn:dev:backend:*"
$ yarn workspace @apps/hash-api dev
$ yarn workspace @apps/hash-realtime dev
$ yarn workspace @apps/hash-search-loader dev
$ next dev
[dev:frontend] ready - started server on 0.0.0.0:3000, url: http://localhost:3000
$ node --max-old-space-size=2048 ./node_modules/.bin/ts-node-dev --respawn --transpile-only ./src/index.ts
$ node --max-old-space-size=2048 ./node_modules/.bin/ts-node-dev --respawn --transpile-only ./src/index.ts
$ echo 'Opensearch currently disabled'
[dev:backend] [search-loader] Opensearch currently disabled
[dev:backend] [search-loader] yarn run dev:backend:search-loader exited with code 0
[dev:frontend] warn  - You have enabled experimental feature (allowMiddlewareResponseBody) in next.config.js.
[dev:frontend] warn  - Experimental features are not covered by semver, and may cause unexpected or broken application behavior. Use at your own risk.
[dev:frontend] 
[dev:backend] [api] [INFO] 12:19:22 ts-node-dev ver. 2.0.0 (using ts-node ver. 10.9.1, typescript ver. 4.9.4)
[dev:backend] [realtime] [INFO] 12:19:22 ts-node-dev ver. 2.0.0 (using ts-node ver. 10.9.1, typescript ver. 4.9.4)
[dev:frontend] info  - automatically enabled Fast Refresh for 1 custom loader
[dev:frontend] [@sentry/nextjs] You are using edge functions or middleware. Please note that Sentry does not yet support error monitoring for these features.
[dev:backend] [realtime] info: STARTED {"service":"realtime","instanceId":"d22d8be4-3453-4ea6-bc80-4c611e54a164","timestamp":"2023-02-14T12:19:23.158Z"}
[dev:backend] [realtime] info: HTTP server listening on port 3333 {"service":"realtime","instanceId":"d22d8be4-3453-4ea6-bc80-4c611e54a164","timestamp":"2023-02-14T12:19:23.159Z"}
[dev:backend] [realtime] info: Replication slot 'realtime' exists. {"service":"realtime","instanceId":"d22d8be4-3453-4ea6-bc80-4c611e54a164","timestamp":"2023-02-14T12:19:23.262Z"}
[dev:backend] [api] info: Type System initialized {"service":"api"}
[dev:backend] [api] info: Registered OpenTelemetry trace exporter at endpoint http://localhost:4317 {"service":"api"}
[dev:backend] [api] info: Created system user account id: bf97c9d1-f4b3-45f3-a2a5-3f3ef2e4c8d7 {"service":"api"}
[dev:frontend] event - compiled client and server successfully in 2.7s (3435 modules)

```
