### PR TITLE
Prepare several blocks for republishing

### DIFF
--- a/hub/@hash/callout.json
+++ b/hub/@hash/callout.json
@@ -1,8 +1,0 @@
-{
-  "repository": "https://github.com/hashintel/hash.git",
-  "commit": "09b559a2bc48973ab9a2cfa3be8bf28e84d2dd85",
-
-  "workspace": "@blocks/callout",
-  "distDir": "dist",
-  "verified": true
-}

--- a/hub/@hash/divider.json
+++ b/hub/@hash/divider.json
@@ -1,8 +1,0 @@
-{
-  "repository": "https://github.com/hashintel/hash.git",
-  "commit": "09b559a2bc48973ab9a2cfa3be8bf28e84d2dd85",
-
-  "workspace": "@blocks/divider",
-  "distDir": "dist",
-  "verified": true
-}

--- a/hub/@hash/header.json
+++ b/hub/@hash/header.json
@@ -1,8 +1,0 @@
-{
-  "repository": "https://github.com/hashintel/hash.git",
-  "commit": "09b559a2bc48973ab9a2cfa3be8bf28e84d2dd85",
-
-  "workspace": "@blocks/header",
-  "distDir": "dist",
-  "verified": true
-}

--- a/hub/@hash/paragraph.json
+++ b/hub/@hash/paragraph.json
@@ -1,8 +1,0 @@
-{
-  "repository": "https://github.com/hashintel/hash.git",
-  "commit": "09b559a2bc48973ab9a2cfa3be8bf28e84d2dd85",
-
-  "workspace": "@blocks/paragraph",
-  "distDir": "dist",
-  "verified": true
-}

--- a/hub/@hash/table.json
+++ b/hub/@hash/table.json
@@ -1,8 +1,0 @@
-{
-  "repository": "https://github.com/hashintel/hash.git",
-  "commit": "09b559a2bc48973ab9a2cfa3be8bf28e84d2dd85",
-
-  "workspace": "@blocks/table",
-  "distDir": "dist",
-  "verified": true
-}

--- a/hub/@timdiekmann/countdown.json
+++ b/hub/@timdiekmann/countdown.json
@@ -1,8 +1,0 @@
-{
-  "repository": "https://github.com/hashintel/hash.git",
-  "commit": "09b559a2bc48973ab9a2cfa3be8bf28e84d2dd85",
-
-  "workspace": "@blocks/countdown",
-  "distDir": "dist",
-  "verified": true
-}

--- a/hub/@timdiekmann/timer.json
+++ b/hub/@timdiekmann/timer.json
@@ -1,8 +1,0 @@
-{
-  "repository": "https://github.com/hashintel/hash.git",
-  "commit": "09b559a2bc48973ab9a2cfa3be8bf28e84d2dd85",
-
-  "workspace": "@blocks/timer",
-  "distDir": "dist",
-  "verified": true
-}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR removes several blocks from `/hub`. The blocks are re-published via CLI which has been introduced in https://github.com/hashintel/hash/pull/2043

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](link) _(internal)_
- Publish job: https://github.com/hashintel/hash/actions/runs/4240967603

## 🐾 Next steps

When this PR is merged, I will run publish job for production: https://github.com/hashintel/hash/actions/workflows/publish-blocks-to-production.yml

## ❓ How to test this?

Open preview release and ensure that blocks in the diff are still there.

## 📹 Demo

<img width="356" alt="Screenshot 2023-02-22 at 09 01 19" src="https://user-images.githubusercontent.com/608862/220572307-1c58b0f3-6935-490f-b962-e3a9081b7f6e.png">

<img width="1196" alt="Screenshot 2023-02-22 at 09 02 21" src="https://user-images.githubusercontent.com/608862/220572313-f7940cc5-3303-4024-a5a3-97533ae7385b.png">
