### PR TITLE
Correct 'schema' to 'entity type' in copy, fix schema creation test

### DIFF
--- a/apps/site/src/components/pages/user/placeholder-buttons.tsx
+++ b/apps/site/src/components/pages/user/placeholder-buttons.tsx
@@ -18,7 +18,7 @@ export const BuildBlockButton: FunctionComponent = () => {
   );
 };
 
-export const CreateSchemaButton: FunctionComponent<{
+export const CreateEntityTypeButton: FunctionComponent<{
   onClick: () => void;
 }> = ({ onClick }) => {
   return (
@@ -28,7 +28,7 @@ export const CreateSchemaButton: FunctionComponent<{
       onClick={onClick}
       startIcon={<TableTreeIcon />}
     >
-      Create a schema
+      Create an entity type
     </Button>
   );
 };

--- a/apps/site/src/components/pages/user/placeholder-buttons.tsx
+++ b/apps/site/src/components/pages/user/placeholder-buttons.tsx
@@ -28,7 +28,7 @@ export const CreateEntityTypeButton: FunctionComponent<{
       onClick={onClick}
       startIcon={<TableTreeIcon />}
     >
-      Create an entity type
+      Create an Entity Type
     </Button>
   );
 };

--- a/apps/site/src/components/pages/user/placeholder.tsx
+++ b/apps/site/src/components/pages/user/placeholder.tsx
@@ -28,6 +28,7 @@ export const Placeholder: FunctionComponent<PlaceholderProps> = ({
           color: ({ palette }) => palette.gray[70],
           paddingTop: 1,
           paddingBottom: 2,
+          margin: "0 auto",
         }}
       >
         {tip}

--- a/apps/site/src/components/pages/user/tab-panel-contents-with-overview.tsx
+++ b/apps/site/src/components/pages/user/tab-panel-contents-with-overview.tsx
@@ -10,7 +10,7 @@ import { Placeholder } from "./placeholder";
 import {
   BrowseHubButton,
   BuildBlockButton,
-  CreateSchemaButton,
+  CreateEntityTypeButton,
 } from "./placeholder-buttons";
 import { useUserStatus } from "./use-user-status";
 
@@ -41,7 +41,9 @@ export const TabPanelContentsWithOverview: FunctionComponent<
           actions={
             <>
               <BuildBlockButton />
-              <CreateSchemaButton onClick={() => setSchemaModalOpen(true)} />
+              <CreateEntityTypeButton
+                onClick={() => setSchemaModalOpen(true)}
+              />
             </>
           }
         />

--- a/apps/site/src/components/pages/user/tab-panel-contents-with-schemas.tsx
+++ b/apps/site/src/components/pages/user/tab-panel-contents-with-schemas.tsx
@@ -62,7 +62,7 @@ export const TabPanelContentsWithSchemas: FunctionComponent<
           }}
         >
           <Button squared size="small" onClick={() => setSchemaModalOpen(true)}>
-            Create New Entity Type
+            Create an Entity Type
           </Button>
         </Box>
       )}

--- a/apps/site/src/components/pages/user/tab-panel-contents-with-schemas.tsx
+++ b/apps/site/src/components/pages/user/tab-panel-contents-with-schemas.tsx
@@ -7,7 +7,7 @@ import { Button } from "../../button";
 import { CreateSchemaModal } from "../../modal/create-schema-modal";
 import { ListViewCard } from "./list-view-card";
 import { Placeholder } from "./placeholder";
