### PR TITLE
Add `additionalProperties: false` to property type objects

### DIFF
--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/error.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/error.rs
@@ -26,6 +26,4 @@ pub enum ParseEntityTypeError {
     InvalidVersionedUri(ParseVersionedUriError),
     #[error("error in JSON: `{0}`")]
     InvalidJson(String),
-    #[error("additional properties was set to `true` but must be `false`")]
-    InvalidAdditionalPropertiesValue,
 }

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/repr.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/repr.rs
@@ -42,8 +42,6 @@ pub struct EntityType {
     property_object: repr::Object<repr::ValueOrArray<repr::PropertyTypeReference>>,
     #[serde(flatten)]
     links: repr::Links,
-    #[cfg_attr(target_arch = "wasm32", tsify(type = "false"))]
-    additional_properties: bool,
 }
 
 impl TryFrom<EntityType> for super::EntityType {
@@ -85,10 +83,6 @@ impl TryFrom<EntityType> for super::EntityType {
             .try_into()
             .map_err(ParseEntityTypeError::InvalidLinks)?;
 
-        if entity_type_repr.additional_properties {
-            return Err(ParseEntityTypeError::InvalidAdditionalPropertiesValue);
-        }
-
         Ok(Self::new(
             id,
             entity_type_repr.title,
@@ -123,7 +117,6 @@ impl From<super::EntityType> for EntityType {
             all_of: entity_type.inherits_from.into(),
             examples,
             links: entity_type.links.into(),
-            additional_properties: false,
         }
     }
 }

--- a/libs/@blockprotocol/type-system/crate/src/ontology/shared/object/error.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/shared/object/error.rs
@@ -14,6 +14,8 @@ use crate::{
 pub enum ParsePropertyTypeObjectError {
     #[error("invalid property type reference: `{0}`")]
     InvalidPropertyTypeReference(ParseVersionedUriError),
+    #[error("additional properties was set to `true` but must be `false`")]
+    InvalidAdditionalPropertiesValue,
     #[error("invalid array definition: `{0}`")]
     InvalidArray(ParsePropertyTypeReferenceArrayError),
     #[error("invalid property key: `{0}`")]

--- a/libs/@blockprotocol/type-system/crate/src/ontology/shared/object/repr.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/shared/object/repr.rs
@@ -26,6 +26,8 @@ pub struct Object<T> {
     #[cfg_attr(target_arch = "wasm32", tsify(optional, type = "BaseUri[]"))]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     required: Vec<String>,
+    #[cfg_attr(target_arch = "wasm32", tsify(type = "false"))]
+    additional_properties: bool,
 }
 
 impl<const MIN: usize> TryFrom<Object<repr::ValueOrArray<repr::PropertyTypeReference>>>
@@ -56,6 +58,10 @@ impl<const MIN: usize> TryFrom<Object<repr::ValueOrArray<repr::PropertyTypeRefer
             })
             .collect::<Result<Vec<_>, Self::Error>>()?;
 
+        if object_repr.additional_properties {
+            return Err(ParsePropertyTypeObjectError::InvalidAdditionalPropertiesValue);
+        }
+
         Self::new(properties, required).map_err(ParsePropertyTypeObjectError::ValidationError)
     }
 }
@@ -79,6 +85,7 @@ where
             r#type: ObjectTypeTag::Object,
             properties,
             required,
+            additional_properties: false,
         }
     }
 }
@@ -112,6 +119,7 @@ mod tests {
                     r#type: ObjectTypeTag::Object,
                     properties: HashMap::new(),
                     required: vec![],
+                    additional_properties: false,
                 }),
             );
         }
@@ -135,6 +143,7 @@ mod tests {
                         PropertyTypeReference::new(uri.to_string()),
                     )]),
                     required: vec![],
+                    additional_properties: false,
                 }),
             );
         }
@@ -167,6 +176,7 @@ mod tests {
                         ),
                     ]),
                     required: vec![],
+                    additional_properties: false,
                 }),
             );
         }
@@ -196,6 +206,7 @@ mod tests {
                         PropertyTypeReference::new(uri.to_string()),
                     )]),
                     required: vec![],
+                    additional_properties: false,
                 }),
             );
         }
@@ -228,6 +239,7 @@ mod tests {
                         ),
                     ]),
                     required: vec![],
+                    additional_properties: false,
                 }),
             );
         }
@@ -264,6 +276,7 @@ mod tests {
                     ),
                 ]),
                 required: vec![uri_a.base_uri.to_string()],
+                additional_properties: false,
             }),
         );
     }

