### PR TITLE
Remove `additionalProperties` from Entity Type and Property Type schemas

### DIFF
--- a/apps/site/public/types/modules/graph/0.3/schema/entity-type.json
+++ b/apps/site/public/types/modules/graph/0.3/schema/entity-type.json
@@ -92,13 +92,7 @@
     }
   },
   "additionalProperties": false,
-  "required": [
-    "$schema",
-    "kind",
-    "$id",
-    "title",
-    "properties",
-  ],
+  "required": ["$schema", "kind", "$id", "title", "properties"],
   "$defs": {
     "oneOfEntityTypeReference": {
       "description": "Specifies a set of entity types inside a oneOf",

--- a/apps/site/public/types/modules/graph/0.3/schema/entity-type.json
+++ b/apps/site/public/types/modules/graph/0.3/schema/entity-type.json
@@ -89,10 +89,6 @@
           "additionalProperties": false
         }
       }
-    },
-    "additionalProperties": {
-      "type": "boolean",
-      "const": false
     }
   },
   "additionalProperties": false,
@@ -102,7 +98,6 @@
     "$id",
     "title",
     "properties",
-    "additionalProperties"
   ],
   "$defs": {
     "oneOfEntityTypeReference": {

--- a/apps/site/public/types/modules/graph/0.3/schema/property-type.json
+++ b/apps/site/public/types/modules/graph/0.3/schema/property-type.json
@@ -49,14 +49,9 @@
             "properties": {
               "$ref": "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type-object"
             },
-            "minimumProperties": 1,
-            "additionalProperties": {
-              "type": "boolean",
-              "const": false
-            }
+            "minimumProperties": 1
           },
-          "required": ["type", "properties", "additionalProperties"],
-          "additionalProperties": false
+          "required": ["type", "properties"]
         },
         {
           "title": "propertyArrayValue",

--- a/apps/site/src/middleware.page/return-types-as-json/hardcoded-types.ts
+++ b/apps/site/src/middleware.page/return-types-as-json/hardcoded-types.ts
@@ -7,7 +7,6 @@ export const hardcodedTypes = {
     type: "object",
     title: "Link",
     properties: {},
-    additionalProperties: false,
   },
   // @todo replace below data types with types in db when data type hosting available
   "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1": {

--- a/apps/site/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
+++ b/apps/site/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
@@ -58,7 +58,8 @@ const EntityTypePage: NextPage = () => {
   const setEntityType = useCallback(
     (stateToSet: EntityTypeState) => {
       setEntityTypeState(stateToSet);
-      reset(getFormDataFromSchema(stateToSet.entityType.schema));
+      /* @todo remove these casts when @hashintel/type-editor uses a new version of @blockprotocol/type-system */
+      reset(getFormDataFromSchema(stateToSet.entityType.schema as any));
       void router.push(stateToSet.entityType.schema.$id);
     },
     [reset, router, setEntityTypeState],

--- a/apps/site/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/entity-type-form.tsx
+++ b/apps/site/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/entity-type-form.tsx
@@ -239,12 +239,14 @@ export const EntityTypeForm = ({
   if (!entityTypeOptions || !propertyTypeOptions) {
     return <>Loading...</>;
   }
+
+  /* @todo remove these casts when @hashintel/type-editor uses a new version of @blockprotocol/type-system */
   return (
     <EntityTypeEditor
-      entityType={entityType.schema}
-      entityTypeOptions={entityTypeOptions}
+      entityType={entityType as any}
+      entityTypeOptions={entityTypeOptions as any}
       ontologyFunctions={ontologyFunctions}
-      propertyTypeOptions={propertyTypeOptions}
+      propertyTypeOptions={propertyTypeOptions as any}
       readonly={readonly}
     />
   );

--- a/apps/site/src/pages/api/types/entity-type/shared/db.ts
+++ b/apps/site/src/pages/api/types/entity-type/shared/db.ts
@@ -9,6 +9,7 @@ import { Db, ObjectId } from "mongodb";
 import { User } from "../../../../../lib/api/model/user.model";
 import { generateOntologyUrl } from "../../../../shared/schema";
 import { SystemDefinedProperties } from "../../shared/constants";
+import { removeAdditionalProperties } from "../../shared/temp-patch";
 import { generateEntityTypeWithMetadata } from "./schema";
 
 export const COLLECTION_NAME = "bp-entity-types";
@@ -141,6 +142,9 @@ export const createEntityType = async (
 
   const now = new Date();
 
+  /* @todo - remove this when the type-editor uses a newer version of the type-system */
+  removeAdditionalProperties(entityTypeWithMetadata);
+
   const insertionData = {
     entityTypeWithMetadata,
     createdAt: now,
@@ -202,6 +206,9 @@ export const updateEntityType = async (
       }`,
     );
   }
+
+  /* @todo - remove this when the type-editor uses a newer version of the type-system */
+  removeAdditionalProperties(entityTypeWithMetadata);
 
   const now = new Date();
 

--- a/apps/site/src/pages/api/types/entity-type/shared/schema.ts
+++ b/apps/site/src/pages/api/types/entity-type/shared/schema.ts
@@ -24,7 +24,6 @@ export const generateEntityTypeWithMetadata = (data: {
   });
 
   const entityType: Required<EntityType> = {
-    additionalProperties: false,
     allOf: incompleteSchema.allOf ?? [],
     description: incompleteSchema.description ?? "",
     examples: incompleteSchema.examples ?? [],

--- a/apps/site/src/pages/api/types/property-type/shared/db.ts
+++ b/apps/site/src/pages/api/types/property-type/shared/db.ts
@@ -12,6 +12,7 @@ import { Db, ObjectId } from "mongodb";
 import { User } from "../../../../../lib/api/model/user.model";
 import { generateOntologyUrl } from "../../../../shared/schema";
 import { SystemDefinedProperties } from "../../shared/constants";
+import { removeAdditionalProperties } from "../../shared/temp-patch";
 import { generatePropertyTypeWithMetadata } from "./schema";
 
 export const COLLECTION_NAME = "bp-property-types";
@@ -140,6 +141,9 @@ export const createPropertyType = async (
     );
   }
 
+  /* @todo - remove this when the type-editor uses a newer version of the type-system */
+  removeAdditionalProperties(propertyTypeWithMetadata);
+
   const now = new Date();
 
   const insertionData = {
@@ -205,6 +209,9 @@ export const updatePropertyType = async (
       }`,
     );
   }
+
+  /* @todo - remove this when the type-editor uses a newer version of the type-system */
+  removeAdditionalProperties(propertyTypeWithMetadata);
 
   const now = new Date();
 

--- a/apps/site/src/pages/api/types/shared/constants.ts
+++ b/apps/site/src/pages/api/types/shared/constants.ts
@@ -1,7 +1,3 @@
 export const DEFAULT_$ID_ORIGIN = "https://blockprotocol.org";
 
-export type SystemDefinedProperties =
-  | "$id"
-  | "kind"
-  | "additionalProperties"
-  | "type";
+export type SystemDefinedProperties = "$id" | "kind" | "type";

--- a/apps/site/src/pages/api/types/shared/temp-patch.ts
+++ b/apps/site/src/pages/api/types/shared/temp-patch.ts
@@ -1,0 +1,11 @@
+/* @todo - remove this when the type-editor uses a newer version of the type-system */
+export const removeAdditionalProperties = (object: Record<string, unknown>) => {
+  for (const key in object) {
+    if (key === "additionalProperties") {
+      // eslint-disable-next-line no-param-reassign -- we want to mutate
+      delete object[key];
+    } else if (typeof object[key] === "object") {
+      removeAdditionalProperties(object[key] as Record<string, unknown>);
+    }
+  }
+};

--- a/libs/@blockprotocol/graph/src/shared/codegen/entity-type-meta-schema.json
+++ b/libs/@blockprotocol/graph/src/shared/codegen/entity-type-meta-schema.json
@@ -83,14 +83,10 @@
           "additionalProperties": false
         }
       }
-    },
-    "additionalProperties": {
-      "type": "boolean",
-      "const": false
     }
   },
   "additionalProperties": false,
-  "required": ["kind", "$id", "title", "properties", "additionalProperties"],
+  "required": ["kind", "$id", "title", "properties"],
   "$defs": {
     "propertyTypeObject": {
       "type": "object",

--- a/libs/@blockprotocol/graph/src/shared/codegen/entity-type-to-typescript.ts
+++ b/libs/@blockprotocol/graph/src/shared/codegen/entity-type-to-typescript.ts
@@ -162,7 +162,7 @@ const _jsonSchemaToTypeScript = async (
       title: propertyTypeName,
     },
     {
-      additionalProperties: false, // @todo add additionalProperties: false to entity type JSON schemas
+      additionalProperties: false,
       bannerComment: rootSchema ? bannerComment(schema.$id, depth) : "",
     },
   );

--- a/libs/@blockprotocol/graph/src/shared/codegen/hardcoded-bp-types.ts
+++ b/libs/@blockprotocol/graph/src/shared/codegen/hardcoded-bp-types.ts
@@ -8,7 +8,6 @@ export const hardcodedBpTypes = {
       leftEntityId: { type: "string" },
       rightEntityId: { type: "string" },
     },
-    additionalProperties: false,
   },
   "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1": {
     kind: "dataType",

--- a/libs/@blockprotocol/graph/src/shared/types/ontology/entity-type.ts
+++ b/libs/@blockprotocol/graph/src/shared/types/ontology/entity-type.ts
@@ -27,11 +27,7 @@ export type GetEntityTypeData = {
   entityTypeId: VersionedUrl;
 };
 
-type SystemDefinedEntityTypeProperties =
-  | "$id"
-  | "additionalProperties"
-  | "kind"
-  | "type";
+type SystemDefinedEntityTypeProperties = "$id" | "kind" | "type";
 
 export type CreateEntityTypeData = {
   entityType: Omit<EntityType, SystemDefinedEntityTypeProperties>;

--- a/libs/@blockprotocol/type-system/crate/src/ontology/shared/object/error.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/shared/object/error.rs
@@ -14,8 +14,6 @@ use crate::{
 pub enum ParsePropertyTypeObjectError {
     #[error("invalid property type reference: `{0}`")]
     InvalidPropertyTypeReference(ParseVersionedUrlError),
-    #[error("additional properties was set to `true` but must be `false`")]
-    InvalidAdditionalPropertiesValue,
     #[error("invalid array definition: `{0}`")]
     InvalidArray(ParsePropertyTypeReferenceArrayError),
     #[error("invalid property key: `{0}`")]

--- a/libs/@blockprotocol/type-system/crate/src/ontology/shared/object/repr.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/shared/object/repr.rs
@@ -26,8 +26,6 @@ pub struct Object<T> {
     #[cfg_attr(target_arch = "wasm32", tsify(optional, type = "BaseUrl[]"))]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     required: Vec<String>,
-    #[cfg_attr(target_arch = "wasm32", tsify(type = "false"))]
-    additional_properties: bool,
 }
 
 impl<const MIN: usize> TryFrom<Object<repr::ValueOrArray<repr::PropertyTypeReference>>>
@@ -58,10 +56,6 @@ impl<const MIN: usize> TryFrom<Object<repr::ValueOrArray<repr::PropertyTypeRefer
             })
             .collect::<Result<Vec<_>, Self::Error>>()?;
 
-        if object_repr.additional_properties {
-            return Err(ParsePropertyTypeObjectError::InvalidAdditionalPropertiesValue);
-        }
-
         Self::new(properties, required).map_err(ParsePropertyTypeObjectError::ValidationError)
     }
 }
@@ -85,7 +79,6 @@ where
             r#type: ObjectTypeTag::Object,
             properties,
             required,
-            additional_properties: false,
         }
     }
 }
