### PR TITLE
Update + fix block templates, schema -> TS codegen

### DIFF
--- a/apps/site/src/pages/api/types/entity-type/shared/schema.ts
+++ b/apps/site/src/pages/api/types/entity-type/shared/schema.ts
@@ -26,8 +26,8 @@ export const generateEntityTypeWithMetadata = (data: {
   const entityType = {
     additionalProperties: false,
     allOf: incompleteSchema.allOf ?? [],
-    description: incompleteSchema.description,
-    examples: incompleteSchema.examples,
+    description: incompleteSchema.description ?? "",
+    examples: incompleteSchema.examples ?? [],
     $id: versionedUri,
     kind,
     links: incompleteSchema.links,

--- a/libs/@blockprotocol/graph/src/non-temporal/custom-element.ts
+++ b/libs/@blockprotocol/graph/src/non-temporal/custom-element.ts
@@ -69,10 +69,11 @@ export abstract class BlockElementBase<
     if (!this.graph || !this.graph.blockEntitySubgraph) {
       throw new Error("graph.blockEntitySubgraph was not passed to block.");
     }
+
     const blockEntity = getRoots(this.graph.blockEntitySubgraph)[0];
     if (!blockEntity) {
       throw new Error(
-        "Cannot update self: no root entity on graph.blockEntitySubgraph passed to block",
+        "No root entity on graph.blockEntitySubgraph passed to block",
       );
     }
 

--- a/libs/@blockprotocol/graph/src/non-temporal/custom-element.ts
+++ b/libs/@blockprotocol/graph/src/non-temporal/custom-element.ts
@@ -30,8 +30,6 @@ export abstract class BlockElementBase<
    * @see https://blockprotocol.org/docs/spec/graph-module#message-definitions for a full list of available messages
    */
   protected graphModule?: GraphBlockHandler;
-  protected blockEntity?: RootEntity;
-  protected linkedEntities?: LinkEntityAndRightEntity[];
 
   /**
    * The properties sent to the block represent the messages sent automatically from the application to the block.
@@ -45,40 +43,12 @@ export abstract class BlockElementBase<
      * @see https://blockprotocol.org/docs/spec/graph-module#message-definitions for a full list
      */
     graph: { type: Object },
-
-    /**
-     * These are properties derived from the block subgraph – the root entity, and those linked from it
-     * // @see https://lit.dev/docs/components/properties/#internal-reactive-state
-     */
-    blockEntity: { state: true },
-    linkedEntities: { state: true },
   };
-
-  private updateDerivedProperties() {
-    const blockEntitySubgraph = this.graph?.blockEntitySubgraph;
-
-    if (blockEntitySubgraph) {
-      const rootEntity = getRoots(blockEntitySubgraph)[0];
-      if (!rootEntity) {
-        throw new Error("Root entity not present in subgraph");
-      }
-      this.blockEntity = rootEntity;
-
-      this.linkedEntities =
-        getOutgoingLinkAndTargetEntities<RootEntityLinkedEntities>(
-          blockEntitySubgraph,
-          rootEntity.metadata.recordId.entityId,
-        );
-    }
-  }
 
   connectedCallback() {
     super.connectedCallback();
     if (!this.graphModule || this.graphModule.destroyed) {
       this.graphModule = new GraphBlockHandler({
-        callbacks: {
-          blockEntitySubgraph: () => this.updateDerivedProperties(),
-        },
         element: this,
       });
     }
@@ -92,6 +62,39 @@ export abstract class BlockElementBase<
   }
 
   /**
+   * A helper method that returns the root entity from blockEntitySubgraph,
+   * i.e. the 'block entity'
+   */
+  protected getBlockEntity(): RootEntity {
+    if (!this.graph || !this.graph.blockEntitySubgraph) {
+      throw new Error("graph.blockEntitySubgraph was not passed to block.");
+    }
+    const blockEntity = getRoots(this.graph.blockEntitySubgraph)[0];
+    if (!blockEntity) {
+      throw new Error(
+        "Cannot update self: no root entity on graph.blockEntitySubgraph passed to block",
+      );
+    }
+
+    return blockEntity;
+  }
+
+  /**
+   * A helper method that returns the entities linked from the root entity
+   * of blockEntitySubgraph, i.e. the 'block entity'
+   */
+  protected getLinkedEntities(): RootEntityLinkedEntities {
+    if (!this.graph || !this.graph.blockEntitySubgraph) {
+      throw new Error("graph.blockEntitySubgraph was not passed to block.");
+    }
+
+    return getOutgoingLinkAndTargetEntities<RootEntityLinkedEntities>(
+      this.graph.blockEntitySubgraph,
+      this.getBlockEntity().metadata.recordId.entityId,
+    );
+  }
+
+  /**
    * A helper method to update the properties of the entity loaded into the block, i.e. this.graph.blockEntity
    * @param properties the properties object to assign to the entity, which will overwrite the existing object
    */
@@ -101,17 +104,9 @@ export abstract class BlockElementBase<
         "Cannot updateSelfProperties – graphModule not yet connected.",
       );
     }
