### PR TITLE
Remove GitHub PR overview block from `/hub`

### DIFF
--- a/hub/@alfie/github-pr-overview.json
+++ b/hub/@alfie/github-pr-overview.json
@@ -1,7 +1,0 @@
-{
-  "repository": "https://github.com/hashintel/hash.git",
-  "commit": "09b559a2bc48973ab9a2cfa3be8bf28e84d2dd85",
-
-  "workspace": "@blocks/github-pr-overview",
-  "distDir": "dist"
-}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR complements https://github.com/hashintel/hash/pull/2077 and is similar to https://github.com/blockprotocol/blockprotocol/pull/972
<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/0/1203922830586241/f) _(internal)_
- https://github.com/hashintel/hash/pull/2077
- https://github.com/hashdeps/github-pr-overview
