### PR TITLE
Re-export central "type-system" elements from the Graph Module package

### DIFF
--- a/apps/site/src/pages/api/types/entity-type/shared/db.ts
+++ b/apps/site/src/pages/api/types/entity-type/shared/db.ts
@@ -1,7 +1,11 @@
-import type { EntityType, EntityTypeWithMetadata } from "@blockprotocol/graph";
-import { extractVersion } from "@blockprotocol/type-system";
-import type { BaseUri, VersionedUri } from "@blockprotocol/type-system/slim";
-import { extractBaseUri } from "@blockprotocol/type-system/slim";
+import {
+  type BaseUri,
+  type VersionedUri,
+  EntityType,
+  EntityTypeWithMetadata,
+  extractBaseUri,
+  extractVersion,
+} from "@blockprotocol/graph";
 import { Db, ObjectId } from "mongodb";
 
 import { User } from "../../../../../lib/api/model/user.model";

--- a/apps/site/src/pages/api/types/property-type/shared/schema.ts
+++ b/apps/site/src/pages/api/types/property-type/shared/schema.ts
@@ -1,5 +1,7 @@
-import { PropertyTypeWithMetadata } from "@blockprotocol/graph";
-import { PropertyType } from "@blockprotocol/type-system";
+import {
+  type PropertyType,
+  type PropertyTypeWithMetadata,
+} from "@blockprotocol/graph";
 
 import { generateOntologyUri } from "../../../../shared/schema";
 import { SystemDefinedProperties } from "../../shared/constants";

