### PR TITLE
Make blockEntitySubgraph required in graph properties sent to block

### DIFF
--- a/libs/@blockprotocol/core/src/react.ts
+++ b/libs/@blockprotocol/core/src/react.ts
@@ -16,7 +16,10 @@ export const useModuleConstructor = <T extends ModuleHandler>({
   ref,
 }: {
   Handler: ModuleConstructor<T>;
-  constructorArgs?: { callbacks?: Record<string, GenericMessageCallback> };
+  constructorArgs?: Omit<
+    ConstructorParameters<ModuleConstructor<T>>[0],
+    "element"
+  >;
   ref: RefObject<HTMLElement>;
 }) => {
   const previousRef = useRef<HTMLElement | null>(null);

--- a/libs/@blockprotocol/graph/src/non-temporal/custom-element.ts
+++ b/libs/@blockprotocol/graph/src/non-temporal/custom-element.ts
@@ -66,10 +66,6 @@ export abstract class BlockElementBase<
    * i.e. the 'block entity'
    */
   protected getBlockEntity(): RootEntity {
-    if (!this.graph || !this.graph.blockEntitySubgraph) {
-      throw new Error("graph.blockEntitySubgraph was not passed to block.");
-    }
-
     const blockEntity = getRoots(this.graph.blockEntitySubgraph)[0];
     if (!blockEntity) {
       throw new Error(

--- a/libs/@blockprotocol/graph/src/non-temporal/graph-embedder-handler.ts
+++ b/libs/@blockprotocol/graph/src/non-temporal/graph-embedder-handler.ts
@@ -18,7 +18,7 @@ export class GraphEmbedderHandler
   extends ModuleHandler
   implements GraphEmbedderMessages
 {
-  private _blockEntitySubgraph?: Subgraph<EntityRootType>;
+  private _blockEntitySubgraph: Subgraph<EntityRootType>;
   // private _linkedAggregations?: LinkedAggregations;
   private _readonly?: boolean;
 
@@ -29,7 +29,7 @@ export class GraphEmbedderHandler
     // linkedAggregations,
     readonly,
   }: {
-    blockEntitySubgraph?: Subgraph<EntityRootType>;
+    blockEntitySubgraph: Subgraph<EntityRootType>;
     callbacks?: Partial<GraphEmbedderMessageCallbacks>;
     element?: HTMLElement | null;
     // linkedAggregations?: LinkedAggregations;
@@ -96,6 +96,9 @@ export class GraphEmbedderHandler
   }
 
   blockEntitySubgraph({ data }: { data?: Subgraph<EntityRootType> }) {
+    if (!data) {
+      throw new Error("'data' must be provided with blockEntitySubgraph");
+    }
     this._blockEntitySubgraph = data;
     this.sendMessage({
       message: {

--- a/libs/@blockprotocol/graph/src/non-temporal/main.ts
+++ b/libs/@blockprotocol/graph/src/non-temporal/main.ts
@@ -219,7 +219,7 @@ export type BlockGraphProperties<RootEntity extends Entity = Entity> = {
    * @see https://blockprotocol.org/docs/spec/graph-module#message-definitions for a full list
    */
   graph: {
-    blockEntitySubgraph?: Subgraph<{
+    blockEntitySubgraph: Subgraph<{
       vertexId: EntityVertexId;
       element: RootEntity;
     }>;

--- a/libs/@blockprotocol/graph/src/non-temporal/react.ts
+++ b/libs/@blockprotocol/graph/src/non-temporal/react.ts
@@ -45,13 +45,13 @@ export const useGraphBlockModule = (
  */
 export const useGraphEmbedderModule = (
   ref: RefObject<HTMLElement>,
-  constructorArgs?: Omit<
+  constructorArgs: Omit<
     ConstructorParameters<typeof GraphEmbedderHandler>[0],
     "element"
   >,
 ): { graphModule: GraphEmbedderHandler } => ({
   graphModule: useModuleConstructor({
-    Handler: GraphEmbedderHandler,
+    Handler: GraphEmbedderHandler as { new (): GraphEmbedderHandler },
     ref,
     constructorArgs,
   }),

--- a/libs/@blockprotocol/graph/src/temporal/custom-element.ts
+++ b/libs/@blockprotocol/graph/src/temporal/custom-element.ts
@@ -68,9 +68,6 @@ export abstract class BlockElementBase<
    * i.e. the 'block entity'
    */
   getBlockEntity() {
-    if (!this.graph || !this.graph.blockEntitySubgraph) {
-      throw new Error("graph.blockEntitySubgraph was not passed to block.");
-    }
     const blockEntity = getRoots(this.graph.blockEntitySubgraph)[0];
     if (!blockEntity) {
       throw new Error(

--- a/libs/@blockprotocol/graph/src/temporal/graph-embedder-handler.ts
+++ b/libs/@blockprotocol/graph/src/temporal/graph-embedder-handler.ts
@@ -18,7 +18,7 @@ export class GraphEmbedderHandler
   extends ModuleHandler
   implements GraphEmbedderMessages
 {
-  private _blockEntitySubgraph?: Subgraph<EntityRootType>;
+  private _blockEntitySubgraph: Subgraph<EntityRootType>;
   // private _linkedAggregations?: LinkedAggregations;
   private _readonly?: boolean;
 
@@ -29,7 +29,7 @@ export class GraphEmbedderHandler
     // linkedAggregations,
     readonly,
   }: {
-    blockEntitySubgraph?: Subgraph<EntityRootType>;
+    blockEntitySubgraph: Subgraph<EntityRootType>;
     callbacks?: Partial<GraphEmbedderMessageCallbacks>;
     element?: HTMLElement | null;
     // linkedAggregations?: LinkedAggregations;
@@ -96,6 +96,9 @@ export class GraphEmbedderHandler
   }
 
   blockEntitySubgraph({ data }: { data?: Subgraph<EntityRootType> }) {
+    if (!data) {
+      throw new Error("'data' must be provided with blockEntitySubgraph");
+    }
     this._blockEntitySubgraph = data;
     this.sendMessage({
       message: {

--- a/libs/@blockprotocol/graph/src/temporal/main.ts
+++ b/libs/@blockprotocol/graph/src/temporal/main.ts
@@ -220,7 +220,7 @@ export type BlockGraphProperties<RootEntity extends Entity = Entity> = {
    * @see https://blockprotocol.org/docs/spec/graph-module#message-definitions for a full list
    */
   graph: {
-    blockEntitySubgraph?: Subgraph<{
+    blockEntitySubgraph: Subgraph<{
       vertexId: EntityVertexId;
       element: RootEntity;
     }>;

--- a/libs/@blockprotocol/graph/src/temporal/react.ts
+++ b/libs/@blockprotocol/graph/src/temporal/react.ts
@@ -45,13 +45,13 @@ export const useGraphBlockModule = (
  */
 export const useGraphEmbedderModule = (
   ref: RefObject<HTMLElement>,
-  constructorArgs?: Omit<
+  constructorArgs: Omit<
     ConstructorParameters<typeof GraphEmbedderHandler>[0],
     "element"
   >,
 ): { graphModule: GraphEmbedderHandler } => ({
   graphModule: useModuleConstructor({
-    Handler: GraphEmbedderHandler,
+    Handler: GraphEmbedderHandler as { new (): GraphEmbedderHandler },
     ref,
     constructorArgs,
   }),

--- a/libs/block-template-react/src/app.tsx
+++ b/libs/block-template-react/src/app.tsx
@@ -54,10 +54,6 @@ export const App: BlockComponent<RootEntity> = ({
   const blockRootRef = useRef<HTMLDivElement>(null);
   const { graphModule } = useGraphBlockModule(blockRootRef);
 
-  if (!blockEntitySubgraph) {
-    throw new Error("No blockEntitySubgraph provided");
-  }
-
   const { rootEntity: blockEntity } = useEntitySubgraph<
     RootEntity,
     RootEntityLinkedEntities

--- a/libs/mock-block-dock/dev/test-react-block.tsx
+++ b/libs/mock-block-dock/dev/test-react-block.tsx
@@ -69,7 +69,7 @@ export const TestReactBlock: BlockComponent = ({ graph }) => {
         setOpenaiCompleteTextResponse(response.data);
       }
     },
-    [mapboxSuggestSearchText, serviceModule],
+    [openaiCompleteTextPrompt, serviceModule],
   );
 
   const handleMapboxSuggestSubmit = useCallback(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The block entity subgraph is a fundamental part of a block that works with the graph module. So much so that it seems silly to have it something that the embedding application can choose not to send to the block, which leads to having to check for its existence all over the place, always throwing an error if it doesn't exist because most graph-dependent blocks won't function without it.

This PR makes `blockEntitySubgraph` a required part of the `graph` messages sent to a block.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203358502199087/1203701650452072/f) _(internal)_
