### PR TITLE
Better hub JSON editing. Bump code block. Docs fixes

### DIFF
--- a/apps/site/src/_pages/docs/1_developing-blocks.mdx
+++ b/apps/site/src/_pages/docs/1_developing-blocks.mdx
@@ -20,7 +20,7 @@ We provide three templates which allow you to define the entry point for your bl
 - `html`: create a block defined as an HTML file, with JavaScript added via `<script>` tags.
 - `react`: create a block defined as a React component.
 
-To create a new block, run `npx create-block-app@canary block-name --template template`, replacing `block-name` with the name to give your block, and `template` with one of the template names listed above.
+To create a new block, run `npx create-block-app@canary block-name --template template@canary`, replacing `block-name` with the name to give your block, and `template` with one of the template names listed above (keep the @canary on the end!)
 
 ### I want to use a different technology
 
@@ -37,7 +37,7 @@ You can write your block in regular JavaScript using the methods described above
 ## Creating a block
 
 1.  Move to a folder where you want to create your block.
-1.  Run `npx create-block-app@canary your-block-name --template template`.
+1.  Run `npx create-block-app@canary your-block-name --template react@canary` (or `--template custom-element@canary`).
 1.  Switch to your new folder: `cd [your-block-name]`.
 1.  Run `yarn install && yarn dev` or `npm install && npm run dev`.
 1.  Open [http://localhost:63212](http://localhost:63212/) in your browser to see the starter template.

--- a/apps/site/src/components/pages/hub/json-editor.tsx
+++ b/apps/site/src/components/pages/hub/json-editor.tsx
@@ -146,6 +146,7 @@ export const JsonEditor = ({ onChange, value, height }: JsonEditorProps) => {
           tabSize: 2,
           fontFamily: CODE_FONT_FAMILY,
           fontSize: "1em",
+          whiteSpace: "pre-wrap",
         })}
         wrap="off"
         component="textarea"

--- a/apps/site/src/styles/prism.css
+++ b/apps/site/src/styles/prism.css
@@ -14,7 +14,7 @@ pre[class*="language-"] {
   font-family: "JetBrains Mono", Monaco, monospace;
   font-size: 1em;
   text-align: left;
-  white-space: pre;
+  white-space: pre-wrap;
   word-spacing: normal;
   word-break: normal;
   word-wrap: normal;

--- a/hub/@hash/code.json
+++ b/hub/@hash/code.json
@@ -1,6 +1,6 @@
 {
   "repository": "https://github.com/hashintel/hash.git",
-  "commit": "44a5c25e36fdb4e4210f533713960bf2c46beec1",
+  "commit": "3c1349e0f026da31f7c729acaaed613566178227",
   "workspace": "@blocks/code",
   "distDir": "dist",
   "verified": true


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

1. Fixes docs instructions to specify that you must use `[template]@canary` when running `create-block-app`.

2. Bump code block to get improvements made in https://github.com/hashintel/hash/pull/2107 and https://github.com/hashintel/hash/pull/2108

3. Wraps text in hub JSON editor – now that property keys are URIs, it is pretty difficult to edit the JSON without wrapping

**Before**

![Screenshot 2023-02-21 at 11 38 19](https://user-images.githubusercontent.com/37743469/220335393-037c2f29-b35f-4924-954a-846777f4ddcb.png)

**Now**


https://user-images.githubusercontent.com/37743469/220335490-5900aacf-fe95-4eea-94ec-3a7ffa46a989.mp4