--- a/libs/@blockprotocol/type-system/crate/tests/data/property_type/contact_information.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/property_type/contact_information.json
@@ -15,7 +15,8 @@
       },
       "required": [
         "https://blockprotocol.org/@blockprotocol/types/property-type/email/"
-      ]
+      ],
+      "additionalProperties": false
     }
   ]
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/property_type/interests.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/property_type/interests.json
@@ -18,7 +18,8 @@
             "$ref": "https://blockprotocol.org/@blockprotocol/types/property-type/hobby/v/1"
           }
         }
-      }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/libs/@blockprotocol/type-system/test/entity-type.test.ts
+++ b/libs/@blockprotocol/type-system/test/entity-type.test.ts
@@ -500,7 +500,10 @@ const brokenTypes: [any, ParseEntityTypeError][] = [
       additionalProperties: true,
     },
     {
-      reason: "InvalidAdditionalPropertiesValue",
+      reason: "InvalidPropertyTypeObject",
+      inner: {
+        reason: "InvalidAdditionalPropertiesValue",
+      },
     },
   ],
 ];

--- a/libs/@blockprotocol/type-system/test/property-type.test.ts
+++ b/libs/@blockprotocol/type-system/test/property-type.test.ts
@@ -36,6 +36,7 @@ const propertyTypes: PropertyType[] = [
         required: [
           "https://blockprotocol.org/@blockprotocol/types/property-type/email/",
         ],
+        additionalProperties: false,
       },
     ],
   },
@@ -94,6 +95,7 @@ const propertyTypes: PropertyType[] = [
               },
             },
         },
+        additionalProperties: false,
       },
     ],
   },
@@ -248,6 +250,7 @@ const invalidPropertyTypes: [string, PropertyType, ParsePropertyTypeError][] = [
                 $ref: "https://blockprotocol.org/@blockprotocol/types/property-type/broken/v/1",
               },
           },
+          additionalProperties: false,
         },
       ],
     },
@@ -289,7 +292,7 @@ const brokenTypes: [any, ParsePropertyTypeError][] = [
   [
     {
       kind: "propertyType",
-      $id: "https://blockprotocol.org/@blockprotocol/types/property-type/broken/v/1",
+      $id: "https://blockprotocol.org/@blockprotocol/types/property-type/empty-one-of/v/1",
       title: "Broken",
       oneOf: [],
     },
@@ -301,6 +304,60 @@ const brokenTypes: [any, ParsePropertyTypeError][] = [
           type: "EmptyOneOf",
         },
       },
+    },
+  ],
+  [
+    {
+      kind: "propertyType",
+      $id: "https://blockprotocol.org/@blockprotocol/types/property-type/true-additional-properties/v/1",
+      title: "Broken",
+      oneOf: [
+        {
+          type: "object",
+          properties: {
+            "https://blockprotocol.org/@blockprotocol/types/property-type/broken/":
+              {
+                $ref: "https://blockprotocol.org/@blockprotocol/types/property-type/broken/v/1",
+              },
+          },
+          additionalProperties: true,
+        },
+      ],
+    },
+    {
+      reason: "InvalidOneOf",
+      inner: {
+        reason: "PropertyValuesError",
+        inner: {
+          reason: "InvalidPropertyTypeObject",
+          inner: {
+            reason: "InvalidAdditionalPropertiesValue",
+          },
+        },
+      },
+    },
+  ],
+  [
+    {
+      kind: "propertyType",
+      $id: "https://blockprotocol.org/@blockprotocol/types/property-type/missing-additional-properties/v/1",
+      title: "Broken",
+      oneOf: [
+        {
+          type: "object",
+          properties: {
+            "https://blockprotocol.org/@blockprotocol/types/property-type/broken/":
+              {
+                $ref: "https://blockprotocol.org/@blockprotocol/types/property-type/broken/v/1",
+              },
+          },
+        },
+      ],
+    },
+    {
+      inner:
+        "data did not match any variant of untagged enum PropertyValues at line 1 column 340",
+      reason: "InvalidJson",
     },
   ],
 ];


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#937 required "additionalProperties: false" on entity types. This also should be present on property type objects. This PR fixes that.

## 📜 Does this require a change to the docs?

This crate/package at the moment is treated as the source of truth and spec, the types being updated therefore constitute a change to the docs for now.

## ⚠️ Known issues

N/A

## 🐾 Next steps

N/A

## 🛡 What tests cover this?

- Type System crate tests
- Type system node package tests

## ❓ How to test this?

1.  Checkout the branch / view the deployment
1.  `yarn` should pass, rebuilding the Type System crate
1.  `yarn workspace @blockprotocol/type-system test` should pass
1.  `cargo make test` should pass inside the `type-system/crate` directory 
1.  `cargo make lint` should pass inside the `type-system/crate` directory
