### PR TITLE
Fix mock-block-dock datastore visualization

### DIFF
--- a/libs/mock-block-dock/dev/test-react-block.tsx
+++ b/libs/mock-block-dock/dev/test-react-block.tsx
@@ -1,12 +1,11 @@
-import { Entity } from "@blockprotocol/graph";
+import { extractBaseUri } from "@blockprotocol/graph";
 import {
   type BlockComponent,
   useGraphBlockModule,
 } from "@blockprotocol/graph/react";
 import { getRoots } from "@blockprotocol/graph/stdlib";
 import { useHook, useHookBlockModule } from "@blockprotocol/hook/react";
-import { extractBaseUri } from "@blockprotocol/type-system/slim";
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useRef } from "react";
 
 import { propertyTypes } from "../src/data/property-types";
 
@@ -36,8 +35,6 @@ export const TestReactBlock: BlockComponent = ({ graph }) => {
     },
   );
 
-  const [entities, setEntities] = useState<Record<string, Entity>>({});
-
   if (readonly) {
     return (
       <div ref={blockRef}>
@@ -66,143 +63,6 @@ export const TestReactBlock: BlockComponent = ({ graph }) => {
 
   return (
     <div ref={blockRef}>
-      <button
-        onClick={async () => {
-          const { data, errors } = await graphModule.createEntity({
-            data: {
-              entityTypeId: blockEntity!.metadata!.entityTypeId,
-              properties: {
-                [extractBaseUri(propertyTypes.name.$id)]: "alice",
-              },
-            },
-          });
-
-          if (!data) {
-            console.error(errors);
-            throw new Error("Failed to create entity: alice");
-          }
-
-          setEntities((prevEntities) => ({ ...prevEntities, alice: data }));
-        }}
-      >
-        Create Alice
-      </button>
-      <button
-        onClick={async () => {
-          const { data, errors } = await graphModule.createEntity({
-            data: {
-              entityTypeId: blockEntity!.metadata!.entityTypeId,
-              properties: {
-                [extractBaseUri(propertyTypes.name.$id)]: "bob",
-              },
-            },
-          });
-
-          if (!data) {
-            console.error(errors);
-            throw new Error("Failed to create entity: bob");
-          }
-
-          setEntities((prevEntities) => ({ ...prevEntities, bob: data }));
-        }}
-      >
-        Create Bob
-      </button>
-      <button
-        onClick={async () => {
-          const { data, errors } = await graphModule.createEntity({
-            data: {
-              entityTypeId: blockEntity!.metadata!.entityTypeId,
-              properties: {
-                [extractBaseUri(propertyTypes.name.$id)]: "charlie",
-              },
-            },
-          });
-
-          if (!data) {
-            console.error(errors);
-            throw new Error("Failed to create entity: charlie");
-          }
-
-          setEntities((prevEntities) => ({ ...prevEntities, charlie: data }));
-        }}
-      >
-        Create Charlie
-      </button>
-      <button
-        onClick={async () => {
-          const { data, errors } = await graphModule.createEntity({
-            data: {
-              entityTypeId: blockEntity!.metadata!.entityTypeId,
-              properties: {},
-              linkData: {
-                leftEntityId: entities.alice!.metadata.recordId.entityId,
-                rightEntityId: entities.bob!.metadata.recordId.entityId,
-              },
-            },
-          });
-
-          if (!data) {
-            console.error(errors);
-            throw new Error(`Failed to create entity: aliceToBob`);
-          }
-
-          setEntities((prevEntities) => ({
-            ...prevEntities,
-            aliceToBob: data!,
-          }));
-        }}
-      >
-        Create Alice to Bob Link
-      </button>
-      <button
-        onClick={async () => {
-          const { data, errors } = await graphModule.createEntity({
-            data: {
-              entityTypeId: blockEntity!.metadata!.entityTypeId,
-              properties: {},
-              linkData: {
-                leftEntityId: entities.alice!.metadata.recordId.entityId,
-                rightEntityId: entities.charlie!.metadata.recordId.entityId,
-              },
-            },
-          });
-
-          if (!data) {
-            console.error(errors);
-            throw new Error(`Failed to create entity: aliceToCharlie`);
-          }
-
-          setEntities((prevEntities) => ({
-            ...prevEntities,
-            aliceToCharlie: data!,
-          }));
-        }}
-      >
-        Create Alice to Charlie Link
-      </button>
-      <button
-        onClick={async () => {
-          await graphModule.deleteEntity({
-            data: {
-              entityId: entities.aliceToBob!.metadata.recordId.entityId,
-            },
-          });
-        }}
-      >
-        Delete Alice To Bob
-      </button>
-      <button
-        onClick={async () => {
-          await graphModule.deleteEntity({
-            data: {
-              entityId: entities.charlie!.metadata.recordId.entityId,
-            },
-          });
-        }}
-      >
-        Delete Charlie
-      </button>
       <h1>
         <>
           Hello{" "}

--- a/libs/mock-block-dock/dev/test-react-block.tsx
+++ b/libs/mock-block-dock/dev/test-react-block.tsx
@@ -1,11 +1,12 @@
-import { extractBaseUri } from "@blockprotocol/graph";
+import { Entity } from "@blockprotocol/graph";
 import {
   type BlockComponent,
   useGraphBlockModule,
 } from "@blockprotocol/graph/react";
 import { getRoots } from "@blockprotocol/graph/stdlib";
 import { useHook, useHookBlockModule } from "@blockprotocol/hook/react";
-import { useMemo, useRef } from "react";
+import { extractBaseUri } from "@blockprotocol/type-system/slim";
+import { useMemo, useRef, useState } from "react";
 
 import { propertyTypes } from "../src/data/property-types";
 
@@ -35,6 +36,8 @@ export const TestReactBlock: BlockComponent = ({ graph }) => {
     },
   );
 
+  const [entities, setEntities] = useState<Record<string, Entity>>({});
+
   if (readonly) {
     return (
       <div ref={blockRef}>
@@ -63,6 +66,143 @@ export const TestReactBlock: BlockComponent = ({ graph }) => {
 
   return (
     <div ref={blockRef}>
+      <button
+        onClick={async () => {
+          const { data, errors } = await graphModule.createEntity({
+            data: {
+              entityTypeId: blockEntity!.metadata!.entityTypeId,
+              properties: {
+                [extractBaseUri(propertyTypes.name.$id)]: "alice",
+              },
+            },
+          });
+
+          if (!data) {
+            console.error(errors);
+            throw new Error("Failed to create entity: alice");
+          }
+
+          setEntities((prevEntities) => ({ ...prevEntities, alice: data }));
+        }}
+      >
+        Create Alice
+      </button>
+      <button
+        onClick={async () => {
+          const { data, errors } = await graphModule.createEntity({
+            data: {
+              entityTypeId: blockEntity!.metadata!.entityTypeId,
+              properties: {
+                [extractBaseUri(propertyTypes.name.$id)]: "bob",
+              },
+            },
+          });
+
+          if (!data) {
+            console.error(errors);
+            throw new Error("Failed to create entity: bob");
+          }
+
+          setEntities((prevEntities) => ({ ...prevEntities, bob: data }));
+        }}
+      >
+        Create Bob
+      </button>
+      <button
+        onClick={async () => {
+          const { data, errors } = await graphModule.createEntity({
+            data: {
+              entityTypeId: blockEntity!.metadata!.entityTypeId,
+              properties: {
+                [extractBaseUri(propertyTypes.name.$id)]: "charlie",
+              },
+            },
+          });
+
+          if (!data) {
+            console.error(errors);
+            throw new Error("Failed to create entity: charlie");
+          }
+
+          setEntities((prevEntities) => ({ ...prevEntities, charlie: data }));
+        }}
+      >
+        Create Charlie
+      </button>
+      <button
+        onClick={async () => {
+          const { data, errors } = await graphModule.createEntity({
+            data: {
+              entityTypeId: blockEntity!.metadata!.entityTypeId,
+              properties: {},
+              linkData: {
+                leftEntityId: entities.alice!.metadata.recordId.entityId,
+                rightEntityId: entities.bob!.metadata.recordId.entityId,
+              },
+            },
+          });
+
+          if (!data) {
+            console.error(errors);
+            throw new Error(`Failed to create entity: aliceToBob`);
+          }
+
+          setEntities((prevEntities) => ({
+            ...prevEntities,
+            aliceToBob: data!,
+          }));
+        }}
+      >
+        Create Alice to Bob Link
+      </button>
+      <button
+        onClick={async () => {
+          const { data, errors } = await graphModule.createEntity({
+            data: {
+              entityTypeId: blockEntity!.metadata!.entityTypeId,
+              properties: {},
+              linkData: {
+                leftEntityId: entities.alice!.metadata.recordId.entityId,
+                rightEntityId: entities.charlie!.metadata.recordId.entityId,
+              },
+            },
+          });
+
+          if (!data) {
+            console.error(errors);
+            throw new Error(`Failed to create entity: aliceToCharlie`);
+          }
+
+          setEntities((prevEntities) => ({
+            ...prevEntities,
+            aliceToCharlie: data!,
+          }));
+        }}
+      >
+        Create Alice to Charlie Link
+      </button>
+      <button
+        onClick={async () => {
+          await graphModule.deleteEntity({
+            data: {
+              entityId: entities.aliceToBob!.metadata.recordId.entityId,
+            },
+          });
+        }}
+      >
+        Delete Alice To Bob
+      </button>
+      <button
+        onClick={async () => {
+          await graphModule.deleteEntity({
+            data: {
+              entityId: entities.charlie!.metadata.recordId.entityId,
+            },
+          });
+        }}
+      >
+        Delete Charlie
+      </button>
       <h1>
         <>
           Hello{" "}

--- a/libs/mock-block-dock/src/debug-view/dev-tools/datastore-graph-visualization.tsx
+++ b/libs/mock-block-dock/src/debug-view/dev-tools/datastore-graph-visualization.tsx
@@ -1,14 +1,18 @@
 import {
   Entity as EntityNonTemporal,
   EntityRecordId as EntityRecordIdNonTemporal,
+  EntityRevisionId as EntityRevisionIdNonTemporal,
+  EntityVertex as EntityVertexNonTemporal,
   EntityVertexId as EntityVertexIdNonTemporal,
   GraphElementVertexId as GraphElementVertexIdNonTemporal,
+  isEntityVertex as isEntityVertexNonTemporal,
+  isHasRightEntityEdge as isHasRightEntityEdgeNonTemporal,
+  isOutgoingLinkEdge as isOutgoingLinkEdgeNonTemporal,
   OutwardEdge as OutwardEdgeNonTemporal,
   Subgraph as SubgraphNonTemporal,
 } from "@blockprotocol/graph";
 import { isTemporalSubgraph } from "@blockprotocol/graph/internal";
 import {
-  getEntities as getEntitiesNonTemporal,
   getEntityTypeById as getEntityTypeByIdNonTemporal,
   getOutgoingLinkAndTargetEntities as getOutgoingLinkAndTargetEntitiesNonTemporal,
   getPropertyTypesByBaseUri as getPropertyTypesByBaseUriNonTemporal,
@@ -16,6 +20,8 @@ import {
 import {
   Entity as EntityTemporal,
   EntityRecordId as EntityRecordIdTemporal,
+  EntityRevisionId as EntityRevisionIdTemporal,
+  EntityVertex as EntityVertexTemporal,
   EntityVertexId as EntityVertexIdTemporal,
   GraphElementVertexId as GraphElementVertexIdTemporal,
   isEntityVertex as isEntityVertexTemporal,
@@ -25,7 +31,6 @@ import {
   Subgraph as SubgraphTemporal,
 } from "@blockprotocol/graph/temporal";
 import {
-  getEntities as getEntitiesTemporal,
   getEntityTypeById as getEntityTypeByIdTemporal,
   getOutgoingLinkAndTargetEntities as getOutgoingLinkAndTargetEntitiesTemporal,
   getPropertyTypesByBaseUri as getPropertyTypesByBaseUriTemporal,
@@ -35,6 +40,10 @@ import { Box } from "@mui/material";
 import { GraphChart, GraphSeriesOption } from "echarts/charts";
 import * as echarts from "echarts/core";
 import { SVGRenderer } from "echarts/renderers";
+import {
+  GraphEdgeItemOption,
+  GraphNodeItemOption,
+} from "echarts/types/src/chart/graph/GraphSeries";
 import { useEffect, useRef, useState } from "react";
 
 import {
@@ -48,7 +57,7 @@ const parseLabelFromEntity = (
   subgraph: SubgraphTemporal | SubgraphNonTemporal,
 ) => {
   const getFallbackLabel = () => {
-    // fallback to the entity type and a few characters of the entityUuid
+    // fallback to the entity type and a few characters of the entityId
     const entityId = entityToLabel.metadata.recordId.entityId;
 
     const entityType = isTemporalSubgraph(subgraph)
@@ -149,34 +158,20 @@ const createDefaultEChartOptions = (params?: {
 // Register the required components
 echarts.use([GraphChart, SVGRenderer]);
 
-type EChartNode = {
-  id: string;
-  name: string;
-  fixed?: boolean;
-  x?: number;
-  y?: number;
-  label: {
-    show?: boolean;
-  };
-};
+type EChartNode = GraphNodeItemOption & { id: string };
 
 const mapEntityToEChartNode = (
   entity: EntityNonTemporal | EntityTemporal,
+  vertexId: EntityVertexIdNonTemporal | EntityVertexIdTemporal,
   subgraph: SubgraphNonTemporal | SubgraphTemporal,
 ): EChartNode => ({
-  id: JSON.stringify(entity.metadata.recordId),
+  id: JSON.stringify(vertexId),
   name: parseLabelFromEntity(entity, subgraph),
   label: { show: false },
 });
 
-type EChartEdge = {
-  id: string;
-  source: string;
+type EChartEdge = GraphEdgeItemOption & {
   target: string;
-  kind: string;
-  label: {
-    show?: boolean;
-  };
 };
 
 /** todo - render ontology-related edges */
@@ -184,33 +179,63 @@ const mapGraphEdgeToEChartEdge = (
   sourceVertexId: EntityVertexIdNonTemporal | EntityVertexIdTemporal,
   targetVertexId: EntityVertexIdNonTemporal | EntityVertexIdTemporal,
   edgeKind: (OutwardEdgeNonTemporal | OutwardEdgeTemporal)["kind"],
+  edgeLabel: "has outgoing link" | "has target",
 ): EChartEdge => ({
   /** @todo - Can we do better than this, this assumes that this triple is unique, which it might not be */
   id: `${JSON.stringify(sourceVertexId)}-${edgeKind}->${JSON.stringify(
     targetVertexId,
   )}`,
+  name: edgeLabel,
   source: JSON.stringify(sourceVertexId),
   target: JSON.stringify(targetVertexId),
-  kind: edgeKind,
-  label: { show: false },
+  label: {
+    show: false,
+    formatter: edgeLabel,
+  },
 });
 
 const getSubgraphEntitiesAsEChartNodes = (
   subgraph: SubgraphNonTemporal | SubgraphTemporal,
 ): EChartNode[] => {
-  const allEntities = isTemporalSubgraph(subgraph)
-    ? getEntitiesTemporal(subgraph)
-    : getEntitiesNonTemporal(subgraph);
+  const entitiesAndVertexIds = isTemporalSubgraph(subgraph)
+    ? typedEntries(subgraph.vertices).flatMap(([baseId, revisionObject]) =>
+        typedEntries(revisionObject)
+          .filter(
+            (
+              entry,
+            ): entry is [EntityRevisionIdTemporal, EntityVertexTemporal] =>
+              isEntityVertexTemporal(entry[1]),
+          )
+          .map(([revisionId, vertex]) => {
+            return [vertex.inner, { baseId, revisionId }] as const;
+          }),
+      )
+    : typedEntries(subgraph.vertices).flatMap(([baseId, revisionObject]) =>
+        typedEntries(revisionObject)
+          .filter(
+            (
+              entry,
+            ): entry is [
+              EntityRevisionIdNonTemporal,
+              EntityVertexNonTemporal,
+            ] => isEntityVertexNonTemporal(entry[1]),
+          )
+          .map(([revisionId, vertex]) => {
+            return [vertex.inner, { baseId, revisionId }] as const;
+          }),
+      );
 
   /** @todo - Render link entities differently */
   // const [linkEntities, nonLinkEntities] = partitionArrayByCondition(
-  //   allEntities,
-  //   (entity) =>
+  //   entitiesAndVertexIds,
+  //   ([entity, _]) =>
   //     entity.linkData?.leftEntityId !== undefined &&
   //     entity.linkData?.rightEntityId !== undefined,
   // );
 
-  return allEntities.map((entity) => mapEntityToEChartNode(entity, subgraph));
+  return entitiesAndVertexIds.map(([entity, entityVertexId]) =>
+    mapEntityToEChartNode(entity, entityVertexId, subgraph),
+  );
 };
 
 const getSubgraphEdgesAsEChartEdges = (
@@ -266,31 +291,27 @@ const getSubgraphEdgesAsEChartEdges = (
           return sourceRevisions.flatMap((sourceRevisionId) =>
             targetVersions
               .flatMap((targetRevisionId) => {
-                const sourceVertexId:
-                  | GraphElementVertexIdNonTemporal
-                  | GraphElementVertexIdTemporal = {
-                  baseId: sourceBaseId,
-                  revisionId: sourceRevisionId,
-                };
+                if (
+                  isOutgoingLinkEdgeTemporal(outwardEdgeTemporal) ||
+                  isHasRightEntityEdgeTemporal(outwardEdgeTemporal)
+                ) {
+                  const sourceVertexId: GraphElementVertexIdTemporal = {
+                    baseId: sourceBaseId,
+                    revisionId: sourceRevisionId,
+                  };
 
-                const targetVertexId:
-                  | GraphElementVertexIdNonTemporal
-                  | GraphElementVertexIdTemporal = {
-                  baseId: targetBaseId,
-                  revisionId: targetRevisionId,
-                };
+                  const targetVertexId: GraphElementVertexIdTemporal = {
+                    baseId: targetBaseId,
+                    revisionId: targetRevisionId,
+                  };
 
-                if (isOutgoingLinkEdgeTemporal(outwardEdgeTemporal)) {
                   return mapGraphEdgeToEChartEdge(
                     sourceVertexId,
                     targetVertexId,
                     outwardEdge.kind,
-                  );
-                } else if (isHasRightEntityEdgeTemporal(outwardEdgeTemporal)) {
-                  return mapGraphEdgeToEChartEdge(
-                    sourceVertexId,
-                    targetVertexId,
-                    outwardEdge.kind,
+                    isOutgoingLinkEdgeTemporal(outwardEdgeTemporal)
+                      ? "has outgoing link"
+                      : "has target",
                   );
                 }
                 return undefined;
@@ -307,40 +328,28 @@ const getSubgraphEdgesAsEChartEdges = (
           }
           const targetBaseId = outwardEdgeTemporal.rightEndpoint;
 
-          const sourceVertexId:
-            | GraphElementVertexIdNonTemporal
-            | GraphElementVertexIdTemporal = {
-            baseId: sourceBaseId,
-            revisionId: mustBeDefined(
-              Object.keys(subgraph.vertices[sourceBaseId]!).pop(),
-            ),
-          };
+          if (
+            isOutgoingLinkEdgeNonTemporal(outwardEdgeTemporal) ||
+            isHasRightEntityEdgeNonTemporal(outwardEdgeTemporal)
+          ) {
+            const sourceVertexId: GraphElementVertexIdNonTemporal = {
+              baseId: sourceBaseId,
+              revisionId: Object.keys(subgraph.vertices[sourceBaseId]!).pop()!,
+            };
 
-          const targetVertexId:
-            | GraphElementVertexIdNonTemporal
-            | GraphElementVertexIdTemporal = {
-            baseId: targetBaseId,
-            revisionId: mustBeDefined(
-              Object.keys(subgraph.vertices[targetBaseId]!).pop(),
-            ),
-          };
+            const targetVertexId: GraphElementVertexIdNonTemporal = {
+              baseId: targetBaseId,
+              revisionId: Object.keys(subgraph.vertices[targetBaseId]!).pop()!,
+            };
 
-          if (isOutgoingLinkEdgeTemporal(outwardEdge)) {
-            return [
-              mapGraphEdgeToEChartEdge(
-                sourceVertexId,
-                targetVertexId,
-                outwardEdge.kind,
-              ),
-            ];
-          } else if (isHasRightEntityEdgeTemporal(outwardEdge)) {
-            return [
-              mapGraphEdgeToEChartEdge(
-                sourceVertexId,
-                targetVertexId,
-                outwardEdge.kind,
-              ),
-            ];
+            return mapGraphEdgeToEChartEdge(
+              sourceVertexId,
+              targetVertexId,
+              outwardEdge.kind,
+              isOutgoingLinkEdgeNonTemporal(outwardEdgeTemporal)
+                ? "has outgoing link"
+                : "has target",
+            );
           }
           return [];
         }
@@ -388,14 +397,8 @@ const DataStoreGraphVisualizationComponent = ({
     setEChartEdges(getSubgraphEdgesAsEChartEdges(graph));
   }, [graph]);
 
-  const [selectedEntityRecordIdString, setSelectedEntityRecordIdString] =
+  const [selectedEntityVertexIdString, setSelectedEntityVertexIdString] =
     useState<string>();
-
-  /** @todo: un-comment if we want to display something about the currently selected entity */
-  // const selectedEntity = useMemo(
-  //   () => entities.find(({ entityId }) => entityId === selectedEntityRecordIdString),
-  //   [entities, selectedEntityRecordIdString],
-  // );
 
   useEffect(() => {
     if (chart) {
@@ -410,37 +413,71 @@ const DataStoreGraphVisualizationComponent = ({
   }, [chart, eChartEdges]);
 
   useEffect(() => {
-    if (chart && selectedEntityRecordIdString) {
+    if (chart && selectedEntityVertexIdString) {
       const outgoingLinkAndTargetEntities = isTemporalSubgraph(graph)
         ? getOutgoingLinkAndTargetEntitiesTemporal(
             graph,
-            (JSON.parse(selectedEntityRecordIdString) as EntityRecordIdTemporal)
-              .entityId,
+            (JSON.parse(selectedEntityVertexIdString) as EntityVertexIdTemporal)
+              .baseId,
           )
         : getOutgoingLinkAndTargetEntitiesNonTemporal(
             graph,
             (
               JSON.parse(
-                selectedEntityRecordIdString,
-              ) as EntityRecordIdNonTemporal
-            ).entityId,
+                selectedEntityVertexIdString,
+              ) as EntityVertexIdNonTemporal
+            ).baseId,
           );
 
       const neighbourIds = outgoingLinkAndTargetEntities.flatMap(
-        ({ linkEntity, rightEntity }) => [
-          JSON.stringify(
-            (Array.isArray(linkEntity) ? linkEntity[0]! : linkEntity).metadata
-              .recordId,
-          ),
-          JSON.stringify(
-            (Array.isArray(rightEntity) ? rightEntity[0]! : rightEntity)
-              .metadata.recordId,
-          ),
-        ],
+        ({ linkEntity, rightEntity }) => {
+          const vertexIdForRecordId = (
+            recordId: EntityRecordIdNonTemporal | EntityRecordIdTemporal,
+          ): EntityVertexIdNonTemporal | EntityVertexIdTemporal => {
+            for (const [baseId, revisionObject] of typedEntries(
+              graph.vertices,
+            )) {
+              for (const [revisionId, vertex] of typedEntries(revisionObject)) {
+                if (
+                  ((isTemporalSubgraph(graph) &&
+                    isEntityVertexTemporal(vertex as EntityVertexTemporal)) ||
+                    (!isTemporalSubgraph(graph) &&
+                      isEntityVertexNonTemporal(
+                        vertex as EntityVertexNonTemporal,
+                      ))) &&
+                  vertex.inner.metadata.recordId === recordId
+                ) {
+                  return {
+                    baseId,
+                    revisionId,
+                  };
+                }
+              }
+            }
+
+            throw new Error(
+              `Could not find entity vertex for recordId ${recordId}`,
+            );
+          };
+          return [
+            JSON.stringify(
+              vertexIdForRecordId(
+                (Array.isArray(linkEntity) ? linkEntity[0]! : linkEntity)
+                  .metadata.recordId,
+              ),
+            ),
+            JSON.stringify(
+              vertexIdForRecordId(
+                (Array.isArray(rightEntity) ? rightEntity[0]! : rightEntity)
+                  .metadata.recordId,
+              ),
+            ),
+          ];
+        },
       );
 
       const nodesWithVisibleLabelsIds = [
-        selectedEntityRecordIdString,
+        selectedEntityVertexIdString,
         ...neighbourIds,
       ];
 
@@ -463,14 +500,14 @@ const DataStoreGraphVisualizationComponent = ({
         })),
       );
     }
-  }, [chart, graph, selectedEntityRecordIdString]);
+  }, [chart, graph, selectedEntityVertexIdString]);
 
   useEffect(() => {
     if (!chart && eChartWrapperRef.current) {
       const initialisedChart = echarts.init(eChartWrapperRef.current);
 
       initialisedChart.on("click", { dataType: "node" }, ({ data: node }) =>
-        setSelectedEntityRecordIdString((node as EChartNode).id),
+        setSelectedEntityVertexIdString((node as EChartNode).id),
       );
 
       const initialOptions = createDefaultEChartOptions();


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

At some point in the previous changes the datastore visualization was broken in `mock-block-dock`. This PR fixes it, and improves upon the previous implementation by overriding the edge labels to make them more readable.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203358502199087/1203994531454209/f) _(internal)_

## 🚫 Blocked by

N/A

## 🔍 What does this change?

- Stop using `RecordId` as the ID's of the nodes, instead opting to use `VertexId`
- Improve a lot of the typings to rely on the actual typings of the library
- Improve the display label of edges by using a prettified name of the edge-kind, rather than the exceptionally long ID

## 📜 Does this require a change to the docs?

- I don't believe so

## ⚠️ Known issues

- This implementation was always a quick addition to add some functionality, there's a fair bit of UX work we can do to improve the component, including configuration options, filtering, etc.
- The usability of the graph is fairly strongly compromised due to relying on auto-generated entity IDs and a quickly-implemented `getLabel` function we've written. We have plans to think about label properties on entities, or other approaches, and we could benefit from that here.

## 🐾 Next steps

N/A

## 🛡 What tests cover this?

None to my knowledge

## ❓ How to test this?

- Checkout [Expand react block to allow creating links](https://github.com/blockprotocol/blockprotocol/commit/f2ad2c9a979dae0eddd062ac054486476cec4889)
- Create some entities and links
- Click on an entity in the visualization to see the direct neighbors are highlighted
- Delete entities to see that edges and such are correctly deleted

## 📹 Demo

https://user-images.githubusercontent.com/25749103/220348735-67abe9f7-ac17-41f6-97e3-e5d8e26fbd54.mov



