### PR TITLE
Make fields in `VersionedUri` public

### DIFF
--- a/libs/@blockprotocol/type-system/crate/src/ontology/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/data_type/mod.rs
@@ -102,7 +102,7 @@ impl From<&VersionedUri> for &DataTypeReference {
 
 impl ValidateUri for DataTypeReference {
     fn validate_uri(&self, base_uri: &BaseUri) -> Result<(), ValidationError> {
-        if base_uri == self.uri().base_uri() {
+        if base_uri == &self.uri().base_uri {
             Ok(())
         } else {
             Err(ValidationError::BaseUriMismatch {

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/mod.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/mod.rs
@@ -161,7 +161,7 @@ impl From<&VersionedUri> for &EntityTypeReference {
 
 impl ValidateUri for EntityTypeReference {
     fn validate_uri(&self, base_uri: &BaseUri) -> Result<(), ValidationError> {
-        if base_uri == self.uri().base_uri() {
+        if base_uri == &self.uri().base_uri {
             Ok(())
         } else {
             Err(ValidationError::BaseUriMismatch {

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/repr.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/repr.rs
@@ -101,7 +101,7 @@ impl TryFrom<EntityType> for super::EntityType {
             .try_into()
             .map_err(ParseEntityTypeError::InvalidLinks)?;
 
-        if entity_type_repr.additional_properties == true {
+        if entity_type_repr.additional_properties {
             return Err(ParseEntityTypeError::InvalidAdditionalPropertiesValue);
         }
 

--- a/libs/@blockprotocol/type-system/crate/src/ontology/property_type/mod.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/property_type/mod.rs
@@ -104,7 +104,7 @@ impl From<&VersionedUri> for &PropertyTypeReference {
 
 impl ValidateUri for PropertyTypeReference {
     fn validate_uri(&self, base_uri: &BaseUri) -> Result<(), ValidationError> {
-        if base_uri == self.uri().base_uri() {
+        if base_uri == &self.uri().base_uri {
             Ok(())
         } else {
             Err(ValidationError::BaseUriMismatch {

--- a/libs/@blockprotocol/type-system/crate/src/ontology/uri/mod.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/uri/mod.rs
@@ -85,30 +85,11 @@ impl<'de> Deserialize<'de> for BaseUri {
 //  if we can then we should delete wasm::VersionedUriPatch
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash)]
 pub struct VersionedUri {
-    base_uri: BaseUri,
-    version: u32,
+    pub base_uri: BaseUri,
+    pub version: u32,
 }
 
 impl VersionedUri {
-    /// Creates a new [`VersionedUri`] from the given `base_uri` and `version`.
-    ///
-    /// # Errors
-    /// - `ParseBaseUriError` if the given URI string is invalid
-    #[must_use]
-    pub const fn new(base_uri: BaseUri, version: u32) -> VersionedUri {
-        Self { base_uri, version }
-    }
-
-    #[must_use]
-    pub const fn base_uri(&self) -> &BaseUri {
-        &self.base_uri
-    }
-
-    #[must_use]
-    pub const fn version(&self) -> u32 {
-        self.version
-    }
-
     #[must_use]
     pub fn to_url(&self) -> Url {
         let mut url = self.base_uri.to_url();
@@ -151,11 +132,12 @@ impl FromStr for VersionedUri {
             }
         }
 
-        Ok(Self::new(
-            BaseUri::new(base_uri.to_owned()).map_err(ParseVersionedUriError::InvalidBaseUri)?,
-            u32::from_str(version)
+        Ok(Self {
+            base_uri: BaseUri::new(base_uri.to_owned())
+                .map_err(ParseVersionedUriError::InvalidBaseUri)?,
+            version: u32::from_str(version)
                 .map_err(|error| ParseVersionedUriError::InvalidVersion(error.to_string()))?,
-        ))
+        })
     }
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In the HASH Graph Query Layer, we use `VersionedUri` quite often and it's impossible to destructure it into a `BaseUri` and a version.
While not necessarily every combination is valid, any `base_uri` with any `version` is a well-formed `VersionedUri`, it does not need to hold any invariants.
While other languages usually prefer "constructors", "getters", and "setters" (which are also missing), Rust has the concept of borrowing, so it's not possible to partially move out a variable of a struct by a function without consuming the struct. This implies if the `VersionedUri` has to be split into `BaseUri` and `u32`, we need something like
```rust
fn into_base_uri_and_version(self) -> (BaseUri, u32);
```
or 
```rust
fn into_parts(self) -> (BaseUri, u32);
```
which is (a) verbose to write and (b) does not retain the parameter names. It's easier to access `.base_uri` and `.version directly`. In addition, it's possible to modify the variables in place (e.g. `.version += 1`), which we do in our update procedure.

## 🔍 What does this change?

- Make the member variables `pub`
- Remove `new` and "getters"