### PR TITLE
Fix recordId comparison in getVertexIdForRecordId

### DIFF
--- a/libs/@blockprotocol/graph/src/shared/stdlib/subgraph/vertex-id-for-element.ts
+++ b/libs/@blockprotocol/graph/src/shared/stdlib/subgraph/vertex-id-for-element.ts
@@ -1,6 +1,9 @@
 import {
   EntityRecordId,
   GraphElementVertexId,
+  isEntityRecordId,
+  isEntityVertexId,
+  isOntologyTypeRecordId,
   OntologyTypeRecordId,
   Subgraph,
 } from "../../types.js";
@@ -20,7 +23,17 @@ export const getVertexIdForRecordId = (
 ): GraphElementVertexId => {
   for (const [baseId, revisionObject] of typedEntries(subgraph.vertices)) {
     for (const [revisionId, vertex] of typedEntries(revisionObject)) {
-      if (vertex.inner.metadata.recordId === recordId) {
+      const { recordId: vertexRecordId } = vertex.inner.metadata;
+      if (
+        (isOntologyTypeRecordId(recordId) &&
+          isOntologyTypeRecordId(vertexRecordId) &&
+          recordId.baseUrl === vertexRecordId.baseUrl &&
+          recordId.version === vertexRecordId.version) ||
+        (isEntityRecordId(recordId) &&
+          isEntityRecordId(vertexRecordId) &&
+          recordId.entityId === vertexRecordId.entityId &&
+          recordId.editionId === vertexRecordId.editionId)
+      ) {
         return {
           baseId,
           revisionId,

--- a/libs/@blockprotocol/graph/src/shared/stdlib/subgraph/vertex-id-for-element.ts
+++ b/libs/@blockprotocol/graph/src/shared/stdlib/subgraph/vertex-id-for-element.ts
@@ -2,7 +2,6 @@ import {
   EntityRecordId,
   GraphElementVertexId,
   isEntityRecordId,
-  isEntityVertexId,
   isOntologyTypeRecordId,
   OntologyTypeRecordId,
   Subgraph,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

It fixes the `recordId` comparison in `getVertexIdForRecordId`.