### PR TITLE
Fix entity type fix

### DIFF
--- a/apps/site/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
+++ b/apps/site/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
@@ -77,6 +77,8 @@ const EntityTypePage: NextPage = () => {
           links: newLinksAndProperties.links ?? existingSchema.links ?? {},
           properties:
             newLinksAndProperties.properties ?? existingSchema.properties ?? {},
+          required:
+            newLinksAndProperties.required ?? existingSchema.required ?? [],
         },
       });
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In #1012 I switched to only sending `properties` and `links` from the type editor because I thought that's all it sent. But it also sends `required`. This PR fixes that.