### PR TITLE
Type System improvements

### DIFF
--- a/libs/@blockprotocol/type-system/crate/src/ontology/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/data_type/mod.rs
@@ -200,7 +200,7 @@ mod tests {
         let data_type_ref = DataTypeReference::new(uri.clone());
 
         data_type_ref
-            .validate_uri(uri.base_uri())
+            .validate_uri(&uri.base_uri)
             .expect("failed to validate against base URI");
     }
 
@@ -216,7 +216,7 @@ mod tests {
         let data_type_ref = DataTypeReference::new(uri_a);
 
         data_type_ref
-            .validate_uri(uri_b.base_uri()) // Try and validate against a different URI
+            .validate_uri(&uri_b.base_uri) // Try and validate against a different URI
             .expect_err("expected validation against base URI to fail but it didn't");
     }
 }

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/links/error.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/links/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 #[cfg(target_arch = "wasm32")]
 use tsify::Tsify;
 
-use crate::{uri::ParseVersionedUriError, ParseEntityTypeReferenceArrayError, ValidationError};
+use crate::{uri::ParseVersionedUriError, ParseEntityTypeReferenceArrayError};
 
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq, Error)]
@@ -13,10 +13,6 @@ pub enum ParseLinksError {
     InvalidLinkKey(ParseVersionedUriError),
     #[error("invalid array definition: `{0}`")]
     InvalidArray(ParseEntityTypeReferenceArrayError),
-    #[error("invalid key inside required: `{0}`")]
-    InvalidRequiredKey(ParseVersionedUriError),
-    #[error("failed validation: `{0}`")]
-    ValidationError(ValidationError),
     #[error("error in JSON: `{0}`")]
     InvalidJson(String),
 }

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/links/mod.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/links/mod.rs
@@ -13,57 +13,22 @@ use crate::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Links {
-    links: HashMap<VersionedUri, MaybeOrderedArray<Option<OneOf<EntityTypeReference>>>>,
-    required_links: Vec<VersionedUri>,
-}
+pub struct Links(HashMap<VersionedUri, MaybeOrderedArray<Option<OneOf<EntityTypeReference>>>>);
 
 impl Links {
-    /// Creates a new `Links` without validating.
+    /// Creates a new `Links` object.
     #[must_use]
-    pub const fn new_unchecked(
+    pub const fn new(
         links: HashMap<VersionedUri, MaybeOrderedArray<Option<OneOf<EntityTypeReference>>>>,
-        required: Vec<VersionedUri>,
     ) -> Self {
-        Self {
-            links,
-            required_links: required,
-        }
-    }
-
-    /// Creates a new `Links`.
-    ///
-    /// # Errors
-    ///
-    /// - [`ValidationError::MissingRequiredLink`] if a required link is not a key in `links`.
-    pub fn new(
-        links: HashMap<VersionedUri, MaybeOrderedArray<Option<OneOf<EntityTypeReference>>>>,
-        required: Vec<VersionedUri>,
-    ) -> Result<Self, ValidationError> {
-        let links = Self::new_unchecked(links, required);
-        links.validate()?;
-        Ok(links)
-    }
-
-    fn validate(&self) -> Result<(), ValidationError> {
-        for link in self.required() {
-            if !self.links().contains_key(link) {
-                return Err(ValidationError::MissingRequiredLink(link.clone()));
-            }
-        }
-        Ok(())
+        Self(links)
     }
 
     #[must_use]
     pub const fn links(
         &self,
     ) -> &HashMap<VersionedUri, MaybeOrderedArray<Option<OneOf<EntityTypeReference>>>> {
-        &self.links
-    }
-
-    #[must_use]
-    pub fn required(&self) -> &[VersionedUri] {
-        &self.required_links
+        &self.0
     }
 }
 

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/links/repr.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/links/repr.rs
@@ -22,9 +22,6 @@ pub struct Links {
     )]
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     links: HashMap<String, MaybeOrderedArray<MaybeOneOfEntityTypeReference>>,
-    #[cfg_attr(target_arch = "wasm32", tsify(optional, type = "VersionedUri[]"))]
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    required_links: Vec<String>,
 }
 
 impl TryFrom<Links> for super::Links {
@@ -42,34 +39,19 @@ impl TryFrom<Links> for super::Links {
             })
             .collect::<Result<HashMap<_, _>, Self::Error>>()?;
 