@@ -119,7 +112,6 @@ mod tests {
                     r#type: ObjectTypeTag::Object,
                     properties: HashMap::new(),
                     required: vec![],
-                    additional_properties: false,
                 }),
             );
         }
@@ -143,7 +135,6 @@ mod tests {
                         PropertyTypeReference::new(url.to_string()),
                     )]),
                     required: vec![],
-                    additional_properties: false,
                 }),
             );
         }
@@ -176,7 +167,6 @@ mod tests {
                         ),
                     ]),
                     required: vec![],
-                    additional_properties: false,
                 }),
             );
         }
@@ -206,7 +196,6 @@ mod tests {
                         PropertyTypeReference::new(url.to_string()),
                     )]),
                     required: vec![],
-                    additional_properties: false,
                 }),
             );
         }
@@ -239,7 +228,6 @@ mod tests {
                         ),
                     ]),
                     required: vec![],
-                    additional_properties: false,
                 }),
             );
         }
@@ -276,7 +264,6 @@ mod tests {
                     ),
                 ]),
                 required: vec![url_a.base_url.to_string()],
-                additional_properties: false,
             }),
         );
     }

--- a/libs/@blockprotocol/type-system/crate/src/ontology/url/mod.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/url/mod.rs
@@ -115,12 +115,13 @@ impl FromStr for VersionedUrl {
     type Err = ParseVersionedUrlError;
 
     fn from_str(url: &str) -> Result<Self, ParseVersionedUrlError> {
+        static RE: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r#"(.+/)v/(\d+)(.*)"#).expect("regex failed to compile"));
+
         if url.len() > 2048 {
             return Err(ParseVersionedUrlError::TooLong);
         }
 
-        static RE: LazyLock<Regex> =
-            LazyLock::new(|| Regex::new(r#"(.+/)v/(\d+)(.*)"#).expect("regex failed to compile"));
         let captures = RE
             .captures(url)
             .ok_or(ParseVersionedUrlError::IncorrectFormatting)?;

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/address.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/address.json
@@ -18,6 +18,5 @@
     "https://blockprotocol.org/@alice/types/property-type/address-line-1/",
     "https://blockprotocol.org/@alice/types/property-type/postcode/",
     "https://blockprotocol.org/@alice/types/property-type/city/"
-  ],
-  "additionalProperties": false
+  ]
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/block.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/block.json
@@ -8,6 +8,5 @@
       "$ref": "https://blockprotocol.org/@alice/types/property-type/name/v/1"
     }
   },
