### PR TITLE
Fix entity default schema

### DIFF
--- a/apps/site/src/pages/api/types/entity-type/shared/schema.ts
+++ b/apps/site/src/pages/api/types/entity-type/shared/schema.ts
@@ -23,14 +23,14 @@ export const generateEntityTypeWithMetadata = (data: {
     version,
   });
 
-  const entityType = {
+  const entityType: Required<EntityType> = {
     additionalProperties: false,
     allOf: incompleteSchema.allOf ?? [],
     description: incompleteSchema.description ?? "",
     examples: incompleteSchema.examples ?? [],
     $id: versionedUri,
     kind,
-    links: incompleteSchema.links,
+    links: incompleteSchema.links ?? {},
     properties: incompleteSchema.properties ?? {},
     required: incompleteSchema.required ?? [],
     title: incompleteSchema.title,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

`null` is not a valid value for `EntityType["links"]`, but that's what it was being set as in the db if no value for it was provided.

This introduces a fallback to `{}`, which is valid, and prevents nullish fields being set on an `EntityType` to avoid further such traps (unless there is some future reason to allow `null` for any value).