-    if (!this.graph) {
-      throw new Error(
-        "Cannot update self: no 'graph' property object passed to block.",
-      );
-    } else if (!this.graph.blockEntitySubgraph) {
-      throw new Error(
-        "Cannot update self: no 'blockEntitySubgraph' on 'graph' object passed to block",
-      );
-    }
 
-    const blockEntity = getRoots(this.graph.blockEntitySubgraph)[0];
+    const blockEntity = this.getBlockEntity();
+
     if (!blockEntity) {
       throw new Error(
         "Cannot update self: no root entity on graph.blockEntitySubgraph passed to block",

--- a/libs/@blockprotocol/graph/src/shared/codegen/entity-type-to-typescript.ts
+++ b/libs/@blockprotocol/graph/src/shared/codegen/entity-type-to-typescript.ts
@@ -150,9 +150,17 @@ const _jsonSchemaToTypeScript = async (
   // here we import the types defined elsewhere which we rely on, e.g. Entity
   let compiledSchema = rootSchema ? generateImportStatements(temporal) : "";
 
+  if (!schema.allOf || (schema.allOf && schema.allOf.length === 0)) {
+    // eslint-disable-next-line no-param-reassign -- must be deleted. an empty array -> garbage output, null/undefined -> crash
+    delete schema.allOf;
+  }
+
   // Generate the type for FooProperties, representing the entity's 'own properties' (not links or linked entities)
   compiledSchema += await compileSchema(
-    { ...schema, title: propertyTypeName },
+    {
+      ...schema,
+      title: propertyTypeName,
+    },
     {
       additionalProperties: false, // @todo add additionalProperties: false to entity type JSON schemas
       bannerComment: rootSchema ? bannerComment(schema.$id, depth) : "",

--- a/libs/block-template-custom-element/package.json
+++ b/libs/block-template-custom-element/package.json
@@ -64,6 +64,6 @@
     "image": "public/block-preview.png",
     "name": "block-template-custom-element",
     "protocol": "0.3",
-    "schema": "https://alpha.hash.ai/@hash/types/entity-type/page/v/1"
+    "schema": "https://blockprotocol-r2l2zq4gf.stage.hash.ai/@blockprotocol/types/entity-type/thing/v/2"
   }
 }

--- a/libs/block-template-custom-element/src/app.ts
+++ b/libs/block-template-custom-element/src/app.ts
@@ -3,6 +3,9 @@ import { css, html } from "lit";
 
 import { RootEntity } from "./types.gen";
 
+const nameKey: keyof RootEntity["properties"] =
+  "https://blockprotocol-r2l2zq4gf.stage.hash.ai/@blockprotocol/types/property-type/name/";
+
 /**
  * This is the entry point for your block – the class that embedding applications will use to register your element.
  * You should update this comment to describe what your block does, or remove the comment.
@@ -18,7 +21,7 @@ export class BlockElement extends BlockElementBase<RootEntity> {
   `;
 
   private handleInput(event: InputEvent) {
-    if (!this.graphModule || !this.blockEntity) {
+    if (!this.graphModule) {
       return;
     }
     /**
@@ -33,13 +36,11 @@ export class BlockElement extends BlockElementBase<RootEntity> {
     this.graphModule
       .updateEntity<RootEntity["properties"]>({
         data: {
-          entityId: this.blockEntity.metadata.recordId.entityId,
-          entityTypeId: this.blockEntity.metadata.entityTypeId,
+          entityId: this.getBlockEntity().metadata.recordId.entityId,
+          entityTypeId: this.getBlockEntity().metadata.entityTypeId,
           properties: {
-            ...this.blockEntity.properties,
-            "https://alpha.hash.ai/@hash/types/property-type/title/": (
-              event.target as HTMLInputElement
-            ).value,
+            ...this.getBlockEntity().properties,
+            [nameKey]: (event.target as HTMLInputElement).value,
           },
         },
       })
@@ -48,23 +49,16 @@ export class BlockElement extends BlockElementBase<RootEntity> {
 
   /** @see https://lit.dev/docs/components/rendering */
   render() {
-    return html`<h1>
-        Hello,
-        ${this.blockEntity?.properties[
-          "https://alpha.hash.ai/@hash/types/property-type/title/"
-        ]}
-      </h1>
+    return html`<h1>Hello, ${this.getBlockEntity().properties[nameKey]}</h1>
       <p>
         The entityId of this block is
-        ${this.blockEntity?.metadata.recordId.entityId}. Use it to update its
-        data when calling updateEntity.
+        ${this.getBlockEntity()?.metadata.recordId.entityId}. Use it to update
+        its data when calling updateEntity.
       </p>
       <!-- @see https://lit.dev/docs/components/events -->
       <input
         @change=${this.handleInput}
-        value=${this.blockEntity?.properties[
-          "https://alpha.hash.ai/@hash/types/property-type/title/"
-        ]}
+        value=${this.getBlockEntity()?.properties[nameKey]}
       />`;
   }
 }

--- a/libs/block-template-custom-element/src/app.ts
+++ b/libs/block-template-custom-element/src/app.ts
@@ -52,13 +52,13 @@ export class BlockElement extends BlockElementBase<RootEntity> {
     return html`<h1>Hello, ${this.getBlockEntity().properties[nameKey]}</h1>
       <p>
         The entityId of this block is
-        ${this.getBlockEntity()?.metadata.recordId.entityId}. Use it to update
+        ${this.getBlockEntity().metadata.recordId.entityId}. Use it to update
         its data when calling updateEntity.
       </p>
       <!-- @see https://lit.dev/docs/components/events -->
       <input
         @change=${this.handleInput}
-        value=${this.getBlockEntity()?.properties[nameKey]}
+        value=${this.getBlockEntity().properties[nameKey]}
       />`;
   }
 }

--- a/libs/block-template-custom-element/src/dev.tsx
+++ b/libs/block-template-custom-element/src/dev.tsx
@@ -8,7 +8,6 @@ import { RootEntity } from "./types.gen";
 
 const node = document.getElementById("app");
 
-// @todo-0.3 make type blockprotocol.org/[etc]/ExampleEntity when we can host new types there
 const testEntity: RootEntity = {
   metadata: {
     recordId: {
@@ -18,8 +17,8 @@ const testEntity: RootEntity = {
     entityTypeId: packageJson.blockprotocol.schema as VersionedUri,
   },
   properties: {
-    "https://alpha.hash.ai/@hash/types/property-type/title/": "World",
-    "https://alpha.hash.ai/@hash/types/property-type/index/": "0",
+    "https://blockprotocol-r2l2zq4gf.stage.hash.ai/@blockprotocol/types/property-type/name/":
+      "World",
   },
 } as const;
 

--- a/libs/block-template-custom-element/src/types.gen.ts
+++ b/libs/block-template-custom-element/src/types.gen.ts
@@ -2,145 +2,35 @@ import { Entity, JsonObject } from "@blockprotocol/graph";
 
 /**
  * This file was automatically generated – do not edit it.
- * @see https://alpha.hash.ai/@hash/types/entity-type/page/v/1 for the root JSON Schema these types were generated from
+ * @see https://blockprotocol-r2l2zq4gf.stage.hash.ai/@blockprotocol/types/entity-type/thing/v/2 for the root JSON Schema these types were generated from
  * Types for link entities and their destination were generated to a depth of 2 from the root
  */
 
 /**
- * The (fractional) index indicating the current position of something.
+ * The name of something
  */
-export type Index = Text;
+export type Name = Text;
 /**
  * An ordered sequence of characters
  */
 export type Text = string;
-/**
- * The summary of the something.
- */
-export type Summary = Text;
-/**
- * An emoji icon.
- */
-export type Icon = Text;
-/**
- * The title of something.
- */
-export type Title = Text;
-/**
- * Whether or not something has been archived.
- */
-export type Archived = Boolean;
-/**
- * A True or False value
- */
-export type Boolean = boolean;
 
-export type PageProperties = {
-  "https://alpha.hash.ai/@hash/types/property-type/index/": Index;
-  "https://alpha.hash.ai/@hash/types/property-type/summary/"?: Summary;
-  "https://alpha.hash.ai/@hash/types/property-type/icon/"?: Icon;
-  "https://alpha.hash.ai/@hash/types/property-type/title/": Title;
-  "https://alpha.hash.ai/@hash/types/property-type/archived/"?: Archived;
+/**
+ * A generic thing
+ */
+export type ThingProperties = {
+  "https://blockprotocol-r2l2zq4gf.stage.hash.ai/@blockprotocol/types/property-type/name/"?: Name;
 }
 
-export type Page = Entity<PageProperties>;
-
-/**
- * Something containing something.
- */
-export type ContainsProperties = ContainsProperties1 & ContainsProperties2;
-export type ContainsProperties1 = Link;
-
-export type Link = {
-  leftEntityId?: string;
-  rightEntityId?: string;
-}
-export type ContainsProperties2 = {}
-
-export type Contains = Entity<ContainsProperties>;
-export type ContainsLinksByLinkTypeId = {
+export type Thing = Entity<ThingProperties>;
+export type ThingLinksByLinkTypeId = {
 
 };
 
-export type ContainsLinkAndRightEntities = NonNullable<
-  ContainsLinksByLinkTypeId[keyof ContainsLinksByLinkTypeId]
->;
-export type ComponentId = Text;
-/**
- * An ordered sequence of characters
- */
-
-
-export type BlockProperties = {
-  "https://alpha.hash.ai/@hash/types/property-type/component-id/": ComponentId;
-}
-
-export type Block = Entity<BlockProperties>;
-
-/**
- * The entity representing the data in a block.
- */
-export type BlockDataProperties = BlockDataProperties1 & BlockDataProperties2;
-export type BlockDataProperties1 = Link;
-
-
-export type BlockDataProperties2 = {}
-
-export type BlockData = Entity<BlockDataProperties>;
-
-export type BlockBlockDataLinks = [] |
-  {
-    linkEntity: BlockData;
-    rightEntity: Entity;
-  }[];
-
-export type BlockLinksByLinkTypeId = {
-  "https://alpha.hash.ai/@hash/types/entity-type/block-data/v/1": BlockBlockDataLinks;
-};
-
-export type BlockLinkAndRightEntities = NonNullable<
-  BlockLinksByLinkTypeId[keyof BlockLinksByLinkTypeId]
->;
-export type PageContainsLinks = [] |
-  {
-    linkEntity: Contains;
-    rightEntity: Block;
-  }[];
-
-
-/**
- * The parent of something.
- */
-export type ParentProperties = ParentProperties1 & ParentProperties2;
-export type ParentProperties1 = Link;
-
-
-export type ParentProperties2 = {}
-
-export type Parent = Entity<ParentProperties>;
-export type ParentLinksByLinkTypeId = {
-
-};
-
-export type ParentLinkAndRightEntities = NonNullable<
-  ParentLinksByLinkTypeId[keyof ParentLinksByLinkTypeId]
+export type ThingLinkAndRightEntities = NonNullable<
+  ThingLinksByLinkTypeId[keyof ThingLinksByLinkTypeId]
 >;
 
-export type PageParentLinks = [] |
-  {
-    linkEntity: Parent;
-    rightEntity: Page;
-  }[];
-
-export type PageLinksByLinkTypeId = {
-  "https://alpha.hash.ai/@hash/types/entity-type/contains/v/1": PageContainsLinks;
-  "https://alpha.hash.ai/@hash/types/entity-type/parent/v/1": PageParentLinks;
-};
-
-export type PageLinkAndRightEntities = NonNullable<
-  PageLinksByLinkTypeId[keyof PageLinksByLinkTypeId]
->;
-
-export type RootEntity = Page;
-export type RootEntityLinkedEntities = PageLinkAndRightEntities;
-export type RootLinkMap = PageLinksByLinkTypeId;
+export type RootEntity = Thing;
+export type RootEntityLinkedEntities = ThingLinkAndRightEntities;
+export type RootLinkMap = ThingLinksByLinkTypeId;

--- a/libs/block-template-react/package.json
+++ b/libs/block-template-react/package.json
@@ -66,6 +66,6 @@
     "image": "public/block-preview.png",
     "name": "block-template-react",
     "protocol": "0.3",
-    "schema": "https://alpha.hash.ai/@hash/types/entity-type/page/v/1"
+    "schema": "https://blockprotocol-r2l2zq4gf.stage.hash.ai/@blockprotocol/types/entity-type/thing/v/2"
   }
 }

--- a/libs/block-template-react/src/app.tsx
+++ b/libs/block-template-react/src/app.tsx
@@ -65,10 +65,10 @@ export const App: BlockComponent<RootEntity> = ({
 
   const entityId = blockEntity.metadata.recordId.entityId;
 
-  const titleKey: keyof RootEntity["properties"] =
-    "https://alpha.hash.ai/@hash/types/property-type/title/";
+  const nameKey: keyof RootEntity["properties"] =
+    "https://blockprotocol-r2l2zq4gf.stage.hash.ai/@blockprotocol/types/property-type/name/";
 
-  const title = blockEntity.properties[titleKey];
+  const title = blockEntity.properties[nameKey];
 
   return (
     /**
@@ -99,7 +99,7 @@ export const App: BlockComponent<RootEntity> = ({
             data: {
               entityId,
               entityTypeId: blockEntity.metadata.entityTypeId,
-              properties: { [titleKey]: supplyRandomName() },
+              properties: { [nameKey]: supplyRandomName() },
             },
           })
         }

--- a/libs/block-template-react/src/dev.tsx
+++ b/libs/block-template-react/src/dev.tsx
@@ -8,7 +8,6 @@ import { RootEntity } from "./types.gen";
 
 const node = document.getElementById("app");
 
-// @todo-0.3 make type blockprotocol.org/[etc]/ExampleEntity when we can host new types there
 const testEntity: RootEntity = {
   metadata: {
     recordId: {
@@ -18,8 +17,8 @@ const testEntity: RootEntity = {
     entityTypeId: packageJson.blockprotocol.schema as VersionedUri,
   },
   properties: {
-    "https://alpha.hash.ai/@hash/types/property-type/title/": "World",
-    "https://alpha.hash.ai/@hash/types/property-type/index/": "0",
+    "https://blockprotocol-r2l2zq4gf.stage.hash.ai/@blockprotocol/types/property-type/name/":
+      "World",
   },
 } as const;
 

--- a/libs/block-template-react/src/types.gen.ts
+++ b/libs/block-template-react/src/types.gen.ts
@@ -2,145 +2,35 @@ import { Entity, JsonObject } from "@blockprotocol/graph";
 
 /**
  * This file was automatically generated – do not edit it.
- * @see https://alpha.hash.ai/@hash/types/entity-type/page/v/1 for the root JSON Schema these types were generated from
+ * @see https://blockprotocol-r2l2zq4gf.stage.hash.ai/@blockprotocol/types/entity-type/thing/v/2 for the root JSON Schema these types were generated from
  * Types for link entities and their destination were generated to a depth of 2 from the root
  */
 
 /**
- * The summary of the something.
+ * The name of something
  */
-export type Summary = Text;
+export type Name = Text;
 /**
  * An ordered sequence of characters
  */
 export type Text = string;
-/**
- * Whether or not something has been archived.
- */
-export type Archived = Boolean;
-/**
- * A True or False value
- */
-export type Boolean = boolean;
-/**
- * The (fractional) index indicating the current position of something.
- */
-export type Index = Text;
-/**
- * An emoji icon.
- */
-export type Icon = Text;
-/**
- * The title of something.
- */
-export type Title = Text;
 
-export type PageProperties = {
-  "https://alpha.hash.ai/@hash/types/property-type/summary/"?: Summary;
-  "https://alpha.hash.ai/@hash/types/property-type/archived/"?: Archived;
-  "https://alpha.hash.ai/@hash/types/property-type/index/": Index;
-  "https://alpha.hash.ai/@hash/types/property-type/icon/"?: Icon;
-  "https://alpha.hash.ai/@hash/types/property-type/title/": Title;
+/**
+ * A generic thing
+ */
+export type ThingProperties = {
+  "https://blockprotocol-r2l2zq4gf.stage.hash.ai/@blockprotocol/types/property-type/name/"?: Name;
 }
 
-export type Page = Entity<PageProperties>;
-
-/**
- * The parent of something.
- */
-export type ParentProperties = ParentProperties1 & ParentProperties2;
-export type ParentProperties1 = Link;
-
-export type Link = {
-  leftEntityId?: string;
-  rightEntityId?: string;
-}
-export type ParentProperties2 = {}
-
-export type Parent = Entity<ParentProperties>;
-export type ParentLinksByLinkTypeId = {
+export type Thing = Entity<ThingProperties>;
+export type ThingLinksByLinkTypeId = {
 
 };
 
-export type ParentLinkAndRightEntities = NonNullable<
-  ParentLinksByLinkTypeId[keyof ParentLinksByLinkTypeId]
+export type ThingLinkAndRightEntities = NonNullable<
+  ThingLinksByLinkTypeId[keyof ThingLinksByLinkTypeId]
 >;
 
-export type PageParentLinks = [] |
-  {
-    linkEntity: Parent;
-    rightEntity: Page;
-  }[];
-
-
-/**
- * Something containing something.
- */
-export type ContainsProperties = ContainsProperties1 & ContainsProperties2;
-export type ContainsProperties1 = Link;
-
-
-export type ContainsProperties2 = {}
-
-export type Contains = Entity<ContainsProperties>;
-export type ContainsLinksByLinkTypeId = {
-
-};
-
-export type ContainsLinkAndRightEntities = NonNullable<
-  ContainsLinksByLinkTypeId[keyof ContainsLinksByLinkTypeId]
->;
-export type ComponentId = Text;
-/**
- * An ordered sequence of characters
- */
-
-
-export type BlockProperties = {
-  "https://alpha.hash.ai/@hash/types/property-type/component-id/": ComponentId;
-}
-
-export type Block = Entity<BlockProperties>;
-
-/**
- * The entity representing the data in a block.
- */
-export type BlockDataProperties = BlockDataProperties1 & BlockDataProperties2;
-export type BlockDataProperties1 = Link;
-
-
-export type BlockDataProperties2 = {}
-
-export type BlockData = Entity<BlockDataProperties>;
-
-export type BlockBlockDataLinks = [] |
-  {
-    linkEntity: BlockData;
-    rightEntity: Entity;
-  }[];
-
-export type BlockLinksByLinkTypeId = {
-  "https://alpha.hash.ai/@hash/types/entity-type/block-data/v/1": BlockBlockDataLinks;
-};
-
-export type BlockLinkAndRightEntities = NonNullable<
-  BlockLinksByLinkTypeId[keyof BlockLinksByLinkTypeId]
->;
-export type PageContainsLinks = [] |
-  {
-    linkEntity: Contains;
-    rightEntity: Block;
-  }[];
-
-export type PageLinksByLinkTypeId = {
-  "https://alpha.hash.ai/@hash/types/entity-type/parent/v/1": PageParentLinks;
-  "https://alpha.hash.ai/@hash/types/entity-type/contains/v/1": PageContainsLinks;
-};
-
-export type PageLinkAndRightEntities = NonNullable<
-  PageLinksByLinkTypeId[keyof PageLinksByLinkTypeId]
->;
-
-export type RootEntity = Page;
-export type RootEntityLinkedEntities = PageLinkAndRightEntities;
-export type RootLinkMap = PageLinksByLinkTypeId;
+export type RootEntity = Thing;
+export type RootEntityLinkedEntities = ThingLinkAndRightEntities;
+export type RootLinkMap = ThingLinksByLinkTypeId;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

1. Start using a generic `Thing` type as the default type in block templates
2. Handle some crashes in the JSON schema -> TS codegen if `allOf` is present but not a populated array
3. Set a default `description` as the entity type metaschema requires it (folllow up: add a description field to form)
4. Remove derived properties from custom element template due to a timing issue with message passing


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203823571506509