-  "required": ["https://blockprotocol.org/@alice/types/property-type/name/"],
-  "additionalProperties": false
+  "required": ["https://blockprotocol.org/@alice/types/property-type/name/"]
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/book.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/book.json
@@ -30,6 +30,5 @@
       },
       "ordered": false
     }
-  },
-  "additionalProperties": false
+
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/book.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/book.json
@@ -30,5 +30,5 @@
       },
       "ordered": false
     }
-
+  }
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/building.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/building.json
@@ -28,6 +28,5 @@
       },
       "ordered": false
     }
-  },
-  "additionalProperties": false
+
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/building.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/building.json
@@ -28,5 +28,5 @@
       },
       "ordered": false
     }
-
+  }
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/organization.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/organization.json
@@ -8,5 +8,5 @@
     "https://blockprotocol.org/@alice/types/property-type/name/": {
       "$ref": "https://blockprotocol.org/@alice/types/property-type/name/v/1"
     }
-
+  }
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/organization.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/organization.json
@@ -8,6 +8,5 @@
     "https://blockprotocol.org/@alice/types/property-type/name/": {
       "$ref": "https://blockprotocol.org/@alice/types/property-type/name/v/1"
     }
-  },
-  "additionalProperties": false
+
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/page.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/page.json
@@ -31,6 +31,5 @@
       },
       "ordered": true
     }
