### PR TITLE
Refetch user profile data on clientside navigation

### DIFF
--- a/apps/site/src/lib/blocks.ts
+++ b/apps/site/src/lib/blocks.ts
@@ -228,18 +228,6 @@ export const readBlocksFromDisk = async (): Promise<
   return result;
 };
 
-// Blocks which are currently not compliant with the spec, and are thus misleading examples
-const blocksToHide = ["@hash/embed"];
-
-/** Helps consistently hide certain blocks from the Hub and user profile pages */
-export const excludeHiddenBlocks = (
-  blocks: ExpandedBlockMetadata[],
-): ExpandedBlockMetadata[] => {
-  return blocks.filter(
-    ({ pathWithNamespace }) => !blocksToHide.includes(pathWithNamespace),
-  );
-};
-
 export const retrieveBlockFileContent = async ({
   pathWithNamespace,
   schema: metadataSchemaUrl,

--- a/apps/site/src/lib/excluded-blocks.ts
+++ b/apps/site/src/lib/excluded-blocks.ts
@@ -1,0 +1,13 @@
+import { ExpandedBlockMetadata } from "./blocks";
+
+// Blocks which are currently not compliant with the spec, and are thus misleading examples
+const blocksToHide = ["@hash/embed"];
+
+/** Helps consistently hide certain blocks from the Hub and user profile pages */
+export const excludeHiddenBlocks = (
+  blocks: ExpandedBlockMetadata[],
+): ExpandedBlockMetadata[] => {
+  return blocks.filter(
+    ({ pathWithNamespace }) => !blocksToHide.includes(pathWithNamespace),
+  );
+};


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The user profile page is currently fetching data via `getStaticProps`. This means that any data created/editing during a session is not available via client-side navigation, which is poor UX now that users are more likely to create and edit types.

This PR maintains the server-side rendering (blame suggests it was introduced to alleviate slow profile page loading), but also refetches the data client-side on additional renders / navigation.

We could alternative:
- just do this re-fetch once on mount, which would be sufficient to re-fetch the data when a user returned to the page from another route
- just do this re-fetch if the user changes, in case we somehow introduce the ability to navigate from one user's page to another
- do something else I haven't thought of, suggestions welcome

This should probably have an abort controller on it but it will involve feeding it through into the API client, which the fetches are going via. I will add this if people feel it's worth it now.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Go to profile page, look at types
2. Create a new type
3. Client-side nav back to profile page (avatar -> dashboard), check new type is there


