### PR TITLE
Fix access to block assets in a local S3 instance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,7 @@ jobs:
           S3_BUCKET=dev-bucket
           S3_ACCESS_KEY_ID=dev-access-key
           S3_SECRET_ACCESS_KEY=dev-secret-key
-          S3_BASE_URL=http://localhost:9001/dev-bucket
+          S3_BASE_URL=http://localhost:9000/dev-bucket
 
           NEXT_PUBLIC_NPM_PUBLISHING=true
 

--- a/apps/site/README.md
+++ b/apps/site/README.md
@@ -33,7 +33,7 @@ This folder contains the code for [blockprotocol.org](https://blockprotocol.org)
     MONGODB_DB_NAME=local
     
     S3_API_ENDPOINT=http://localhost:9000
-    S3_BASE_URL=http://localhost:9001/dev-bucket
+    S3_BASE_URL=http://localhost:9000/dev-bucket
     S3_BUCKET=dev-bucket
     S3_ACCESS_KEY_ID=dev-access-key
     S3_SECRET_ACCESS_KEY=dev-secret-key

--- a/apps/site/scripts/reset-s3-bucket.ts
+++ b/apps/site/scripts/reset-s3-bucket.ts
@@ -57,6 +57,7 @@ const script = async () => {
   await s3Client.send(
     new CreateBucketCommand({
       Bucket: getS3Bucket(),
+      ACL: "public-read",
     }),
   );
 

--- a/apps/site/scripts/reset-s3-bucket.ts
+++ b/apps/site/scripts/reset-s3-bucket.ts
@@ -3,6 +3,7 @@ import {
   DeleteBucketCommand,
   DeleteObjectsCommand,
   ListObjectsV2Command,
+  PutBucketPolicyCommand,
 } from "@aws-sdk/client-s3";
 import chalk from "chalk";
 
@@ -54,10 +55,34 @@ const script = async () => {
     }
   }
 
+  const Bucket = getS3Bucket();
+
   await s3Client.send(
     new CreateBucketCommand({
+      Bucket,
+    }),
+  );
+
+  // Calling CreateBucketCommand with `ACL: "public-read",` does not make bucket files available
+  // to the public. We set permissions separately to fix that.
+  // https://stackoverflow.com/a/69079415/1818285
+  await s3Client.send(
+    new PutBucketPolicyCommand({
       Bucket: getS3Bucket(),
-      ACL: "public-read",
+      Policy: JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [
+          {
+            Action: ["s3:GetObject"],
+            Effect: "Allow",
+            Principal: {
+              AWS: ["*"],
+            },
+            Resource: [`arn:aws:s3:::${Bucket}/*`],
+            Sid: "",
+          },
+        ],
+      }),
     }),
   );
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When publishing block to a local bucket, I noticed that its contents were not available at http://localhost:3000/hub.

<img width="1173" alt="Screenshot 2023-02-20 at 18 12 41" src="https://user-images.githubusercontent.com/608862/220177847-bd8ea483-7711-4bc7-adc7-62370476b019.png">

Opening direct asset links was showing this error:

<img width="885" alt="Screenshot 2023-02-20 at 18 25 18" src="https://user-images.githubusercontent.com/608862/220177899-db3b0613-d425-4eb9-8057-38403e8420ad.png">

It turned out that port 9001 was for MinIO's [web console](https://min.io/docs/minio/linux/administration/minio-console.html#static-vs-dynamic-port-assignment), so I changed port to 9000 in our CI config and docs. However, accessing objects at port `9000` did not help either:

<img width="760" alt="Screenshot 2023-02-20 at 18 24 49" src="https://user-images.githubusercontent.com/608862/220178004-afad5b28-b5d6-45c4-99a1-17692baeff72.png">

After the investigation, I discovered that bucket permissions for local dev were not configure correctly. This PR fixes that.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203358502199087/1203388867587773/f) _(internal)_
- https://github.com/blockprotocol/blockprotocol/pull/565

## 📜 Does this require a change to the docs?

- See diff

## ⚠️ Known issues

- Existing developers need to open  `apps/site/.env.local` and manually make this change:
  ```diff
  -S3_BASE_URL=http://localhost:9001/dev-bucket
  +S3_BASE_URL=http://localhost:9000/dev-bucket
  ```
  It will be also necessary to run `yarn dev:seed-db`. Alternatively, it should be possible to opn MinIO at http://localhost:9001, login with `dev-access-key` / `dev-secret-key` and change bucket access from _Private_ to _Public_ in the UI.
  
<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

- Publish HASH blocks
- Migrate published blocks to local dev server

## 🛡 What tests cover this?

- Manual

## ❓ How to test this?

1.  Checkout the branch / view the deployment
1.  Update `S3_BASE_URL` `apps/site/.env.local`
1.  Call `yarn dev:seed-db`
1.  Create API token for `@alice`
1.  `cd` to any of the blocks and build it. Don't forget to prepend block name with `@alice/*` before doing that
1. Publish that block locally:
   ```
   BLOCK_PROTOCOL_SITE_HOST=http://localhost:3000 BLOCK_PROTOCOL_API_KEY=b10ck5.??.?? npx blockprotocol@latest  publish --yes
   ```
1. Confirm that the block works and its icon and preview are visible