-  },
-  "additionalProperties": false
+
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/page.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/page.json
@@ -31,5 +31,5 @@
       },
       "ordered": true
     }
-
+  }
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/person.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/person.json
@@ -25,6 +25,5 @@
       "items": {},
       "ordered": false
     }
-  },
-  "additionalProperties": false
+
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/person.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/person.json
@@ -25,5 +25,5 @@
       "items": {},
       "ordered": false
     }
-
+  }
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/playlist.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/playlist.json
@@ -20,6 +20,5 @@
       },
       "ordered": true
     }
-  },
-  "additionalProperties": false
+  }
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/entity_type/song.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/entity_type/song.json
@@ -7,6 +7,5 @@
     "https://blockprotocol.org/@alice/types/property-type/name/": {
       "$ref": "https://blockprotocol.org/@alice/types/property-type/name/v/1"
     }
-  },
-  "additionalProperties": false
+  }
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/property_type/contact_information.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/property_type/contact_information.json
@@ -15,8 +15,7 @@
       },
       "required": [
         "https://blockprotocol.org/@blockprotocol/types/property-type/email/"
-      ],
-      "additionalProperties": false
+      ]
     }
   ]
 }

--- a/libs/@blockprotocol/type-system/crate/tests/data/property_type/interests.json
+++ b/libs/@blockprotocol/type-system/crate/tests/data/property_type/interests.json
@@ -18,8 +18,7 @@
             "$ref": "https://blockprotocol.org/@blockprotocol/types/property-type/hobby/v/1"
           }
         }