-import { BrowseHubButton, CreateSchemaButton } from "./placeholder-buttons";
+import { BrowseHubButton, CreateEntityTypeButton } from "./placeholder-buttons";
 import { useUserStatus } from "./use-user-status";
 
 export interface TabPanelContentsWithSchemasProps {
@@ -38,7 +38,7 @@ export const TabPanelContentsWithSchemas: FunctionComponent<
           header="You haven’t created any types yet"
           tip="Start building to see your creations show up here."
           actions={
-            <CreateSchemaButton onClick={() => setSchemaModalOpen(true)} />
+            <CreateEntityTypeButton onClick={() => setSchemaModalOpen(true)} />
           }
         />
         {createSchemaModal}

--- a/apps/site/tests/integration/accountpage.test.ts
+++ b/apps/site/tests/integration/accountpage.test.ts
@@ -45,7 +45,7 @@ test("key elements should be present when user views their account page", async 
     "/docs/developing-blocks",
   );
 
-  await expect(page.locator("text=Create an entity type")).toBeVisible();
+  await expect(page.locator("text=Create an Entity Type")).toBeVisible();
 
   // Blocks tab tests
   await page.locator("[data-testid='profile-page-blocks-tab']").click();
@@ -76,7 +76,7 @@ test("key elements should be present when user views their account page", async 
     page.locator("text=Start building to see your creations show up here."),
   ).toBeVisible();
 
-  await expect(page.locator("text=Create an entity type schema")).toBeVisible();
+  await expect(page.locator("text=Create an Entity Type")).toBeVisible();
 });
 
 const codeBlockMetadata = (await getBlocksData()).find(

--- a/apps/site/tests/integration/accountpage.test.ts
+++ b/apps/site/tests/integration/accountpage.test.ts
@@ -45,7 +45,7 @@ test("key elements should be present when user views their account page", async 
     "/docs/developing-blocks",
   );
 
-  await expect(page.locator("text=Create a schema")).toBeVisible();
+  await expect(page.locator("text=Create an entity type")).toBeVisible();
 
   // Blocks tab tests
   await page.locator("[data-testid='profile-page-blocks-tab']").click();
@@ -76,7 +76,7 @@ test("key elements should be present when user views their account page", async 
     page.locator("text=Start building to see your creations show up here."),
   ).toBeVisible();
 
-  await expect(page.locator("text=Create a schema")).toBeVisible();
+  await expect(page.locator("text=Create an entity type schema")).toBeVisible();
 });
 
 const codeBlockMetadata = (await getBlocksData()).find(

--- a/apps/site/tests/integration/schema-creation.test.ts
+++ b/apps/site/tests/integration/schema-creation.test.ts
@@ -5,7 +5,7 @@ import { login } from "../shared/nav.js";
 import { createSchema } from "../shared/schemas.js";
 import { expect, test } from "../shared/wrapped-playwright.js";
 
-test("user should be able to create an Entity Type", async ({ page }) => {
+test.skip("user should be able to create an Entity Type", async ({ page }) => {
   await resetSite();
 
   await page.goto("/");

--- a/apps/site/tests/integration/schema-creation.test.ts
+++ b/apps/site/tests/integration/schema-creation.test.ts
@@ -5,7 +5,7 @@ import { login } from "../shared/nav.js";
 import { createSchema } from "../shared/schemas.js";
 import { expect, test } from "../shared/wrapped-playwright.js";
 
-test.skip("user should be able to create an entity type", async ({ page }) => {
+test("user should be able to create an entity type", async ({ page }) => {
   await resetSite();
 
   await page.goto("/");
@@ -22,15 +22,13 @@ test.skip("user should be able to create an entity type", async ({ page }) => {
     page,
   });
 
-  await page.locator("button", { hasText: "Create New Entity Type" }).click();
+  await page.locator("button", { hasText: "Create an Entity Type" }).click();
 
   const schemaModal = page.locator("[data-testid='create-schema-modal']");
 
   await expect(schemaModal).toBeVisible();
 
-  await expect(
-    schemaModal.locator("text=Create New Entity Type"),
-  ).toBeVisible();
+  await expect(schemaModal.locator("text=Create an Entity Type")).toBeVisible();
   await expect(
     schemaModal.locator(
       "text=Types are used to define the structure of entities and their relationships to other entities.",

--- a/apps/site/tests/integration/schema-creation.test.ts
+++ b/apps/site/tests/integration/schema-creation.test.ts
@@ -5,7 +5,7 @@ import { login } from "../shared/nav.js";
 import { createSchema } from "../shared/schemas.js";
 import { expect, test } from "../shared/wrapped-playwright.js";
 
-test.skip("user should be able to create an Entity Type", async ({ page }) => {
+test("user should be able to create an Entity Type", async ({ page }) => {
   await resetSite();
 
   await page.goto("/");
@@ -28,7 +28,9 @@ test.skip("user should be able to create an Entity Type", async ({ page }) => {
 
   await expect(schemaModal).toBeVisible();
 
-  await expect(schemaModal.locator("text=Create an Entity Type")).toBeVisible();
+  await expect(
+    schemaModal.locator("text=Create New Entity Type"),
+  ).toBeVisible();
   await expect(
     schemaModal.locator(
       "text=Types are used to define the structure of entities and their relationships to other entities.",

--- a/apps/site/tests/integration/schema-creation.test.ts
+++ b/apps/site/tests/integration/schema-creation.test.ts
@@ -51,11 +51,11 @@ test("user should be able to create an Entity Type", async ({ page }) => {
 
   await schemaModal.locator('button:has-text("Create")').click();
 
-  await page
-    .locator(
+  await expect(
+    schemaModal.locator(
       `text=Invalid entity type: User already has an entity type with id ${existingSchemaWithMetadata.schema.$id}`,
-    )
-    .click();
+    ),
+  ).toBeVisible();
 
   await inputs[0]!.fill(newSchemaName);
 

--- a/apps/site/tests/integration/schema-creation.test.ts
+++ b/apps/site/tests/integration/schema-creation.test.ts
@@ -53,7 +53,7 @@ test("user should be able to create an Entity Type", async ({ page }) => {
 
   await expect(
     page.locator("[data-testid='create-schema-modal']", {
-      hasText: `Invalid entity type: User already has an entity type with id ${existingSchemaWithMetadata.schema.$id}`,
+      hasText: `User already has an entity type with id ${existingSchemaWithMetadata.schema.$id}`,
     }),
   ).toBeVisible();
 

--- a/apps/site/tests/integration/schema-creation.test.ts
+++ b/apps/site/tests/integration/schema-creation.test.ts
@@ -53,7 +53,7 @@ test("user should be able to create an Entity Type", async ({ page }) => {
 
   await page
     .locator(
-      `text=Invalid schema: User already has an entity type with id ${existingSchemaWithMetadata.schema.$id}`,
+      `text=Invalid entity type: User already has an entity type with id ${existingSchemaWithMetadata.schema.$id}`,
     )
     .click();
 

--- a/apps/site/tests/integration/schema-creation.test.ts
+++ b/apps/site/tests/integration/schema-creation.test.ts
@@ -5,7 +5,7 @@ import { login } from "../shared/nav.js";
 import { createSchema } from "../shared/schemas.js";
 import { expect, test } from "../shared/wrapped-playwright.js";
 
-test("user should be able to create an entity type", async ({ page }) => {
+test("user should be able to create an Entity Type", async ({ page }) => {
   await resetSite();
 
   await page.goto("/");

--- a/apps/site/tests/integration/schema-creation.test.ts
+++ b/apps/site/tests/integration/schema-creation.test.ts
@@ -52,9 +52,9 @@ test("user should be able to create an Entity Type", async ({ page }) => {
   await schemaModal.locator('button:has-text("Create")').click();
 
   await expect(
-    schemaModal.locator(
-      `text=Invalid entity type: User already has an entity type with id ${existingSchemaWithMetadata.schema.$id}`,
-    ),
+    page.locator("[data-testid='create-schema-modal']", {
+      hasText: `Invalid entity type: User already has an entity type with id ${existingSchemaWithMetadata.schema.$id}`,
+    }),
   ).toBeVisible();
 
   await inputs[0]!.fill(newSchemaName);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Corrects some copy consistency – rename 'schema' to 'Entity Type' when we are talking about creating entity types.

This also fixes and un-skips one of the tests that were skipped in the `0.3` branch

Also sorts out centering text.

### Previously

![Screenshot 2023-02-26 at 13 31 34](https://user-images.githubusercontent.com/37743469/221413520-4025b910-25dc-4676-9a53-4cc843f1117c.png)

### Now

![Screenshot 2023-02-26 at 13 31 06](https://user-images.githubusercontent.com/37743469/221413537-be883374-a986-4197-83fa-eb56b280041b.png)

