### PR TITLE
Fix `data-type` meta schema definition

### DIFF
--- a/apps/site/public/types/modules/graph/0.3/schema/data-type.json
+++ b/apps/site/public/types/modules/graph/0.3/schema/data-type.json
@@ -6,7 +6,6 @@
   "type": "object",
   "properties": {
     "$schema": {
-      "type": "string",
       "const": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type"
     },
     "kind": {
@@ -26,24 +25,49 @@
     }
   },
   "required": ["$schema", "kind", "$id", "title", "type"],
+  "$comment": "The following `oneOf` only ensures, that no custom data types are allowed yet",
   "oneOf": [
     {
-      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"
+      "properties": {
+        "$id": {
+          "const": "https://blockprotocol.org/@blockprotocol/types/data-type/null/v/1"
+        }
+      }
     },
     {
-      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1"
+      "properties": {
+        "$id": {
+          "const": "https://blockprotocol.org/@blockprotocol/types/data-type/boolean/v/1"
+        }
+      }
     },
     {
-      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/boolean/v/1"
+      "properties": {
+        "$id": {
+          "const": "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1"
+        }
+      }
     },
     {
-      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/null/v/1"
+      "properties": {
+        "$id": {
+          "const": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"
+        }
+      }
     },
     {
-      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1"
+      "properties": {
+        "$id": {
+          "const": "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1"
+        }
+      }
     },
     {
-      "$ref": "https://blockprotocol.org/@blockprotocol/types/data-type/empty-list/v/1"
+      "properties": {
+        "$id": {
+          "const": "https://blockprotocol.org/@blockprotocol/types/data-type/empty-list/v/1"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Currently, we use `"$ref"` in the data-type *meta* schema in the `"oneOf"`. This, however, does not make sure, that the expected data type schema is matching the meta schema, but it tries to match the actual data type.

## 🔗 Related links

- [Slack discussion](https://hashintel.slack.com/archives/C02LG39FJAU/p1677531751197249) _(internal)_
- [Asana Task](https://app.asana.com/0/1203623179643287/1204068318790075/f) _(internal)_

## 🔍 What does this change?

- Change the `"oneOf"` to fix the `"$id"` property. This is sufficient, that no more data types can be published which are matching the `"https://blockprotocol.org/types/modules/graph/0.3/schema/data-type"` schema.
- Drive-by: Remove unneeded `"type": "string"` in `"$schema"` field 

## 📜 Does this require a change to the docs?

- The meta schema is part of the documentation

## ⚠️ Known issues

Downstream implementations may rely on the `"oneOf"` property. I think this is not an issue, as with a new version of the specs this can be changed and it's likely, that the shape will be extended by [non-primitive data types](https://github.com/blockprotocol/blockprotocol/pull/355)

## 🛡 What tests cover this?

This was manually tested in various JSON Schema validators, that only the listed data types are allowed