### PR TITLE
Remove canary versions from `esm.sh` links

### DIFF
--- a/apps/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
+++ b/apps/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
@@ -116,7 +116,7 @@ const handler: NextApiHandler = async (req, res) => {
       import ReactDOM from "https://esm.sh/react-dom@${reactVersion}?target=es2021"
       import { jsx as _jsx } from "https://esm.sh/react@${reactVersion}/jsx-runtime.js?target=es2021";
       // @todo-0.3 revert this hardcoded version to ${mockBlockDockVersion}
-      import { MockBlockDock } from "https://esm.sh/mock-block-dock@0.1.0/dist/esm/index.js?target=es2021&deps=react@${reactVersion}";
+      import { MockBlockDock } from "https://esm.sh/mock-block-dock@0.1.0-canary-20230225164454/dist/esm/index.js?target=es2021&deps=react@${reactVersion}";
 
       const requireLookup = {
         "react-dom": ReactDOM,

--- a/apps/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
+++ b/apps/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
@@ -116,7 +116,7 @@ const handler: NextApiHandler = async (req, res) => {
       import ReactDOM from "https://esm.sh/react-dom@${reactVersion}?target=es2021"
       import { jsx as _jsx } from "https://esm.sh/react@${reactVersion}/jsx-runtime.js?target=es2021";
       // @todo-0.3 revert this hardcoded version to ${mockBlockDockVersion}
-      import { MockBlockDock } from "https://esm.sh/mock-block-dock@0.1.0-canary-20230225164454/dist/esm/index.js?target=es2021&deps=react@${reactVersion}";
+      import { MockBlockDock } from "https://esm.sh/mock-block-dock@0.1.0/dist/esm/index.js?target=es2021&deps=react@${reactVersion}";
 
       const requireLookup = {
         "react-dom": ReactDOM,

--- a/libs/@blockprotocol/graph/src/non-temporal/main.ts
+++ b/libs/@blockprotocol/graph/src/non-temporal/main.ts
@@ -35,6 +35,7 @@ import {
   EntityTypeVertex as EntityTypeVertexGeneral,
   EntityTypeWithMetadata as EntityTypeWithMetadataGeneral,
   EntityVertex as EntityVertexGeneral,
+  EntityVertexId as EntityVertexIdGeneral,
   FileAtUrlData as FileAtUrlDataGeneral,
   FileData as FileDataGeneral,
   FilterOperatorRequiringValue as FilterOperatorRequiringValueGeneral,
@@ -390,7 +391,7 @@ export const isPropertyTypeVertex = isPropertyTypeVertexGeneral;
 export const isEntityTypeVertex = isEntityTypeVertexGeneral;
 export const isEntityVertex = isEntityVertexGeneral<false>;
 export type VertexId<BaseId, RevisionId> = VertexIdGeneral<BaseId, RevisionId>;
-export type EntityVertexId = VertexId<EntityId, "1970-01-01T00:00:00.000Z">;
+export type EntityVertexId = EntityVertexIdGeneral;
 export type OntologyTypeVertexId = OntologyTypeVertexIdGeneral;
 export type GraphElementVertexId = GraphElementVertexIdGeneral;
 export const isOntologyTypeVertexId = isOntologyTypeVertexIdGeneral;

--- a/libs/block-template-html/dev/index.html
+++ b/libs/block-template-html/dev/index.html
@@ -18,7 +18,7 @@
     <div id="app"></div>
     <script type="module">
       import htm from "https://esm.sh/htm?dev&deps=react@18.2.0,react-dom@18.2.0";
-      import { MockBlockDock } from "https://esm.sh/mock-block-dock@0.1.0-canary-20230228184514?dev&deps=react@18.2.0,react-dom@18.2.0";
+      import { MockBlockDock } from "https://esm.sh/mock-block-dock@0.1.0?dev&deps=react@18.2.0,react-dom@18.2.0";
       import { createElement } from "https://esm.sh/react@18.2.0?dev&deps=react@18.2.0,react-dom@18.2.0";
       import ReactDOM from "https://esm.sh/react-dom@18.2.0?dev&deps=react@18.2.0,react-dom@18.2.0";
 

--- a/libs/block-template-html/src/app.js
+++ b/libs/block-template-html/src/app.js
@@ -2,8 +2,8 @@
 import {
   extractBaseUrl,
   GraphBlockHandler,
-} from "https://esm.sh/@blockprotocol/graph@0.1.0-canary-20230228184514";
-import { getRoots } from "https://esm.sh/@blockprotocol/graph@0.1.0-canary-20230228184514/stdlib";
+} from "https://esm.sh/@blockprotocol/graph@0.1.0";
+import { getRoots } from "https://esm.sh/@blockprotocol/graph@0.1.0/stdlib";
 
 const propertyTypeIds = {
   name: "https://blockprotocol.org/@blockprotocol/types/property-type/name/v/1",

--- a/libs/mock-block-dock/dev/test-html-block/block.js
+++ b/libs/mock-block-dock/dev/test-html-block/block.js
@@ -6,8 +6,8 @@
 import {
   extractBaseUri,
   GraphBlockHandler,
-} from "https://esm.sh/@blockprotocol/graph@0.1.0-canary-20230223103409";
-import { getRoots } from "https://esm.sh/@blockprotocol/graph@0.1.0-canary-20230223103409/stdlib";
+} from "https://esm.sh/@blockprotocol/graph@0.1.0";
+import { getRoots } from "https://esm.sh/@blockprotocol/graph@0.1.0/stdlib";
 
 const propertyTypeIds = {
   name: "http://example.com/types/property-type/name/v/1",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We've been using canary versions during development, it's time to upgrade as we're about to release
