### PR TITLE
Fix misspelled `schema` in property type meta schema

### DIFF
--- a/apps/site/public/types/modules/graph/0.3/schema/property-type.json
+++ b/apps/site/public/types/modules/graph/0.3/schema/property-type.json
@@ -5,7 +5,7 @@
   "description": "Specifies the structure of a Block Protocol property type",
   "type": "object",
   "properties": {
-    "schema": {
+    "$schema": {
       "type": "string",
       "const": "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type"
     },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have a typo in the `property-type`'s meta schema.

## 📹 Demo

<img width="734" alt="image" src="https://user-images.githubusercontent.com/21277928/221855121-0bcc760a-951a-4b73-99be-4ecca2603551.png">
