### PR TITLE
Implement delete entity in MBD for non-temporally-versioned datastores

### DIFF
--- a/libs/mock-block-dock/dev/test-react-block.tsx
+++ b/libs/mock-block-dock/dev/test-react-block.tsx
@@ -1,3 +1,4 @@
+import { Entity } from "@blockprotocol/graph";
 import {
   type BlockComponent,
   useGraphBlockModule,
@@ -5,7 +6,7 @@ import {
 import { getRoots } from "@blockprotocol/graph/stdlib";
 import { useHook, useHookBlockModule } from "@blockprotocol/hook/react";
 import { extractBaseUri } from "@blockprotocol/type-system/slim";
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, useState } from "react";
 
 import { propertyTypes } from "../src/data/property-types";
 
@@ -35,6 +36,8 @@ export const TestReactBlock: BlockComponent = ({ graph }) => {
     },
   );
 
+  const [entities, setEntities] = useState<Record<string, Entity>>({});
+
   if (readonly) {
     return (
       <div ref={blockRef}>
@@ -63,6 +66,143 @@ export const TestReactBlock: BlockComponent = ({ graph }) => {
 
   return (
     <div ref={blockRef}>
+      <button
+        onClick={async () => {
+          const { data, errors } = await graphModule.createEntity({
+            data: {
+              entityTypeId: blockEntity!.metadata!.entityTypeId,
+              properties: {
+                [extractBaseUri(propertyTypes.name.$id)]: "alice",
+              },
+            },
+          });
+
+          if (!data) {
+            console.error(errors);
+            throw new Error("Failed to create entity: alice");
+          }
+
+          setEntities((prevEntities) => ({ ...prevEntities, alice: data }));
+        }}
+      >
+        Create Alice
+      </button>
+      <button
+        onClick={async () => {
+          const { data, errors } = await graphModule.createEntity({
+            data: {
+              entityTypeId: blockEntity!.metadata!.entityTypeId,
+              properties: {
+                [extractBaseUri(propertyTypes.name.$id)]: "bob",
+              },
+            },
+          });
+
+          if (!data) {
+            console.error(errors);
+            throw new Error("Failed to create entity: bob");
+          }
+
+          setEntities((prevEntities) => ({ ...prevEntities, bob: data }));
+        }}
+      >
+        Create Bob
+      </button>
+      <button
+        onClick={async () => {
+          const { data, errors } = await graphModule.createEntity({
+            data: {
+              entityTypeId: blockEntity!.metadata!.entityTypeId,
+              properties: {
+                [extractBaseUri(propertyTypes.name.$id)]: "charlie",
+              },
+            },
+          });
+
+          if (!data) {
+            console.error(errors);
+            throw new Error("Failed to create entity: charlie");
+          }
+
+          setEntities((prevEntities) => ({ ...prevEntities, charlie: data }));
+        }}
+      >
+        Create Charlie
+      </button>
+      <button
+        onClick={async () => {
+          const { data, errors } = await graphModule.createEntity({
+            data: {
+              entityTypeId: blockEntity!.metadata!.entityTypeId,
+              properties: {},
+              linkData: {
+                leftEntityId: entities.alice!.metadata.recordId.entityId,
+                rightEntityId: entities.bob!.metadata.recordId.entityId,
+              },
+            },
+          });
+
+          if (!data) {
+            console.error(errors);
+            throw new Error(`Failed to create entity: aliceToBob`);
+          }
+
+          setEntities((prevEntities) => ({
+            ...prevEntities,
+            aliceToBob: data!,
+          }));
+        }}
+      >
+        Create Alice to Bob Link
+      </button>
+      <button
+        onClick={async () => {
+          const { data, errors } = await graphModule.createEntity({
+            data: {
+              entityTypeId: blockEntity!.metadata!.entityTypeId,
+              properties: {},
+              linkData: {
+                leftEntityId: entities.alice!.metadata.recordId.entityId,
+                rightEntityId: entities.charlie!.metadata.recordId.entityId,
+              },
+            },
+          });
+
+          if (!data) {
+            console.error(errors);
+            throw new Error(`Failed to create entity: aliceToCharlie`);
+          }
+
+          setEntities((prevEntities) => ({
+            ...prevEntities,
+            aliceToCharlie: data!,
+          }));
+        }}
+      >
+        Create Alice to Charlie Link
+      </button>
+      <button
+        onClick={async () => {
+          await graphModule.deleteEntity({
+            data: {
+              entityId: entities.aliceToBob!.metadata.recordId.entityId,
+            },
+          });
+        }}
+      >
+        Delete Alice To Bob
+      </button>
+      <button
+        onClick={async () => {
+          await graphModule.deleteEntity({
+            data: {
+              entityId: entities.charlie!.metadata.recordId.entityId,
+            },
+          });
+        }}
+      >
+        Delete Charlie
+      </button>
       <h1>
         <>
           Hello{" "}

--- a/libs/mock-block-dock/dev/test-react-block.tsx
+++ b/libs/mock-block-dock/dev/test-react-block.tsx
@@ -1,4 +1,3 @@
-import { Entity } from "@blockprotocol/graph";
 import {
   type BlockComponent,
   useGraphBlockModule,
@@ -6,7 +5,7 @@ import {
 import { getRoots } from "@blockprotocol/graph/stdlib";
 import { useHook, useHookBlockModule } from "@blockprotocol/hook/react";
 import { extractBaseUri } from "@blockprotocol/type-system/slim";
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useRef } from "react";
 
 import { propertyTypes } from "../src/data/property-types";
 
@@ -36,8 +35,6 @@ export const TestReactBlock: BlockComponent = ({ graph }) => {
     },
   );
 
-  const [entities, setEntities] = useState<Record<string, Entity>>({});
-
   if (readonly) {
     return (
       <div ref={blockRef}>
@@ -66,143 +63,6 @@ export const TestReactBlock: BlockComponent = ({ graph }) => {
 
   return (
     <div ref={blockRef}>
-      <button
-        onClick={async () => {
-          const { data, errors } = await graphModule.createEntity({
-            data: {
-              entityTypeId: blockEntity!.metadata!.entityTypeId,
-              properties: {
-                [extractBaseUri(propertyTypes.name.$id)]: "alice",
-              },
-            },
-          });
-
-          if (!data) {
-            console.error(errors);
-            throw new Error("Failed to create entity: alice");
-          }
-
-          setEntities((prevEntities) => ({ ...prevEntities, alice: data }));
-        }}
-      >
-        Create Alice
-      </button>
-      <button
-        onClick={async () => {
-          const { data, errors } = await graphModule.createEntity({
-            data: {
-              entityTypeId: blockEntity!.metadata!.entityTypeId,
-              properties: {
-                [extractBaseUri(propertyTypes.name.$id)]: "bob",
-              },
-            },
-          });
-
-          if (!data) {
-            console.error(errors);
-            throw new Error("Failed to create entity: bob");
-          }
-
-          setEntities((prevEntities) => ({ ...prevEntities, bob: data }));
-        }}
-      >
-        Create Bob
-      </button>
-      <button
-        onClick={async () => {
-          const { data, errors } = await graphModule.createEntity({
-            data: {
-              entityTypeId: blockEntity!.metadata!.entityTypeId,
-              properties: {
-                [extractBaseUri(propertyTypes.name.$id)]: "charlie",
-              },
-            },
-          });
-
-          if (!data) {
-            console.error(errors);
-            throw new Error("Failed to create entity: charlie");
-          }
-
-          setEntities((prevEntities) => ({ ...prevEntities, charlie: data }));
-        }}
-      >
-        Create Charlie
-      </button>
-      <button
-        onClick={async () => {
-          const { data, errors } = await graphModule.createEntity({
-            data: {
-              entityTypeId: blockEntity!.metadata!.entityTypeId,
-              properties: {},
-              linkData: {
-                leftEntityId: entities.alice!.metadata.recordId.entityId,
-                rightEntityId: entities.bob!.metadata.recordId.entityId,
-              },
-            },
-          });
-
-          if (!data) {
-            console.error(errors);
-            throw new Error(`Failed to create entity: aliceToBob`);
-          }
-
-          setEntities((prevEntities) => ({
-            ...prevEntities,
-            aliceToBob: data!,
-          }));
-        }}
-      >
-        Create Alice to Bob Link
-      </button>
-      <button
-        onClick={async () => {
-          const { data, errors } = await graphModule.createEntity({
-            data: {
-              entityTypeId: blockEntity!.metadata!.entityTypeId,
-              properties: {},
-              linkData: {
-                leftEntityId: entities.alice!.metadata.recordId.entityId,
-                rightEntityId: entities.charlie!.metadata.recordId.entityId,
-              },
-            },
-          });
-
-          if (!data) {
-            console.error(errors);
-            throw new Error(`Failed to create entity: aliceToCharlie`);
-          }
-
-          setEntities((prevEntities) => ({
-            ...prevEntities,
-            aliceToCharlie: data!,
-          }));
-        }}
-      >
-        Create Alice to Charlie Link
-      </button>
-      <button
-        onClick={async () => {
-          await graphModule.deleteEntity({
-            data: {
-              entityId: entities.aliceToBob!.metadata.recordId.entityId,
-            },
-          });
-        }}
-      >
-        Delete Alice To Bob
-      </button>
-      <button
-        onClick={async () => {
-          await graphModule.deleteEntity({
-            data: {
-              entityId: entities.charlie!.metadata.recordId.entityId,
-            },
-          });
-        }}
-      >
-        Delete Charlie
-      </button>
       <h1>
         <>
           Hello{" "}

--- a/libs/mock-block-dock/src/datastore/use-mock-datastore/non-temporal.ts
+++ b/libs/mock-block-dock/src/datastore/use-mock-datastore/non-temporal.ts
@@ -115,30 +115,34 @@ export const useMockDatastore = (
             ],
           };
         }
-        const entityId = uuid();
-        const { entityTypeId, properties, linkData } = data;
 
-        const newEntity: Entity = {
-          metadata: {
-            recordId: {
-              entityId,
-              editionId: new Date().toISOString(),
+        return new Promise((resolve) => {
+          const entityId = uuid();
+          const { entityTypeId, properties, linkData } = data;
+
+          const newEntity: Entity = {
+            metadata: {
+              recordId: {
+                entityId,
+                editionId: new Date().toISOString(),
+              },
+              entityTypeId,
             },
-            entityTypeId,
-          },
-          properties,
-          linkData,
-        };
-
-        setGraph((currentGraph) => {
-          // A shallow copy should be enough to trigger a re-render
-          const newSubgraph = {
-            ...currentGraph,
+            properties,
+            linkData,
           };
-          addEntitiesToSubgraphByMutation(newSubgraph, [newEntity]);
-          return newSubgraph;
+
+          resolve({ data: newEntity });
+
+          setGraph((currentGraph) => {
+            const newSubgraph = JSON.parse(
+              JSON.stringify(currentGraph),
+            ) as Subgraph;
+
+            addEntitiesToSubgraphByMutation(newSubgraph, [newEntity]);
+            return newSubgraph;
+          });
         });
-        return { data: newEntity };
       },
       [readonly, setGraph],
     );

--- a/libs/mock-block-dock/src/datastore/use-mock-datastore/non-temporal.ts
+++ b/libs/mock-block-dock/src/datastore/use-mock-datastore/non-temporal.ts
@@ -5,6 +5,10 @@ import {
   GraphEmbedderMessageCallbacks,
   isFileAtUrlData,
   isFileData,
+  isHasLeftEntityEdge,
+  isHasRightEntityEdge,
+  KnowledgeGraphOutwardEdge,
+  OntologyOutwardEdge,
   Subgraph,
 } from "@blockprotocol/graph";
 import { addEntitiesToSubgraphByMutation } from "@blockprotocol/graph/internal";
@@ -18,6 +22,7 @@ import { useCallback } from "react";
 import { v4 as uuid } from "uuid";
 
 import { useDefaultState } from "../../use-default-state";
+import { typedEntries } from "../../util";
 import { aggregateEntities as aggregateEntitiesImpl } from "../hook-implementations/entity/aggregate-entities";
 import { getEntity as getEntityImpl } from "../hook-implementations/entity/get-entity";
 import { MockData } from "../mock-data";
@@ -295,17 +300,6 @@ export const useMockDatastore = (
   const deleteEntity: GraphEmbedderMessageCallbacks["deleteEntity"] =
     useCallback(
       async ({ data }) => {
-        return {
-          errors: [
-            {
-              code: "NOT_IMPLEMENTED",
-              message: `Entity deletion is not currently supported`,
-            },
-          ],
-        };
-
-        /** @todo - implement entity deletion */
-        // eslint-disable-next-line no-unreachable -- currently unimplemented
         if (readonly) {
           return readonlyErrorReturn;
         }
@@ -320,10 +314,90 @@ export const useMockDatastore = (
             ],
           };
         }
-        return new Promise((_resolve) => {
+
+        return new Promise((resolve) => {
+          const { entityId } = data;
           setGraph((currentGraph) => {
-            // resolve();
-            return currentGraph;
+            const currentEntity = getEntityRevision(currentGraph, entityId);
+
+            if (!currentEntity) {
+              resolve({
+                errors: [
+                  {
+                    code: "NOT_FOUND",
+                    message: `Could not find entity with ID: ${entityId}`,
+                  },
+                ],
+              });
+            }
+
+            const newGraph = JSON.parse(
+              JSON.stringify(currentGraph),
+            ) as Subgraph;
+
+            const toRemove = [entityId];
+
+            const removeEntityAndLinks = (entityIdToRemove: string) => {
+              delete newGraph.vertices[entityIdToRemove];
+              delete newGraph.edges[entityIdToRemove];
+
+              for (const [baseId, outwardEdgeObject] of typedEntries(
+                newGraph.edges,
+              )) {
+                for (const [at, outwardEdges] of typedEntries(
+                  outwardEdgeObject,
+                )) {
+                  const filteredEdges = (
+                    outwardEdges as (typeof outwardEdges)[number][]
+                  ).filter((outwardEdge) => {
+                    // cascading delete link entities if their endpoints are deleted
+                    if (
+                      isHasLeftEntityEdge(outwardEdge) ||
+                      isHasRightEntityEdge(outwardEdge)
+                    ) {
+                      if (
+                        typeof outwardEdge.rightEndpoint === "string" &&
+                        outwardEdge.rightEndpoint === entityIdToRemove &&
+                        !toRemove.includes(baseId)
+                      ) {
+                        // `baseId` is a link entity, and either its left or right entity has been deleted, so we must
+                        // also delete the link
+                        toRemove.push(baseId);
+                      }
+                    }
+
+                    // `baseId` had an edge to a deleted entity, so we remove the edge
+                    return !(
+                      typeof outwardEdge.rightEndpoint === "string" &&
+                      outwardEdge.rightEndpoint === entityIdToRemove
+                    );
+                  });
+
+                  if (filteredEdges.length > 0) {
+                    newGraph.edges[baseId]![at] = filteredEdges as
+                      | OntologyOutwardEdge[]
+                      | KnowledgeGraphOutwardEdge[];
+                  } else {
+                    delete newGraph.edges[baseId]![at];
+
+                    if (Object.entries(newGraph.edges[baseId]!).length === 0) {
+                      delete newGraph.edges[baseId];
+                    }
+                  }
+                }
+              }
+            };
+
+            while (toRemove.length > 0) {
+              const entityIdToRemove = toRemove.pop()!;
+              removeEntityAndLinks(entityIdToRemove);
+            }
+
+            resolve({
+              data: true,
+            });
+
+            return newGraph;
           });
         });
       },

--- a/libs/mock-block-dock/src/datastore/use-mock-datastore/temporal.ts
+++ b/libs/mock-block-dock/src/datastore/use-mock-datastore/temporal.ts
@@ -119,31 +119,48 @@ export const useMockDatastore = (
             ],
           };
         }
-        const entityId = uuid();
-        const { entityTypeId, properties, linkData } = data;
+        if (readonly) {
+          return readonlyErrorReturn;
+        }
 
-        const newEntity: Entity = {
-          metadata: {
-            recordId: {
-              entityId,
-              editionId: new Date().toISOString(),
-            },
-            entityTypeId,
-            temporalVersioning: getDefaultEntityVersionInterval(),
-          },
-          properties,
-          linkData,
-        };
-
-        setGraph((currentGraph) => {
-          // A shallow copy should be enough to trigger a re-render
-          const newSubgraph = {
-            ...currentGraph,
+        if (!data) {
+          return {
+            errors: [
+              {
+                code: "INVALID_INPUT",
+                message: "createEntity requires 'data' input",
+              },
+            ],
           };
-          addEntitiesToSubgraphByMutation(newSubgraph, [newEntity]);
-          return newSubgraph;
+        }
+
+        return new Promise((resolve) => {
+          const entityId = uuid();
+          const { entityTypeId, properties, linkData } = data;
+
+          const newEntity: Entity = {
+            metadata: {
+              recordId: {
+                entityId,
+                editionId: new Date().toISOString(),
+              },
+              entityTypeId,
+              temporalVersioning: getDefaultEntityVersionInterval(),
+            },
+            properties,
+            linkData,
+          };
+          resolve({ data: newEntity });
+
+          setGraph((currentGraph) => {
+            const newSubgraph = JSON.parse(
+              JSON.stringify(currentGraph),
+            ) as Subgraph;
+
+            addEntitiesToSubgraphByMutation(newSubgraph, [newEntity]);
+            return newSubgraph;
+          });
         });
-        return { data: newEntity };
       },
       [readonly, setGraph],
     );

--- a/libs/mock-block-dock/src/datastore/use-mock-datastore/temporal.ts
+++ b/libs/mock-block-dock/src/datastore/use-mock-datastore/temporal.ts
@@ -342,7 +342,7 @@ export const useMockDatastore = (
           errors: [
             {
               code: "NOT_IMPLEMENTED",
-              message: `Entity deletion is not currently supported`,
+              message: `Entity deletion is not currently supported in a datastore with temporal versioning`,
             },
           ],
         };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The Graph module's `deleteEntity` message was previously unimplemented. This implements it for non-temporally versioned datastores. Temporally versioned datastores are left for a future implementation due to their increased complexity and further considerations.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203623179643284/1203984164017387/f) _(internal)_

## 🚫 Blocked by

- [x] #990 
- [x] #992 

## 🔍 What does this change?

- Implements `deleteEntity` when `temporal=false` in MBD
- Driveby fixes `createEntity`

## 📜 Does this require a change to the docs?

N/A

## ⚠️ Known issues

- This implementation does _not _ do any form of validation. If the deleted entity is at an endpoint of a link, then the link is deleted as well. Besides that, this does not check for link constraints such as `minItems` or `maxItems`.

## 🐾 Next steps

N/A

## 🛡 What tests cover this?

- None besides `tsc` and `eslint`

## ❓ How to test this?

- Checkout [Add demonstration of deleteEntity](https://github.com/blockprotocol/blockprotocol/pull/994/commits/aa1336f58a9672c23d992e20da7402cb17584031) and  check to see what the buttons do
- Click the buttons in order
 - Ensure that deleting a link only deletes the link and associated edges
 - Ensure that deleting the endpoint of a link deletes the endpoint, the link, and the associated edges 

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
