### PR TITLE
Patch link type

### DIFF
--- a/apps/site/src/middleware.page/return-types-as-json.ts
+++ b/apps/site/src/middleware.page/return-types-as-json.ts
@@ -59,5 +59,6 @@ export const returnTypeAsJson = async (request: NextRequest) => {
     );
   }
 
-  return generateJsonResponse(type);
+  // @todo remove this cast when new type hosting available
+  return generateJsonResponse(type as DataType | EntityType | PropertyType);
 };

--- a/apps/site/src/middleware.page/return-types-as-json/hardcoded-types.ts
+++ b/apps/site/src/middleware.page/return-types-as-json/hardcoded-types.ts
@@ -7,7 +7,6 @@ export const hardcodedTypes = {
     type: "object",
     title: "Link",
     properties: {},
-    additionalProperties: false,
   },
   // @todo replace below data types with types in db when data type hosting available
   "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1": {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#1041 removed the `additionalProperties` field. We're currently manually hosting a link type on the prod site, this updates it.
