### PR TITLE
Upload original tarballs alongside individual block files

### DIFF
--- a/apps/site/src/lib/api/blocks/s3.ts
+++ b/apps/site/src/lib/api/blocks/s3.ts
@@ -277,3 +277,25 @@ export const validateExpandAndUploadBlockFiles = async ({
 
   return { expandedMetadata };
 };
+
+export const uploadOriginalTarballToS3 = async ({
+  pathWithNamespace,
+  tarballFilePath,
+  version,
+}: {
+  pathWithNamespace: string;
+  tarballFilePath: string;
+  version: string;
+}) => {
+  await getS3Client().send(
+    new PutObjectCommand({
+      Bucket: getS3Bucket(),
+      Body: await fs.readFile(tarballFilePath),
+      ContentType: "application/x-gtar",
+      Key: resolveS3ResourceKey(
+        "block-uploads",
+        `${stripLeadingAt(pathWithNamespace)}/${version}.tar.gz`,
+      ),
+    }),
+  );
+};

--- a/apps/site/src/lib/s3.ts
+++ b/apps/site/src/lib/s3.ts
@@ -41,7 +41,7 @@ export const getS3Bucket = (): string => {
 };
 
 export const resolveS3ResourceKey = (
-  category: "blocks" | "avatars",
+  category: "blocks" | "block-uploads" | "avatars",
   subkey: string,
 ): string => {
   return `${category}/${subkey}`;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR updates block publishing process. It makes original tarballs available on R3, alongside individual files. This allows us to mirror tarballs between hub instances, thus unblocking the completion of https://github.com/blockprotocol/blockprotocol/pull/936. Uploaded tarballs are especially helpful for local dev and allow us to quickly warm up a local instance with blocks that are already published on blockprotocol.org.
<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203358502199087/1203388867587773/f) _(internal)_


## 🐾 Next steps

- Supplement `block-uploads` key on S3 with `block-contents` (also versioned). We can make the existing `blocks` key redundant after that.