-        let required_links = links_repr
-            .required_links
-            .into_iter()
-            .map(|uri| VersionedUri::from_str(&uri).map_err(ParseLinksError::InvalidRequiredKey))
-            .collect::<Result<Vec<_>, Self::Error>>()?;
-
-        Self::new(links, required_links).map_err(ParseLinksError::ValidationError)
+        Ok(Self::new(links))
     }
 }
 
 impl From<super::Links> for Links {
     fn from(object: super::Links) -> Self {
         let links = object
-            .links
+            .0
             .into_iter()
             .map(|(uri, val)| (uri.to_string(), val.into()))
             .collect();
 
-        let required_links = object
-            .required_links
-            .into_iter()
-            .map(|uri| uri.to_string())
-            .collect();
-
-        Self {
-            links,
-            required_links,
-        }
+        Self { links }
     }
 }
 

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/mod.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/mod.rs
@@ -90,11 +90,6 @@ impl EntityType {
     }
 
     #[must_use]
-    pub fn required_links(&self) -> &[VersionedUri] {
-        self.links.required()
-    }
-
-    #[must_use]
     pub const fn default(&self) -> &HashMap<BaseUri, serde_json::Value> {
         &self.default
     }

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/mod.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/mod.rs
@@ -22,14 +22,12 @@ pub struct EntityType {
     property_object: Object<ValueOrArray<PropertyTypeReference>>,
     inherits_from: AllOf<EntityTypeReference>,
     links: Links,
-    default: HashMap<BaseUri, serde_json::Value>,
     examples: Vec<HashMap<BaseUri, serde_json::Value>>,
 }
 
 impl EntityType {
     /// Creates a new `EntityType`
     #[must_use]
-    #[expect(clippy::too_many_arguments)]
     pub fn new(
         id: VersionedUri,
         title: String,
@@ -37,7 +35,6 @@ impl EntityType {
         property_object: Object<ValueOrArray<PropertyTypeReference>>,
         inherits_from: AllOf<EntityTypeReference>,
         links: Links,
-        default: HashMap<BaseUri, serde_json::Value>,
         examples: Vec<HashMap<BaseUri, serde_json::Value>>,
     ) -> Self {
         Self {
@@ -47,7 +44,6 @@ impl EntityType {
             property_object,
             inherits_from,
             links,
-            default,
             examples,
         }
     }
@@ -87,11 +83,6 @@ impl EntityType {
         &self,
     ) -> &HashMap<VersionedUri, MaybeOrderedArray<Option<OneOf<EntityTypeReference>>>> {
         self.links.links()
-    }
-
-    #[must_use]
-    pub const fn default(&self) -> &HashMap<BaseUri, serde_json::Value> {
-        &self.default
     }
 
     #[must_use]

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/repr.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/repr.rs
@@ -32,10 +32,6 @@ pub struct EntityType {
     description: Option<String>,
     #[serde(flatten)]
     all_of: repr::AllOf<EntityTypeReference>,
-    // TODO - Improve the typing of the values
-    #[cfg_attr(target_arch = "wasm32", tsify(optional, type = "Record<BaseUri, any>"))]
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    default: HashMap<String, serde_json::Value>,
     #[cfg_attr(
         target_arch = "wasm32",
         tsify(optional, type = "Record<BaseUri, any>[]")
@@ -56,18 +52,6 @@ impl TryFrom<EntityType> for super::EntityType {
     fn try_from(entity_type_repr: EntityType) -> Result<Self, Self::Error> {
         let id = VersionedUri::from_str(&entity_type_repr.id)
             .map_err(ParseEntityTypeError::InvalidVersionedUri)?;
-
-        // TODO - validate default against the entity type
-        let default = entity_type_repr
-            .default
-            .into_iter()
-            .map(|(uri, val)| {
-                Ok((
-                    BaseUri::new(uri).map_err(ParseEntityTypeError::InvalidDefaultKey)?,
-                    val,
-                ))
-            })
-            .collect::<Result<_, _>>()?;
 
         // TODO - validate examples against the entity type
         let examples = entity_type_repr
@@ -112,7 +96,6 @@ impl TryFrom<EntityType> for super::EntityType {
             property_object,
             inherits_from,
             links,
-            default,
             examples,
         ))
     }
@@ -120,12 +103,6 @@ impl TryFrom<EntityType> for super::EntityType {
 
 impl From<super::EntityType> for EntityType {
     fn from(entity_type: super::EntityType) -> Self {
-        let default = entity_type
-            .default
-            .into_iter()
-            .map(|(uri, val)| (uri.to_string(), val))
-            .collect();
-
         let examples = entity_type
             .examples
             .into_iter()
@@ -144,7 +121,6 @@ impl From<super::EntityType> for EntityType {
             description: entity_type.description,
             property_object: entity_type.property_object.into(),
             all_of: entity_type.inherits_from.into(),
-            default,
             examples,
             links: entity_type.links.into(),
             additional_properties: false,

--- a/libs/@blockprotocol/type-system/crate/src/ontology/property_type/mod.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/property_type/mod.rs
@@ -384,7 +384,7 @@ mod tests {
         let property_type_ref = PropertyTypeReference::new(uri.clone());
 
         property_type_ref
-            .validate_uri(uri.base_uri())
+            .validate_uri(&uri.base_uri)
             .expect("failed to validate against base URI");
     }
 
@@ -400,7 +400,7 @@ mod tests {
         let property_type_ref = PropertyTypeReference::new(uri_a);
 
         property_type_ref
-            .validate_uri(uri_b.base_uri()) // Try and validate against a different URI
+            .validate_uri(&uri_b.base_uri) // Try and validate against a different URI
             .expect_err("expected validation against base URI to fail but it didn't");
     }
 }

--- a/libs/@blockprotocol/type-system/crate/src/ontology/shared/array/mod.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/shared/array/mod.rs
@@ -83,7 +83,7 @@ mod tests {
         let array = get_test_value_or_array(&uri);
 
         array
-            .validate_uri(uri.base_uri())
+            .validate_uri(&uri.base_uri)
             .expect("failed to validate against base URI");
     }
 
@@ -99,7 +99,7 @@ mod tests {
         let array = get_test_value_or_array(&uri_a);
 
         array
-            .validate_uri(uri_b.base_uri()) // Try and validate against a different URI
+            .validate_uri(&uri_b.base_uri) // Try and validate against a different URI
             .expect_err("expected validation against base URI to fail but it didn't");
     }
 }

--- a/libs/@blockprotocol/type-system/crate/src/ontology/shared/object/repr.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/shared/object/repr.rs
@@ -131,7 +131,7 @@ mod tests {
                 Some(Object {
                     r#type: ObjectTypeTag::Object,
                     properties: HashMap::from([(
-                        uri.base_uri().to_string(),
+                        uri.base_uri.to_string(),
                         PropertyTypeReference::new(uri.to_string()),
                     )]),
                     required: vec![],
@@ -158,11 +158,11 @@ mod tests {
                     r#type: ObjectTypeTag::Object,
                     properties: HashMap::from([
                         (
-                            uri_a.base_uri().to_string(),
+                            uri_a.base_uri.to_string(),
                             PropertyTypeReference::new(uri_a.to_string()),
                         ),
                         (
-                            uri_b.base_uri().to_string(),
+                            uri_b.base_uri.to_string(),
                             PropertyTypeReference::new(uri_b.to_string()),
                         ),
                     ]),
@@ -192,7 +192,7 @@ mod tests {
                 Some(Object {
                     r#type: ObjectTypeTag::Object,
                     properties: HashMap::from([(
-                        uri.base_uri().to_string(),
+                        uri.base_uri.to_string(),
                         PropertyTypeReference::new(uri.to_string()),
                     )]),
                     required: vec![],
@@ -219,11 +219,11 @@ mod tests {
                     r#type: ObjectTypeTag::Object,
                     properties: HashMap::from([
                         (
-                            uri_a.base_uri().to_string(),
+                            uri_a.base_uri.to_string(),
                             PropertyTypeReference::new(uri_a.to_string()),
                         ),
                         (
-                            uri_b.base_uri().to_string(),
+                            uri_b.base_uri.to_string(),
                             PropertyTypeReference::new(uri_b.to_string()),
                         ),
                     ]),
@@ -255,15 +255,15 @@ mod tests {
                 r#type: ObjectTypeTag::Object,
                 properties: HashMap::from([
                     (
-                        uri_a.base_uri().to_string(),
+                        uri_a.base_uri.to_string(),
                         PropertyTypeReference::new(uri_a.to_string()),
                     ),
                     (
-                        uri_b.base_uri().to_string(),
+                        uri_b.base_uri.to_string(),
                         PropertyTypeReference::new(uri_b.to_string()),
                     ),
                 ]),
-                required: vec![uri_a.base_uri().to_string()],
+                required: vec![uri_a.base_uri.to_string()],
             }),
         );
     }

--- a/libs/@blockprotocol/type-system/crate/src/ontology/uri/wasm.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/uri/wasm.rs
@@ -2,10 +2,10 @@ use tsify::Tsify;
 
 use crate::utils::{set_panic_hook, Result};
 
-// Generates the TypeScript alias: type VersionedUri = `${string}/v/${number}`
+// Generates the TypeScript alias: type VersionedUri = `${BaseUri}v/${number}`
 #[derive(Tsify)]
 #[serde(rename = "VersionedUri")]
-pub struct VersionedUriPatch(#[tsify(type = "`${string}/v/${number}`")] String);
+pub struct VersionedUriPatch(#[tsify(type = "`${BaseUri}v/${number}`")] String);
 
 // #[wasm_bindgen(typescript_custom_section)]
 // const VALIDATE_BASE_URI_DEF: &'static str = r#"

--- a/libs/@blockprotocol/type-system/crate/src/utils.rs
+++ b/libs/@blockprotocol/type-system/crate/src/utils.rs
@@ -69,7 +69,10 @@ pub(crate) mod tests {
         R: Debug + PartialEq + Clone + From<T> + Serialize + DeserializeOwned,
     {
         let deserialized_repr: R = serde_json::from_str(input).expect("failed to deserialize");
-        let value: T = deserialized_repr.clone().try_into().expect("failed to convert");
+        let value: T = deserialized_repr
+            .clone()
+            .try_into()
+            .expect("failed to convert");
         let re_serialized_repr: R = value.clone().into();
 
         assert_eq!(deserialized_repr, re_serialized_repr);

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/book.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/book.json
@@ -31,8 +31,5 @@
       "ordered": false
     }
   },
-  "requiredLinks": [
-    "https://blockprotocol.org/@alice/types/entity-type/written-by/v/1"
-  ],
   "additionalProperties": false
 }

--- a/libs/@blockprotocol/type-system/test/entity-type.test.ts
+++ b/libs/@blockprotocol/type-system/test/entity-type.test.ts
@@ -40,9 +40,6 @@ const entityTypes: EntityType[] = [
       },
     },
     required: ["https://blockprotocol.org/@alice/types/property-type/name/"],
-    default: {
-      "https://blockprotocol.org/@alice/types/property-type/name/": "MyBlock",
-    },
     examples: [
       {
         "https://blockprotocol.org/@alice/types/property-type/name/":
@@ -88,9 +85,6 @@ const entityTypes: EntityType[] = [
         ordered: false,
       },
     },
-    requiredLinks: [
-      "https://blockprotocol.org/@alice/types/entity-type/written-by/v/1",
-    ],
     examples: [],
     additionalProperties: false,
   },
@@ -372,32 +366,6 @@ const invalidEntityTypes: [string, EntityType, ParseEntityTypeError][] = [
         inner: {
           reason: "MissingTrailingSlash",
         },
-      },
-    },
-  ],
-  [
-    "invalid default",
-    {
-      kind: "entityType",
-      $id: "https://blockprotocol.org/@blockprotocol/types/property-type/broken/v/1",
-      type: "object",
-      title: "Broken",
-      properties: {
-        "https://blockprotocol.org/@alice/types/property-type/address-line-1/v/1":
-          {
-            $ref: "https://blockprotocol.org/@alice/types/property-type/address-line-1/v/1",
-          },
-      },
-      default: {
-        "https://blockprotocol.org/@alice/types/property-type/address-line-1/v/2.3":
-          "My Address 32, My Street, Narnia",
-      },
-      additionalProperties: false,
-    },
-    {
-      reason: "InvalidDefaultKey",
-      inner: {
-        reason: "MissingTrailingSlash",
       },
     },
   ],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Through usage we've discovered a number of small improvements we could make.
- The `VersionedUri` template string encourages people to put an additional slash when adding a `BaseUri`. This is incorrect as a `BaseUri` _must_ already have a trailing slash, as such, one of the slashes in the template string have been removed and the type improved slightly.
- The `default` field in `EntityType` isn't really useful in its current form, ideally users could define defaults on a per-property basis, this will require more thought and development.
- The `requiredLinks` field is now redundant in `EntityType` as there is no longer a choice for `type: "array"` of links. As such, a `required` link can be represented by `minItems: 1`.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1202805690238892/1203522138014423/f) _(internal)_

## 🚫 Blocked by

- [ ] #990 

## 🔍 What does this change?

See description

## 📜 Does this require a change to the docs?

At the present, no. Although an addendum to the RFC should be added soon.

## ⚠️ Known issues

N/A

## 🐾 Next steps

- Update docs for 0.3

## 🛡 What tests cover this?

- (In `libs/@blockprotocol/type-system/crate`)
  - `cargo make lint`
  - `cargo make test` 
- (In the root)
  - `yarn workspace @blockprotocol/type-system build`
  - `yarn workspace @blockprotocol/type-system test`
 
## ❓ How to test this?

Follow instructions above