--- a/libs/@blockprotocol/graph/src/non-temporal/main.ts
+++ b/libs/@blockprotocol/graph/src/non-temporal/main.ts
@@ -26,7 +26,6 @@ import {
   CreateLinkedAggregationData as CreateLinkedAggregationDataGeneral,
   CreatePropertyTypeData as CreatePropertyTypeDataGeneral,
   CreateResourceError as CreateResourceErrorGeneral,
-  DataType as DataTypeGeneral,
   DataTypeRootType as DataTypeRootTypeGeneral,
   DataTypeVertex as DataTypeVertexGeneral,
   DataTypeWithMetadata as DataTypeWithMetadataGeneral,
@@ -42,7 +41,6 @@ import {
   EntityRecordId as EntityRecordIdGeneral,
   EntityRevisionId as EntityRevisionIdGeneral,
   EntityRootType as EntityRootTypeGeneral,
-  EntityType as EntityTypeGeneral,
   EntityTypeRootType as EntityTypeRootTypeGeneral,
   EntityTypeVertex as EntityTypeVertexGeneral,
   EntityTypeWithMetadata as EntityTypeWithMetadataGeneral,
@@ -134,7 +132,6 @@ import {
   OutgoingLinkEdge as OutgoingLinkEdgeGeneral,
   OutwardEdge as OutwardEdgeGeneral,
   PropertiesConstrainedByEdge as PropertiesConstrainedByEdgeGeneral,
-  PropertyType as PropertyTypeGeneral,
   PropertyTypeRootType as PropertyTypeRootTypeGeneral,
   PropertyTypeVertex as PropertyTypeVertexGeneral,
   PropertyTypeWithMetadata as PropertyTypeWithMetadataGeneral,
@@ -158,6 +155,35 @@ import {
 
 export { GraphBlockHandler } from "./graph-block-handler.js";
 export { GraphEmbedderHandler } from "./graph-embedder-handler.js";
+export {
+  type AllOf,
+  type Array,
+  type BaseUri,
+  type DataType,
+  type DataTypeReference,
+  type EntityType,
+  type EntityTypeReference,
+  type Links,
+  type MaybeOneOfEntityTypeReference,
+  type MaybeOrderedArray,
+  type Object,
+  type OneOf,
+  type ParseBaseUriError,
+  type ParseVersionedUriError,
+  type PropertyType,
+  type PropertyTypeReference,
+  type PropertyValues,
+  type Result,
+  type ValueOrArray,
+  type VersionedUri,
+  extractBaseUri,
+  extractVersion,
+  getReferencedIdsFromEntityType,
+  getReferencedIdsFromPropertyType,
+  isPropertyValuesArray,
+  validateBaseUri,
+  validateVersionedUri,
+} from "@blockprotocol/type-system/slim";
 
 // import {
 //   BoundedTimeInterval as BoundedTimeIntervalGeneral,
@@ -263,9 +289,7 @@ export type GetLinkedAggregationData = GetLinkedAggregationDataGeneral;
 export type CreateLinkedAggregationData = CreateLinkedAggregationDataGeneral;
 export type UpdateLinkedAggregationData = UpdateLinkedAggregationDataGeneral;
 export type DeleteLinkedAggregationData = DeleteLinkedAggregationDataGeneral;
-export type DataType = DataTypeGeneral;
 export type DataTypeWithMetadata = DataTypeWithMetadataGeneral;
-export type EntityType = EntityTypeGeneral;
 export type EntityTypeWithMetadata = EntityTypeWithMetadataGeneral;
 export type AggregateEntityTypesData = AggregateEntityTypesDataGeneral;
 export type AggregateEntityTypesResult<T extends Subgraph<EntityTypeRootType>> =
@@ -274,7 +298,6 @@ export type GetEntityTypeData = GetEntityTypeDataGeneral;
 export type CreateEntityTypeData = CreateEntityTypeDataGeneral;
 export type UpdateEntityTypeData = UpdateEntityTypeDataGeneral;
 export type OntologyElementMetadata = OntologyElementMetadataGeneral;
-export type PropertyType = PropertyTypeGeneral;
 export type PropertyTypeWithMetadata = PropertyTypeWithMetadataGeneral;
 export type AggregatePropertyTypesData = AggregatePropertyTypesDataGeneral;
 export type AggregatePropertyTypesResult = AggregatePropertyTypesResultGeneral;

--- a/libs/@blockprotocol/graph/src/shared/types/ontology/data-type.ts
+++ b/libs/@blockprotocol/graph/src/shared/types/ontology/data-type.ts
@@ -2,12 +2,6 @@ import { DataType } from "@blockprotocol/type-system/slim";
 
 import { OntologyElementMetadata } from "./metadata.js";
 
-/**
- * @todo - Should we re-export this? Should the type-system package be an implementation detail of the graph module?
- *   Or should consumers import it directly? Also raises the question of if we should be re-exporting the functions.
- */
-export type { DataType };
-
 export type DataTypeWithMetadata = {
   schema: DataType;
   metadata: OntologyElementMetadata;

--- a/libs/@blockprotocol/graph/src/shared/types/ontology/entity-type.ts
+++ b/libs/@blockprotocol/graph/src/shared/types/ontology/entity-type.ts
@@ -4,12 +4,6 @@ import { AggregateOperationInput } from "../entity.js";
 import { EntityTypeRootType, Subgraph } from "../subgraph.js";
 import { OntologyElementMetadata } from "./metadata.js";
 
-/**
- * @todo - Should we re-export this? Should the type-system package be an implementation detail of the graph module?
- *   Or should consumers import it directly? Also raises the question of if we should be re-exporting the functions.
- */
-export type { EntityType };
-
 export type EntityTypeWithMetadata = {
   schema: EntityType;
   metadata: OntologyElementMetadata;

--- a/libs/@blockprotocol/graph/src/shared/types/ontology/property-type.ts
+++ b/libs/@blockprotocol/graph/src/shared/types/ontology/property-type.ts
@@ -3,12 +3,6 @@ import { PropertyType, VersionedUri } from "@blockprotocol/type-system/slim";
 import { PropertyTypeRootType, Subgraph } from "../subgraph.js";
 import { OntologyElementMetadata } from "./metadata.js";
 
-/**
- * @todo - Should we re-export this? Should the type-system package be an implementation detail of the graph module?
- *   Or should consumers import it directly? Also raises the question of if we should be re-exporting the functions.
- */
-export type { PropertyType };
-
 export type PropertyTypeWithMetadata = {
   schema: PropertyType;
   metadata: OntologyElementMetadata;

--- a/libs/@blockprotocol/graph/src/temporal/main.ts
+++ b/libs/@blockprotocol/graph/src/temporal/main.ts
@@ -24,7 +24,6 @@ import {
   CreateLinkedAggregationData as CreateLinkedAggregationDataGeneral,
   CreatePropertyTypeData as CreatePropertyTypeDataGeneral,
   CreateResourceError as CreateResourceErrorGeneral,
-  DataType as DataTypeGeneral,
   DataTypeRootType as DataTypeRootTypeGeneral,
   DataTypeVertex as DataTypeVertexGeneral,
   DataTypeWithMetadata as DataTypeWithMetadataGeneral,
@@ -43,7 +42,6 @@ import {
   EntityRevisionId as EntityRevisionIdGeneral,
   EntityRootType as EntityRootTypeGeneral,
   EntityTemporalVersioningMetadata as EntityTemporalVersioningMetadataGeneral,
-  EntityType as EntityTypeGeneral,
   EntityTypeRootType as EntityTypeRootTypeGeneral,
   EntityTypeVertex as EntityTypeVertexGeneral,
   EntityTypeWithMetadata as EntityTypeWithMetadataGeneral,
@@ -140,7 +138,6 @@ import {
   PinnedTemporalAxis as PinnedTemporalAxisGeneral,
   PinnedTemporalAxisUnresolved as PinnedTemporalAxisUnresolvedGeneral,
   PropertiesConstrainedByEdge as PropertiesConstrainedByEdgeGeneral,
-  PropertyType as PropertyTypeGeneral,
   PropertyTypeRootType as PropertyTypeRootTypeGeneral,
   PropertyTypeVertex as PropertyTypeVertexGeneral,
   PropertyTypeWithMetadata as PropertyTypeWithMetadataGeneral,
@@ -172,6 +169,36 @@ import {
   VertexId as VertexIdGeneral,
   Vertices as VerticesGeneral,
 } from "../shared/types.js";
+
+export {
+  type AllOf,
+  type Array,
+  type BaseUri,
+  type DataType,
+  type DataTypeReference,
+  type EntityType,
+  type EntityTypeReference,
+  type Links,
+  type MaybeOneOfEntityTypeReference,
+  type MaybeOrderedArray,
+  type Object,
+  type OneOf,
+  type ParseBaseUriError,
+  type ParseVersionedUriError,
+  type PropertyType,
+  type PropertyTypeReference,
+  type PropertyValues,
+  type Result,
+  type ValueOrArray,
+  type VersionedUri,
+  extractBaseUri,
+  extractVersion,
+  getReferencedIdsFromEntityType,
+  getReferencedIdsFromPropertyType,
+  isPropertyValuesArray,
+  validateBaseUri,
+  validateVersionedUri,
+} from "@blockprotocol/type-system/slim";
 
 // import {
 //   BlockGraphProperties as BlockGraphPropertiesGeneral,
@@ -262,9 +289,7 @@ export type GetLinkedAggregationData = GetLinkedAggregationDataGeneral;
 export type CreateLinkedAggregationData = CreateLinkedAggregationDataGeneral;
 export type UpdateLinkedAggregationData = UpdateLinkedAggregationDataGeneral;
 export type DeleteLinkedAggregationData = DeleteLinkedAggregationDataGeneral;
-export type DataType = DataTypeGeneral;
 export type DataTypeWithMetadata = DataTypeWithMetadataGeneral;
-export type EntityType = EntityTypeGeneral;
 export type EntityTypeWithMetadata = EntityTypeWithMetadataGeneral;
 export type AggregateEntityTypesData = AggregateEntityTypesDataGeneral;
 export type AggregateEntityTypesResult<T extends Subgraph<EntityTypeRootType>> =
@@ -273,7 +298,6 @@ export type GetEntityTypeData = GetEntityTypeDataGeneral;
 export type CreateEntityTypeData = CreateEntityTypeDataGeneral;
 export type UpdateEntityTypeData = UpdateEntityTypeDataGeneral;
 export type OntologyElementMetadata = OntologyElementMetadataGeneral;
-export type PropertyType = PropertyTypeGeneral;
 export type PropertyTypeWithMetadata = PropertyTypeWithMetadataGeneral;
 export type AggregatePropertyTypesData = AggregatePropertyTypesDataGeneral;
 export type AggregatePropertyTypesResult = AggregatePropertyTypesResultGeneral;

--- a/libs/block-template-custom-element/package.json
+++ b/libs/block-template-custom-element/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "@blockprotocol/graph": "0.0.20",
-    "@blockprotocol/type-system": "0.0.4",
     "lit": "^2.4.1"
   },
   "devDependencies": {

--- a/libs/block-template-custom-element/src/dev.tsx
+++ b/libs/block-template-custom-element/src/dev.tsx
@@ -1,4 +1,4 @@
-import { VersionedUri } from "@blockprotocol/type-system/slim";
+import { VersionedUri } from "@blockprotocol/graph";
 import { MockBlockDock } from "mock-block-dock";
 import { createRoot } from "react-dom/client";
 

--- a/libs/block-template-react/package.json
+++ b/libs/block-template-react/package.json
@@ -33,8 +33,7 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "@blockprotocol/graph": "0.0.20",
-    "@blockprotocol/type-system": "0.0.4"
+    "@blockprotocol/graph": "0.0.20"
   },
   "devDependencies": {
     "@local/eslint-config": "0.0.0-private",

--- a/libs/block-template-react/src/dev.tsx
+++ b/libs/block-template-react/src/dev.tsx
@@ -1,4 +1,4 @@
-import { VersionedUri } from "@blockprotocol/type-system/slim";
+import { VersionedUri } from "@blockprotocol/graph";
 import { MockBlockDock } from "mock-block-dock";
 import { createRoot } from "react-dom/client";
 

--- a/libs/mock-block-dock/dev/dev-app.tsx
+++ b/libs/mock-block-dock/dev/dev-app.tsx
@@ -1,4 +1,4 @@
-import { extractBaseUri } from "@blockprotocol/type-system/slim";
+import { extractBaseUri } from "@blockprotocol/graph";
 import { ChangeEvent, FunctionComponent, useState } from "react";
 import { createRoot } from "react-dom/client";
 

--- a/libs/mock-block-dock/dev/test-custom-element-block.ts
+++ b/libs/mock-block-dock/dev/test-custom-element-block.ts
@@ -1,6 +1,6 @@
+import { extractBaseUri } from "@blockprotocol/graph";
 import { BlockElementBase } from "@blockprotocol/graph/custom-element";
 import { getRoots } from "@blockprotocol/graph/stdlib";
-import { extractBaseUri } from "@blockprotocol/type-system/slim";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { html } from "lit";
 

--- a/libs/mock-block-dock/dev/test-react-block.tsx
+++ b/libs/mock-block-dock/dev/test-react-block.tsx
@@ -1,10 +1,10 @@
+import { extractBaseUri } from "@blockprotocol/graph";
 import {
   type BlockComponent,
   useGraphBlockModule,
 } from "@blockprotocol/graph/react";
 import { getRoots } from "@blockprotocol/graph/stdlib";
 import { useHook, useHookBlockModule } from "@blockprotocol/hook/react";
-import { extractBaseUri } from "@blockprotocol/type-system/slim";
 import { useMemo, useRef } from "react";
 
 import { propertyTypes } from "../src/data/property-types";

--- a/libs/mock-block-dock/package.json
+++ b/libs/mock-block-dock/package.json
@@ -40,7 +40,6 @@
     "@blockprotocol/core": "0.0.14",
     "@blockprotocol/graph": "0.0.20",
     "@blockprotocol/hook": "0.0.10",
-    "@blockprotocol/type-system": "0.0.4",
     "@emotion/react": "^11.10.0",
     "@emotion/styled": "^11.10.0",
     "@lit-labs/react": "^1.0.4",

--- a/libs/mock-block-dock/src/data/entities.ts
+++ b/libs/mock-block-dock/src/data/entities.ts
@@ -1,10 +1,9 @@
-import { Entity } from "@blockprotocol/graph";
+import { Entity, extractBaseUri } from "@blockprotocol/graph";
 import {
   Entity as EntityTemporal,
   EntityTemporalVersioningMetadata,
   QueryTemporalAxes,
 } from "@blockprotocol/graph/temporal";
-import { extractBaseUri } from "@blockprotocol/type-system/slim";
 
 import { entityTypes } from "./entity-types";
 import { propertyTypes } from "./property-types";

--- a/libs/mock-block-dock/src/data/entity-types.ts
+++ b/libs/mock-block-dock/src/data/entity-types.ts
@@ -1,5 +1,4 @@
-import { EntityType } from "@blockprotocol/graph";
-import { extractBaseUri } from "@blockprotocol/type-system/slim";
+import { EntityType, extractBaseUri } from "@blockprotocol/graph";
 
 import { propertyTypes } from "./property-types";
 

--- a/libs/mock-block-dock/src/debug-view/dev-tools/entity-switcher.tsx
+++ b/libs/mock-block-dock/src/debug-view/dev-tools/entity-switcher.tsx
@@ -1,6 +1,7 @@
 import {
   Entity as EntityNonTemporal,
   EntityRecordId as EntityRecordIdNonTemporal,
+  VersionedUri,
 } from "@blockprotocol/graph";
 import {
   getEntities as getEntitiesNonTemporal,
@@ -18,7 +19,6 @@ import {
   getEntityTypes as getEntityTypesTemporal,
   getRoots as getRootsTemporal,
 } from "@blockprotocol/graph/temporal/stdlib";
-import { VersionedUri } from "@blockprotocol/type-system/slim";
 import {
   Box,
   Button,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

With the current state of the `0.3` branch almost all usages will require a dependency on the `@blockprotocol/graph` package _and_ the `@blockprotocol/type-system` package. The latter of which has a learning curve due to advanced functionalities that require initialisation of WASM.

This lowers the barrier to entry by re-exporting non-WASM requiring functions and types from the type-system package, so that users can simply add the graph module package as a dependency.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203358502199087/1203922286227449/f) _(internal)_

## 🚫 Blocked by

N/A

## 🔍 What does this change?

See description

## 📜 Does this require a change to the docs?

As we refine the new version of the spec we will probably want to help power-users discover the type system package and understand when they may need to import it directly.

## ⚠️ Known issues

N/A

## 🐾 Next steps

N/A

## 🛡 What tests cover this?

- `tsc`
- `eslint`

## ❓ How to test this?

Watch CI
