### PR TITLE
Increase build heap size for Graph

### DIFF
--- a/libs/@blockprotocol/graph/package.json
+++ b/libs/@blockprotocol/graph/package.json
@@ -91,7 +91,7 @@
   ],
   "scripts": {
     "build": "yarn clean && yarn build:bundle",
-    "build:bundle": "rollup -c --bundleConfigAsCjs",
+    "build:bundle": "node --max-old-space-size=4096 ../../../node_modules/rollup/dist/bin/rollup -c --bundleConfigAsCjs",
     "clean": "rimraf ./dist/",
     "fix:eslint": "eslint --fix .",
     "lint:eslint": "eslint --report-unused-disable-directives .",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#975 added a new bundling step for the `@blockprotocol/graph` package which uses rollup. Rollup can be a bit of a memory hog and the [publish job](https://github.com/blockprotocol/blockprotocol/actions/runs/4174329059/jobs/7227752921) failed due to running out of memory on build.

This PR attempts to fix that by doubling the heap size to 4GB (and [GitHub actions machines apparently have 7GB](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)).

If this continues to cause problems we should look into moving to some other lightweight build tool (such as [tsup](https://tsup.egoist.dev/)) for the Graph Package instead of `rollup`. Ideally this will solve the problem in the meantime though.