-      },
-      "additionalProperties": false
+      }
     }
   ]
 }

--- a/libs/@blockprotocol/type-system/test/entity-type.test.ts
+++ b/libs/@blockprotocol/type-system/test/entity-type.test.ts
@@ -27,7 +27,6 @@ const entityTypes: EntityType[] = [
       "https://blockprotocol.org/@alice/types/property-type/postcode/",
       "https://blockprotocol.org/@alice/types/property-type/city/",
     ],
-    additionalProperties: false,
   },
   {
     kind: "entityType",
@@ -50,7 +49,6 @@ const entityTypes: EntityType[] = [
           "YourBlock",
       },
     ],
-    additionalProperties: false,
   },
   {
     kind: "entityType",
@@ -86,7 +84,6 @@ const entityTypes: EntityType[] = [
       },
     },
     examples: [],
-    additionalProperties: false,
   },
   {
     kind: "entityType",
@@ -119,7 +116,6 @@ const entityTypes: EntityType[] = [
         ordered: false,
       },
     },
-    additionalProperties: false,
   },
   {
     kind: "entityType",
@@ -131,7 +127,6 @@ const entityTypes: EntityType[] = [
         $ref: "https://blockprotocol.org/@alice/types/property-type/name/v/1",
       },
     },
-    additionalProperties: false,
   },
   {
     kind: "entityType",
@@ -144,7 +139,6 @@ const entityTypes: EntityType[] = [
         $ref: "https://blockprotocol.org/@alice/types/property-type/name/v/1",
       },
     },
-    additionalProperties: false,
   },
   {
     kind: "entityType",
@@ -180,7 +174,6 @@ const entityTypes: EntityType[] = [
         ordered: true,
       },
     },
-    additionalProperties: false,
   },
   {
     kind: "entityType",
@@ -210,7 +203,6 @@ const entityTypes: EntityType[] = [
         ordered: false,
       },
     },
-    additionalProperties: false,
   },
   {
     kind: "entityType",
@@ -235,7 +227,6 @@ const entityTypes: EntityType[] = [
         ordered: true,
       },
     },
-    additionalProperties: false,
   },
   {
     kind: "entityType",
@@ -247,7 +238,6 @@ const entityTypes: EntityType[] = [
         $ref: "https://blockprotocol.org/@alice/types/property-type/name/v/1",
       },
     },
-    additionalProperties: false,
   },
   {
     kind: "entityType",
@@ -260,7 +250,6 @@ const entityTypes: EntityType[] = [
       },
     ],
     properties: {},
-    additionalProperties: false,
   },
 ];
 
