### PR TITLE
Update aggregations syntax

### DIFF
--- a/apps/site/public/types/services/graph/aggregation-operation.json
+++ b/apps/site/public/types/services/graph/aggregation-operation.json
@@ -76,17 +76,17 @@
   "$defs": {
     "FilterOperatorRequiringValue": {
       "enum": [
-        "CONTAINS",
-        "DOES_NOT_CONTAIN",
+        "CONTAINS_SEGMENT",
+        "DOES_NOT_CONTAIN_SEGMENT",
         "ENDS_WITH",
-        "IS",
-        "IS_NOT",
+        "EQUALS",
+        "DOES_NOT_EQUAL",
         "STARTS_WITH"
       ],
       "type": "string"
     },
     "FilterOperatorWithoutValue": {
-      "enum": ["IS_EMPTY", "IS_NOT_EMPTY"],
+      "enum": ["IS_DEFINED", "IS_NOT_DEFINED"],
       "type": "string"
     },
     "MultiFilterOperatorType": {

--- a/libs/@blockprotocol/graph/src/shared.ts
+++ b/libs/@blockprotocol/graph/src/shared.ts
@@ -22,7 +22,7 @@ type Entry<T extends {}> = T extends readonly [unknown, ...unknown[]]
   ? [`${number}`, U]
   : ObjectEntry<T>;
 
-// @todo deduplicate this and packages/mock-block-dock/src/util.ts
+// @todo deduplicate this and libs/mock-block-dock/src/util.ts
 /** `Object.entries` analogue which returns a well-typed array
  *
  * Source: https://dev.to/harry0000/a-bit-convenient-typescript-type-definitions-for-objectentries-d6g

--- a/libs/@blockprotocol/graph/src/types/entity.ts
+++ b/libs/@blockprotocol/graph/src/types/entity.ts
@@ -135,17 +135,17 @@ export type MultiFilterOperatorType = "AND" | "OR";
 export type MultiFilter = {
   filters: (
     | {
-        field: string[];
+        field: (string | number)[];
         operator: FilterOperatorRequiringValue;
-        value: string;
+        value: CoreJsonValue;
       }
-    | { field: string[]; operator: FilterOperatorWithoutValue }
+    | { field: (string | number)[]; operator: FilterOperatorWithoutValue }
   )[];
   operator: MultiFilterOperatorType;
 };
 
 export type Sort = {
-  field: string;
+  field: (string | number)[];
   desc?: boolean | undefined | null;
 };
 

--- a/libs/@blockprotocol/graph/src/types/entity.ts
+++ b/libs/@blockprotocol/graph/src/types/entity.ts
@@ -120,13 +120,13 @@ export type FilterOperatorType =
   | FilterOperatorRequiringValue
   | FilterOperatorWithoutValue;
 
-export type FilterOperatorWithoutValue = "IS_EMPTY" | "IS_NOT_EMPTY";
+export type FilterOperatorWithoutValue = "IS_DEFINED" | "IS_NOT_DEFINED";
 
 export type FilterOperatorRequiringValue =
-  | "CONTAINS"
-  | "DOES_NOT_CONTAIN"
-  | "IS"
-  | "IS_NOT"
+  | "CONTAINS_SEGMENT"
+  | "DOES_NOT_CONTAIN_SEGMENT"
+  | "EQUALS"
+  | "DOES_NOT_EQUAL"
   | "STARTS_WITH"
   | "ENDS_WITH";
 

--- a/libs/@blockprotocol/hook/README.md
+++ b/libs/@blockprotocol/hook/README.md
@@ -24,7 +24,7 @@ handler.hook({
     node, // a reference to the DOM node to render into
     type: "text", // the type of hook
     entityId: "entity1", // the id of the entity this hook will show/edit data for
-    path: "$.text", // the path in the entity's properties data will be taken from/saved to
+    path: ["http://example.com/property-type/text/"], // the path in the entity's properties data will be taken from/saved to
   },
 });
 ```
@@ -38,7 +38,7 @@ We also provide a `useHook` hook to make sending hook messages easier.
 ```typescript
 import { useHook } from "@blockprotocol/hook/react";
 
-useHook(hookService, nodeRef, "text", ["text"], (node) => {
+useHook(hookService, nodeRef, "text", ["http://example.com/property-type/text/"], (node) => {
   node.innerText = "hook fallback";
 
   return () => {

--- a/libs/@blockprotocol/hook/README.md
+++ b/libs/@blockprotocol/hook/README.md
@@ -38,7 +38,7 @@ We also provide a `useHook` hook to make sending hook messages easier.
 ```typescript
 import { useHook } from "@blockprotocol/hook/react";
 
-useHook(hookService, nodeRef, "text", "$.text", (node) => {
+useHook(hookService, nodeRef, "text", ["text"], (node) => {
   node.innerText = "hook fallback";
 
   return () => {

--- a/libs/@blockprotocol/hook/src/react.ts
+++ b/libs/@blockprotocol/hook/src/react.ts
@@ -56,7 +56,7 @@ type Hook<T extends HTMLElement> = {
     node: T;
     type: string;
     entityId: EntityId;
-    path: string;
+    path: (string | number)[];
   };
 };
 
@@ -80,7 +80,7 @@ export const useHook = <T extends HTMLElement>(
   ref: RefObject<T | null | void>,
   type: string,
   entityId: EntityId,
-  path: string,
+  path: (string | number)[],
   fallback: (node: T) => void | (() => void),
 ) => {
   /**
@@ -137,7 +137,7 @@ export const useHook = <T extends HTMLElement>(
       existingHook.service === service &&
       existingHook.node === node &&
       existingHook.entityId === entityId &&
-      existingHook.path === path &&
+      JSON.stringify(existingHook.path) === JSON.stringify(path) &&
       existingHook.type === type
     ) {
       return;

--- a/libs/@blockprotocol/hook/src/types.ts
+++ b/libs/@blockprotocol/hook/src/types.ts
@@ -8,7 +8,7 @@ export type HookResponse = {
 export type HookData = {
   node: HTMLElement | null;
   type: string;
-  path: string;
+  path: (string | number)[];
   hookId: string | null;
   entityId: EntityId;
 };

--- a/libs/mock-block-dock/dev/dev-app.tsx
+++ b/libs/mock-block-dock/dev/dev-app.tsx
@@ -61,7 +61,10 @@ const blockEntityMap = {
       entityTypeId: entityTypes.testType.$id,
       temporalVersioning: entityTemporalMetadata(),
     },
-    properties: { [extractBaseUri(propertyTypes.name.$id)]: "World" },
+    properties: {
+      [extractBaseUri(propertyTypes.name.$id)]: "World",
+      [extractBaseUri(propertyTypes.description.$id)]: "This is a description",
+    },
   },
   "custom-element": {
     metadata: {

--- a/libs/mock-block-dock/dev/test-react-block.tsx
+++ b/libs/mock-block-dock/dev/test-react-block.tsx
@@ -27,7 +27,7 @@ export const TestReactBlock: BlockComponent<true> = ({ graph }) => {
     hookRef,
     "text",
     blockEntity?.metadata.recordId.entityId ?? "",
-    ["description"],
+    [extractBaseUri(propertyTypes.description.$id)],
     () => {
       throw new Error(
         "Fallback called – dock is not correctly handling text hook.",

--- a/libs/mock-block-dock/dev/test-react-block.tsx
+++ b/libs/mock-block-dock/dev/test-react-block.tsx
@@ -27,7 +27,7 @@ export const TestReactBlock: BlockComponent<true> = ({ graph }) => {
     hookRef,
     "text",
     blockEntity?.metadata.recordId.entityId ?? "",
-    "$.description",
+    ["description"],
     () => {
       throw new Error(
         "Fallback called – dock is not correctly handling text hook.",

--- a/libs/mock-block-dock/src/data/property-types.ts
+++ b/libs/mock-block-dock/src/data/property-types.ts
@@ -50,6 +50,16 @@ const username: PropertyType = {
     },
   ],
 };
+const description: PropertyType = {
+  kind: "propertyType",
+  $id: "http://example.com/types/property-type/description/v/1",
+  title: "An explanation of this thing",
+  oneOf: [
+    {
+      $ref: "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1",
+    },
+  ],
+};
 
 export const propertyTypes = {
   numberOfEmployees,
@@ -57,5 +67,6 @@ export const propertyTypes = {
   age,
   email,
   username,
+  description,
 };
 // satisfies Record<string, PropertyType>;

--- a/libs/mock-block-dock/src/hook-portals.tsx
+++ b/libs/mock-block-dock/src/hook-portals.tsx
@@ -1,3 +1,4 @@
+import { JsonValue } from "@blockprotocol/core";
 import { getEntityRevision } from "@blockprotocol/graph/stdlib";
 import { HookData } from "@blockprotocol/hook";
 import { useCallback, useMemo } from "react";
@@ -5,7 +6,10 @@ import { createPortal } from "react-dom";
 
 import { TextHookView } from "./hook-portals/text";
 import { useMockBlockDockContext } from "./mock-block-dock-context";
-import { getFromObjectByPathComponents, set } from "./util";
+import {
+  getFromObjectByPathComponents,
+  setValueInObjectByPathComponents,
+} from "./util";
 
 const HookPortal = ({ entityId, path, type }: HookData) => {
   const { graph, readonly, updateEntity } = useMockBlockDockContext();
@@ -30,10 +34,10 @@ const HookPortal = ({ entityId, path, type }: HookData) => {
   }, [graph, entityId, path]);
 
   const updateValue = useCallback(
-    async (newValue: unknown) => {
+    async (newValue: JsonValue) => {
       const newProperties = { ...entity?.properties };
 
-      set(newProperties, path, newValue);
+      setValueInObjectByPathComponents(newProperties, path, newValue);
 
       return updateEntity({
         data: {

--- a/libs/mock-block-dock/src/hook-portals.tsx
+++ b/libs/mock-block-dock/src/hook-portals.tsx
@@ -23,9 +23,7 @@ const HookPortal = ({ entityId, path, type }: HookData) => {
     /** @todo update `path` to be an array so this doesn't break on Base URIs */
     const foundValue = getFromObjectByPathComponents(
       foundEntity.properties,
-      path
-        .replace(/^\$\./, "") // remove json path root identifier '$.'
-        .split("."),
+      path,
     );
 
     return { entity: foundEntity, value: foundValue };

--- a/libs/mock-block-dock/src/hook-portals.tsx
+++ b/libs/mock-block-dock/src/hook-portals.tsx
@@ -24,7 +24,6 @@ const HookPortal = ({ entityId, path, type }: HookData) => {
     }
 
     /** @todo - do we want to catch potential errors here? */
-    /** @todo update `path` to be an array so this doesn't break on Base URIs */
     const foundValue = getFromObjectByPathComponents(
       foundEntity.properties,
       path,

--- a/libs/mock-block-dock/src/hook-portals.tsx
+++ b/libs/mock-block-dock/src/hook-portals.tsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom";
 
 import { TextHookView } from "./hook-portals/text";
 import { useMockBlockDockContext } from "./mock-block-dock-context";
-import { get, set } from "./util";
+import { getFromObjectByPathComponents, set } from "./util";
 
 const HookPortal = ({ entityId, path, type }: HookData) => {
   const { graph, readonly, updateEntity } = useMockBlockDockContext();
@@ -19,10 +19,13 @@ const HookPortal = ({ entityId, path, type }: HookData) => {
       );
     }
 
-    const foundValue = get(
+    /** @todo - do we want to catch potential errors here? */
+    /** @todo update `path` to be an array so this doesn't break on Base URIs */
+    const foundValue = getFromObjectByPathComponents(
       foundEntity.properties,
-      path.replace(/^\$\./, ""), // remove json path root identifier '$.'
-      undefined,
+      path
+        .replace(/^\$\./, "") // remove json path root identifier '$.'
+        .split("."),
     );
 
     return { entity: foundEntity, value: foundValue };

--- a/libs/mock-block-dock/src/util.ts
+++ b/libs/mock-block-dock/src/util.ts
@@ -339,43 +339,53 @@ const filterEntitiesOrEntityTypes = <
         const item = getFromObjectByPathComponents(entity, filterItem.field);
 
         switch (filterItem.operator) {
-          case "IS_EMPTY": {
+          case "IS_DEFINED": {
             return item === undefined;
           }
-          case "IS_NOT_EMPTY":
+          case "IS_NOT_DEFINED":
             return item !== undefined;
-          case "CONTAINS":
+          case "CONTAINS_SEGMENT":
             if (item === undefined) {
               return null;
             }
             return contains(item, filterItem.value);
-          case "DOES_NOT_CONTAIN": {
+          case "DOES_NOT_CONTAIN_SEGMENT": {
             if (item === undefined) {
               return null;
             }
             const doesContain = contains(item, filterItem.value);
             return doesContain === null ? null : !doesContain;
           }
-          case "IS":
+          case "EQUALS":
             return isEqual(item, filterItem.value);
-          case "IS_NOT":
+          case "DOES_NOT_EQUAL":
             return !isEqual(item, filterItem.value);
           case "STARTS_WITH":
             if (
-              typeof item !== "string" ||
-              typeof filterItem.value !== "string"
+              typeof item === "string" &&
+              typeof filterItem.value === "string"
             ) {
-              return null;
+              return item.startsWith(filterItem.value);
+            } else if (Array.isArray(item) && Array.isArray(filterItem.value)) {
+              return isEqual(
+                item.slice(0, filterItem.value.length),
+                filterItem.value,
+              );
             }
-            return item.startsWith(filterItem.value);
+            return null;
           case "ENDS_WITH":
             if (
-              typeof item !== "string" ||
-              typeof filterItem.value !== "string"
+              typeof item === "string" &&
+              typeof filterItem.value === "string"
             ) {
-              return null;
+              return item.endsWith(filterItem.value);
+            } else if (Array.isArray(item) && Array.isArray(filterItem.value)) {
+              return isEqual(
+                item.slice(-filterItem.value.length),
+                filterItem.value,
+              );
             }
-            return item.endsWith(filterItem.value);
+            return null;
         }
 
         /* @ts-expect-error - This should be unreachable, it's here for JS or incorrectly typed usages */


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#941 modified the aggregations syntax to allow for querying/filtering inside of Entities/Entity Types. However there was an oversight which didn't allow a distinction between array indexing and property access, this fixes it 
by allowing for the path to be expressed as strings or numbers, where strings are property accesses and numbers are array indexing.

It also updates the implementation, and then also reworks the names for the operators as they become unclear now that we aren't just operating over strings (for example you may want to find an array that contains another sub array, similar to how you would want a string that contains a substring).

This also applies the same path component logic to the hook service which was outdated due to similar reasoning.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203543021352041/1203749694686234/f) _(internal)_
- [Asana task](https://app.asana.com/0/1203358502199087/1203978096566296/f) _(internal)_
- [Asana task](https://app.asana.com/0/1203358502199087/1203978096566294/f) _(internal)_

## 🚫 Blocked by

N/A

## 🔍 What does this change?

- Rewrites the `field` definitions as `(string|number)[]`
- Reworks the aggregation operators to be as follows

| Previous | New | Definition for `true` |
| -------- | ----- | ---------- |
| IS_NOT_EMPTY | IS_DEFINED | The path doesn't point to a defined value in the object (key does not exist, or in JS === `undefined`) | 
| IS_EMPTY | IS_NOT_DEFINED | Negation of above  | 
| CONTAINS | CONTAINS_SEGMENT | The string contains a substring, the array contains a subarray, the object contains all top-level keys of the other object, where the values of those keys are the same | 
| DOES_NOT_CONTAIN | DOES_NOT_CONTAIN_SEGMENT | Negation of above | 
| IS | EQUALS | Deep equality check (all keys and values are shared, but ordering within objects is not important) | 
| IS_NOT | DOES_NOT_EQUAL | Negation of above | 
| STARTS_WITH | STARTS_WITH | The string starts with the given substring, the first N elements of the array are deep-equal to the N elements of the other array (with order) | 
| ENDS_WITH | ENDS_WITH | The string ends with the given substring, the last N elements of the array are deep-equal to the N elements of the other array (with order) | 

## 📜 Does this require a change to the docs?

- Yes, we will need to update the documentation about the aggregation syntax and how it works

## ⚠️ Known issues

- N/A, the previous issues with `get` and `set` were fixed as drive-bys

## 🐾 Next steps

N/A

## 🛡 What tests cover this?

- Beyond `tsc` and `eslint` and ensuring `mock-block-dock` still works, none to my knowledge at this time.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch and rebuild the packages `yarn`
2. Run `yarn workspace mock-block-dock dev`
3. Modify `dev-app.tsx` to have some more sample data:
    ```ts
          initialEntities: [
            ...Object.values(blockEntityMap),
            {
              metadata: {
                recordId: {
                  entityId: "alice",
                  editionId: new Date(0).toISOString(),
                },
                entityTypeId: entityTypes.testType.$id,
                temporalVersioning: entityTemporalMetadata(),
              },
              properties: {
                [extractBaseUri(propertyTypes.name.$id)]: "Alice",
                "http://example.com/bar/": 1,
                "http://example.com/baz/": {
                  "http://example.com/qux/": true,
                  "http://example.com/quux/": [0, 1],
                  "http://example.com/corge/": null,
                },
              },
            },
            {
              metadata: {
                recordId: {
                  entityId: "bob",
                  editionId: new Date(0).toISOString(),
                },
                entityTypeId: entityTypes.testType.$id,
                temporalVersioning: entityTemporalMetadata(),
              },
              properties: {
                [extractBaseUri(propertyTypes.name.$id)]: "Bob",
                "http://example.com/bar/": 2,
                "http://example.com/baz/": {
                  "http://example.com/qux/": true,
                  "http://example.com/quux/": [2, 3],
                  "http://example.com/corge/": null,
                },
              },
            },
            {
              metadata: {
                recordId: {
                  entityId: "charlie",
                  editionId: new Date(0).toISOString(),
                },
                entityTypeId: entityTypes.testType.$id,
                temporalVersioning: entityTemporalMetadata(),
              },
              properties: {
                [extractBaseUri(propertyTypes.name.$id)]: "Charlie",
                "http://example.com/bar/": 3,
                "http://example.com/baz/": {
                  "http://example.com/qux/": false,
                  "http://example.com/quux/": [4, 5],
                  "http://example.com/corge/": null,
                },
              },
            },
            {
              metadata: {
                recordId: {
                  entityId: "dania",
                  editionId: new Date(0).toISOString(),
                },
                entityTypeId: entityTypes.testType.$id,
                temporalVersioning: entityTemporalMetadata(),
              },
              properties: {
                [extractBaseUri(propertyTypes.name.$id)]: "Dania",
                "http://example.com/bar/": 4,
                "http://example.com/baz/": {
                  "http://example.com/qux/": "Qux",
                  "http://example.com/quux/": [6, 7],
                  "http://example.com/corge/": null,
                },
              },
            },
          ],
    ```
4. Test some aggregation queries within the `test-react-block.tsx`, for example:
    ```ts

    const isAliceFilter = (): MultiFilter["filters"][number] => ({
        field: ["metadata", "recordId", "entityId"],
        operator: "EQUALS",
        value: "alice",
    });

    const isBobFilter = (): MultiFilter["filters"][number] => ({
        field: ["metadata", "recordId", "entityId"],
        operator: "EQUALS",
        value: "bob",
    });

    const quuxContainsSegmentFilter = (
        value: JsonValue,
    ): MultiFilter["filters"][number] => ({
        field: [
        "properties",
        "http://example.com/baz/",
        "http://example.com/quux/",
        ],
        operator: "CONTAINS_SEGMENT",
        value,
    });

    const quxIsFilter = (value: JsonValue): MultiFilter["filters"][number] => ({
        field: ["properties", "http://example.com/baz/", "http://example.com/qux/"],
        operator: "EQUALS",
        value,
    });

    (async () => {
        console.log({
        isAliceOrBob: getRoots(
            (
            await graphService.aggregateEntities({
                data: {
                operation: {
                    multiFilter: {
                    filters: [isAliceFilter(), isBobFilter()],
                    operator: "OR",
                    },
                },
                },
            })
            ).data!.results,
        ),
        quuxContainsZeroOr4: getRoots(
            (
            await graphService.aggregateEntities({
                data: {
                operation: {
                    multiFilter: {
                    filters: [
                        quuxContainsSegmentFilter([0]),
                        quuxContainsSegmentFilter([4]),
                    ],
                    operator: "OR",
                    },
                },
                },
            })
            ).data!.results,
        ),
        quxIsTrueAndQuuxContains2: getRoots(
            (
            await graphService.aggregateEntities({
                data: {
                operation: {
                    multiFilter: {
                    filters: [quxIsFilter(true), quuxContainsSegmentFilter([2])],
                    operator: "AND",
                    },
                },
                },
            })
            ).data!.results,
        ),
        });
    })();
    ```

## 📹 Demo

<img width="850" alt="image" src="https://user-images.githubusercontent.com/25749103/219067450-ddecea0b-93d7-48bb-989c-083f6f854659.png">
