### PR TITLE
Add BP reporting og block listing

### DIFF
--- a/apps/site/README.md
+++ b/apps/site/README.md
@@ -82,6 +82,13 @@ During local development, an S3-compatible service (`minio`) is automatically st
 Avatars are uploaded to the `avatars/(user.id)` folder within the bucket root.
 When running in development environments, avatars go to the `dev/avatars/(user.id)` folder of the bucket.
 
+### Data reporting
+
+The BP site allows publishing data to a collector platform. Currently the payloads are very simple and server-side only. To configure the targets for data collection, the following environment variables are required:
+
+- `DATA_URL`: The URL of the collector platform
+- `DATA_WRITE_KEY`: The write key for the collector platform, used in the username of HTTP basic auth header
+
 ### AWS configuration
 
 If you want to send verification codes to an email address, the following AWS environment variables have to be additionally configured:

--- a/apps/site/src/util/usage.ts
+++ b/apps/site/src/util/usage.ts
@@ -1,0 +1,62 @@
+const dataUrl = process.env.DATA_URL;
+const dataWriteKey = process.env.DATA_WRITE_KEY;
+
+export type BlockListingProperties = {
+  origin: string | null;
+  bpUserId: string;
+  ip: string | null;
+  userAgent: string | null;
+  query: string | null;
+  resultCount: number;
+};
+
+export type EventContext = {
+  event: "block_listing";
+  userId: string;
+  properties: BlockListingProperties;
+};
+
+/**
+ * @param {string} context.identifier - used as the Anonymous ID for data sending
+ */
+const createReport = (context: EventContext) => ({
+  userId: context.userId,
+  event: context.event,
+  properties: {
+    ...context.properties,
+    BpTimestamp: new Date().toISOString(),
+  },
+});
+
+/**
+ * Send a report to the data endpoint, for now we only support using it in the
+ * server-side.
+ *
+ * @param context - context for the event to report
+ */
+export const sendReport = async (context: EventContext) => {
+  if (dataUrl && dataWriteKey) {
+    const data = createReport(context);
+
+    // set the write key as the username and leave the password blank using
+    // HTTP basic authentication.
+    const encodedKey = Buffer.from(`${dataWriteKey}:`).toString("base64");
+
+    const authHeader = `Basic ${encodedKey}`;
+    const _response = await fetch(dataUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: authHeader,
+      },
+      body: JSON.stringify(data),
+    }).catch((error) => {
+      // eslint-disable-next-line no-console -- TODO: consider using logger
+      console.error(
+        `Error sending report [report=${JSON.stringify(
+          context,
+        )},error="${error}"]`,
+      );
+    });
+  }
+};


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This PR adds analytics reporting for listing blocks. We want to see who/when/from where blocks were fetched.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203623179643284/1203983951760415/f) _(internal)_

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->


## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
- I've added documentation about the new environment variables

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow-ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->
- manual testing, I've ensured the shape matches what is expected in the data collector service we run.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch / view the deployment
1.  Set the follow values in your local .env
```
DATA_URL=https://requestinspector.com/inspect/01grv082jp6z0yk13tjxrx2c20
DATA_WRITE_KEY=something-not-relevant-for-test
```
1.  Call the `/api/blocks` endpoint with an API key
1.  observe that the data is reported to the endpoint at https://requestinspector.com/p/01grv082jp6z0yk13tjxrx2c20

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

![image](https://user-images.githubusercontent.com/6988668/219363572-8d6823b6-cd89-475c-ba19-0124b4af7413.png)