@@ -280,7 +269,6 @@ const invalidEntityTypes: [string, EntityType, ParseEntityTypeError][] = [
             $ref: "https://blockprotocol.org/@alice/types/property-type/address-line-1/v/1",
           },
       },
-      additionalProperties: false,
     },
     {
       reason: "InvalidVersionedUrl",
@@ -302,7 +290,6 @@ const invalidEntityTypes: [string, EntityType, ParseEntityTypeError][] = [
             $ref: "https://blockprotocol.org/@alice/types/property-type/address-line-1/v/1",
           },
       },
-      additionalProperties: false,
     },
     {
       reason: "InvalidVersionedUrl",
@@ -328,7 +315,6 @@ const invalidEntityTypes: [string, EntityType, ParseEntityTypeError][] = [
             $ref: "im a broken ref haha /v/1",
           },
       },
-      additionalProperties: false,
     },
     {
       reason: "InvalidPropertyTypeObject",
@@ -357,7 +343,6 @@ const invalidEntityTypes: [string, EntityType, ParseEntityTypeError][] = [
             $ref: "https://blockprotocol.org/@alice/types/property-type/address-line-1/v/1",
           },
       },
-      additionalProperties: false,
     },
     {
       reason: "InvalidPropertyTypeObject",
@@ -395,7 +380,6 @@ const invalidEntityTypes: [string, EntityType, ParseEntityTypeError][] = [
           ordered: false,
         },
       },
-      additionalProperties: false,
     },
     {
       reason: "InvalidPropertyTypeObject",
@@ -433,7 +417,6 @@ const invalidEntityTypes: [string, EntityType, ParseEntityTypeError][] = [
           ordered: false,
         },
       },
-      additionalProperties: false,
     },
     {
       reason: "InvalidPropertyTypeObject",
@@ -458,7 +441,6 @@ const invalidEntityTypes: [string, EntityType, ParseEntityTypeError][] = [
         },
       ],
       properties: {},
-      additionalProperties: false,
     },
     {
       reason: "InvalidAllOf",
@@ -487,23 +469,6 @@ const brokenTypes: [any, ParseEntityTypeError][] = [
     {
       reason: "InvalidJson",
       inner: "missing field `kind` at line 1 column 13",
-    },
-  ],
-  [
-    {
-      kind: "entityType",
-      $id: "https://blockprotocol.org/@alice/types/entity-type/foo/v/1",
-      type: "object",
-      title: "Foo",
-      allOf: [],
-      properties: {},
-      additionalProperties: true,
-    },
-    {
-      reason: "InvalidPropertyTypeObject",
-      inner: {
-        reason: "InvalidAdditionalPropertiesValue",
-      },
     },
   ],
 ];

--- a/libs/@blockprotocol/type-system/test/property-type.test.ts
+++ b/libs/@blockprotocol/type-system/test/property-type.test.ts
@@ -303,29 +303,6 @@ const brokenTypes: [any, ParsePropertyTypeError][] = [
       },
     },
   ],
-  [
-    {
-      kind: "propertyType",
-      $id: "https://blockprotocol.org/@blockprotocol/types/property-type/missing-additional-properties/v/1",
-      title: "Broken",
-      oneOf: [
-        {
-          type: "object",
-          properties: {
-            "https://blockprotocol.org/@blockprotocol/types/property-type/broken/":
-              {
-                $ref: "https://blockprotocol.org/@blockprotocol/types/property-type/broken/v/1",
-              },
-          },
-        },
-      ],
-    },
-    {
-      inner:
-        "data did not match any variant of untagged enum PropertyValues at line 1 column 340",
-      reason: "InvalidJson",
-    },
-  ],
 ];
 
 beforeAll(async () => {

--- a/libs/@blockprotocol/type-system/test/property-type.test.ts
+++ b/libs/@blockprotocol/type-system/test/property-type.test.ts
@@ -36,7 +36,6 @@ const propertyTypes: PropertyType[] = [
         required: [
           "https://blockprotocol.org/@blockprotocol/types/property-type/email/",
         ],
-        additionalProperties: false,
       },
     ],
   },
