### PR TITLE
Fix HTML block in mock-block-dock

### DIFF
--- a/libs/mock-block-dock/dev/test-html-block/block.js
+++ b/libs/mock-block-dock/dev/test-html-block/block.js
@@ -3,7 +3,15 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck -- unable to typecheck GraphBlockHandler because of URL import
 
-import { GraphBlockHandler } from "https://esm.sh/@blockprotocol/graph@0.0.11";
+import {
+  extractBaseUri,
+  GraphBlockHandler,
+} from "https://esm.sh/@blockprotocol/graph@0.1.0-canary-20230223103409";
+import { getRoots } from "https://esm.sh/@blockprotocol/graph@0.1.0-canary-20230223103409/stdlib";
+
+const propertyTypeIds = {
+  name: "http://example.com/types/property-type/name/v/1",
+};
 
 const element = blockprotocol.getBlockContainer(import.meta.url);
 
@@ -12,17 +20,24 @@ const paragraph = element.querySelector("[data-paragraph]");
 const input = element.querySelector("[data-input]");
 const readonlyParagraph = element.querySelector("[data-readonly]");
 
-let entityId;
+let entity;
 
 const handler = new GraphBlockHandler({
   element,
   callbacks: {
-    blockEntity: (entity) => {
-      entityId = entity.data.entityId;
+    blockEntitySubgraph: ({ data: entitySubgraph }) => {
+      entity = getRoots(entitySubgraph)[0];
+      if (!entity) {
+        throw new Error(
+          "Couldn't find block entity in the roots of the subgraph",
+        );
+      }
 
-      title.innerText = `Hello, ${entity.data.properties.name}`;
-      paragraph.innerText = `The entityId of this block is ${entity.data.entityId}. Use it to update its data when calling updateEntity`;
-      input.value = entity.data.properties.name;
+      title.innerText = `Hello, ${
+        entity.properties[extractBaseUri(propertyTypeIds.name)]
+      }`;
+      paragraph.innerText = `The entityId of this block is ${entity.metadata.recordId.entityId}. Use it to update its data when calling updateEntity`;
+      input.value = entity.properties[extractBaseUri(propertyTypeIds.name)];
       readonlyParagraph.innerText = input.value;
     },
     readonly: ({ data: readonly }) => {
@@ -40,12 +55,15 @@ const handler = new GraphBlockHandler({
 });
 
 input.addEventListener("change", (event) => {
-  if (entityId) {
+  if (entity) {
     handler
       .updateEntity({
         data: {
-          entityId,
-          properties: { name: event.target.value },
+          entityId: entity.metadata.recordId.entityId,
+          entityTypeId: entity.metadata.entityTypeId,
+          properties: {
+            [extractBaseUri(propertyTypeIds.name)]: event.target.value,
+          },
         },
       })
       .catch((err) => {

--- a/libs/mock-block-dock/src/mock-block-dock.tsx
+++ b/libs/mock-block-dock/src/mock-block-dock.tsx
@@ -394,7 +394,7 @@ const MockBlockDockTemporal: FunctionComponent<
     [blockProtocolApiKey, serviceModuleCallbacksFromProps],
   );
 
-  const { serviceModule: _serviceModule } = useServiceEmbedderModule(
+  useServiceEmbedderModule(
     wrapperRef,
     {
       callbacks: serviceModuleCallbacks,

--- a/libs/mock-block-dock/src/mock-block-dock.tsx
+++ b/libs/mock-block-dock/src/mock-block-dock.tsx
@@ -394,9 +394,12 @@ const MockBlockDockTemporal: FunctionComponent<
     [blockProtocolApiKey, serviceModuleCallbacksFromProps],
   );
 
-  const { serviceModule } = useServiceEmbedderModule(wrapperRef, {
-    callbacks: serviceModuleCallbacks,
-  });
+  const { serviceModule: _serviceModule } = useServiceEmbedderModule(
+    wrapperRef,
+    {
+      callbacks: serviceModuleCallbacks,
+    },
+  );
 
   const hookCallback = useCallback<HookEmbedderMessageCallbacks["hook"]>(
     async ({ data }) => {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The HTML block was broken, with #1006 it could be fixed.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203358502199087/1203866892869243/f) _(internal)_

## 🚫 Blocked by

N/A

## 🔍 What does this change?

- Updates the versions of the dependencies used in the HTML block
- Updates the callbacks to the new ones
- Replaces properties access with BaseURIs
- Driveby fixes ESLint

## 📜 Does this require a change to the docs?

Not to my knowledge

## ⚠️ Known issues

- There's a chicken and egg problem at the moment where we need to publish a version of the packages before being able to update the HTML block due to using `esm.sh`
- It's quite slow to load, and it's not clear it's trying to load while that happens

## 🐾 Next steps

N/A

## 🛡 What tests cover this?

None

## ❓ How to test this?

Run MBD, check the two HTML block variants work

## 📹 Demo

<img width="973" alt="image" src="https://user-images.githubusercontent.com/25749103/220887591-ad7a3998-1f70-4081-a376-95e4391e4b2d.png">
<img width="929" alt="image" src="https://user-images.githubusercontent.com/25749103/220887654-986e0cc8-ea7f-4e5c-a0dd-9bb10d5d1af1.png">

