### PR TITLE
Remove `@canary` from Block development documentation

### DIFF
--- a/apps/site/src/_pages/docs/1_developing-blocks.mdx
+++ b/apps/site/src/_pages/docs/1_developing-blocks.mdx
@@ -20,7 +20,7 @@ We provide three templates which allow you to define the entry point for your bl
 - `html`: create a block defined as an HTML file, with JavaScript added via `<script>` tags.
 - `react`: create a block defined as a React component.
 
-To create a new block, run `npx create-block-app@canary block-name --template template@canary`, replacing `block-name` with the name to give your block, and `template` with one of the template names listed above (keep the @canary on the end!)
+To create a new block, run `npx create-block-app block-name --template template`, replacing `block-name` with the name to give your block, and `template` with one of the template names listed above.
 
 ### I want to use a different technology
 
@@ -37,7 +37,7 @@ You can write your block in regular JavaScript using the methods described above
 ## Creating a block
 
 1.  Move to a folder where you want to create your block.
-1.  Run `npx create-block-app@canary your-block-name --template react@canary` (or `--template custom-element@canary`).
+1.  Run `npx create-block-app your-block-name --template react` (or `--template custom-element`).
 1.  Switch to your new folder: `cd [your-block-name]`.
 1.  Run `yarn install && yarn dev` or `npm install && npm run dev`.
 1.  Open [http://localhost:63212](http://localhost:63212/) in your browser to see the starter template.
@@ -425,15 +425,15 @@ To publish a block on the Hub take the following steps.
 ### Publish from your terminal
 
 - Run `npm run build` or `yarn build` to create a production build of your block (it will appear in the `dist` folder)
-- run `npx blockprotocol@canary publish` to generate a `.blockprotocolrc` file when prompted
+- run `npx blockprotocol publish` to generate a `.blockprotocolrc` file when prompted
 - Replace the placeholder key in that file with your API key
-- now run `npx blockprotocol@canary publish` again
+- now run `npx blockprotocol publish` again
 - See your block on the Hub!
 
 ### Updating your block
 
 You can update your published block at any time by running
-`npm run build && npx blockprotocol@canary publish` or `yarn build && npx blockprotocol@canary publish`
+`npm run build && npx blockprotocol publish` or `yarn build && npx blockprotocol publish`
 
 ### Have your block verified
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have published the blocks, so we don't need `@canary` anymore

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204038271168774