@@ -95,7 +94,6 @@ const propertyTypes: PropertyType[] = [
               },
             },
         },
-        additionalProperties: false,
       },
     ],
   },
@@ -250,7 +248,6 @@ const invalidPropertyTypes: [string, PropertyType, ParsePropertyTypeError][] = [
                 $ref: "https://blockprotocol.org/@blockprotocol/types/property-type/broken/v/1",
               },
           },
-          additionalProperties: false,
         },
       ],
     },
@@ -302,37 +299,6 @@ const brokenTypes: [any, ParsePropertyTypeError][] = [
         reason: "ValidationError",
         inner: {
           type: "EmptyOneOf",
-        },
-      },
-    },
-  ],
-  [
-    {
-      kind: "propertyType",
-      $id: "https://blockprotocol.org/@blockprotocol/types/property-type/true-additional-properties/v/1",
-      title: "Broken",
-      oneOf: [
-        {
-          type: "object",
-          properties: {
-            "https://blockprotocol.org/@blockprotocol/types/property-type/broken/":
-              {
-                $ref: "https://blockprotocol.org/@blockprotocol/types/property-type/broken/v/1",
-              },
-          },
-          additionalProperties: true,
-        },
-      ],
-    },
-    {
-      reason: "InvalidOneOf",
-      inner: {
-        reason: "PropertyValuesError",
-        inner: {
-          reason: "InvalidPropertyTypeObject",
-          inner: {
-            reason: "InvalidAdditionalPropertiesValue",
-          },
         },
       },
     },

--- a/libs/mock-block-dock/src/data/entity-types.ts
+++ b/libs/mock-block-dock/src/data/entity-types.ts
@@ -15,7 +15,6 @@ const worksFor: EntityType = {
   ],
   properties: {},
   required: [],
-  additionalProperties: false,
 };
 const founderOf: EntityType = {
   kind: "entityType",
@@ -30,7 +29,6 @@ const founderOf: EntityType = {
   ],
   properties: {},
   required: [],
-  additionalProperties: false,
 };
 const company: EntityType = {
   kind: "entityType",
@@ -51,7 +49,6 @@ const company: EntityType = {
     extractBaseUrl(propertyTypes.name.$id),
   ],
   links: {},
-  additionalProperties: false,
 };
 const person: EntityType = {
   kind: "entityType",
@@ -95,7 +92,6 @@ const person: EntityType = {
       ordered: false,
     },
   },
-  additionalProperties: false,
 };
 const testType: EntityType = {
   kind: "entityType",
@@ -110,7 +106,6 @@ const testType: EntityType = {
   },
   required: [extractBaseUrl(propertyTypes.name.$id)],
   links: {},
-  additionalProperties: false,
 };
 
 export const entityTypes = {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#937 and #1011 added `additionalProperties: false` to both Entity Type and Property Type schemas for `type: object`. We have remembered that we encountered issues with both `additionalProperties` and `unevaluatedProperties` with `allOf` fields in JSON schema ([context](https://github.com/blockprotocol/blockprotocol/compare/b675818bbc41...82f9032c84db)).

Adding an additional keyword (and specifying that it should be implied on previous versions) will be an easier change to migrate, as opposed to enforcing that all schemas have that word now, and having to somehow remove it in the future.

We aim to stay compatible with existing JSON schema validators if possible, so avoiding such breakages is paramount.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203358502199087/1204058698747794/f) _(internal)_

## 🚫 Blocked by

N/A

## 🔍 What does this change?

- Removes `additionalProperties`
- Adds a temporary migration patch to ensure the type editor doesn't create types with that field for now

## 📜 Does this require a change to the docs?

This has updated the meta-schemas which were the docs for this.

## ⚠️ Known issues

- The external dependency on `@hashintel/type-editor` will produce types with this field. We should update it and remove the temporary patch

## 🐾 Next steps

- Update `@hashintel/type-editor` to remove the patch

## 🛡 What tests cover this?

- Unknown, but MBD and the editor should continue to work as expected

