### PR TITLE
Fix entity type updates

### DIFF
--- a/apps/site/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
+++ b/apps/site/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
@@ -65,15 +65,18 @@ const EntityTypePage: NextPage = () => {
       return;
     }
 
-    const schema = getSchemaFromFormData(data);
+    const newLinksAndProperties = getSchemaFromFormData(data);
+
+    const existingSchema = entityType.schema;
 
     const { data: responseData, error: responseError } =
       await apiClient.updateEntityType({
         versionedUri: entityType.schema.$id,
         schema: {
-          ...schema,
-          properties: schema.properties ?? {},
-          title: schema.title ?? entityType.schema.title,
+          ...existingSchema,
+          links: newLinksAndProperties.links ?? existingSchema.links ?? {},
+          properties:
+            newLinksAndProperties.properties ?? existingSchema.properties ?? {},
         },
       });
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `type-editor` package only deals with `links` and `properties` on an entity type, which means that the consumer is repsonsible for maintaining any other properties on an entity type, e.g. when updating.

The BP site wasn't doing that – this PR fixes that by adding in the existing entity type underneath whatever the type editor is sending as an update.

I am going to separately update the return of `getSchemaFromFormData` in the type editor which is currently a `Partial<EntityType>` to more accurately reflect 'links and properties only'