### PR TITLE
Improve documentation around block creation

### DIFF
--- a/apps/site/src/_pages/docs/1_developing-blocks.mdx
+++ b/apps/site/src/_pages/docs/1_developing-blocks.mdx
@@ -28,7 +28,7 @@ If you want to write blocks **using other technologies or frameworks**, we provi
 Currently the three templates are:
 
 1.  `react` - the default template which uses React and has a suite of helpful hooks you can use.
-1.  `custom-element` - create a block defined as a custom element (also known as Web Components). You can use this with different approaches when constructing the element-i.e. use a custom element as a wrapper for anything else you like.
+1.  `custom-element` - create a block defined as a custom element (also known as Web Components), which is based on [Lit](https://lit.dev/). You can also use different approaches when constructing the element-i.e. use a custom element as a wrapper for anything else you like.
 1.  `html` - give up some of the ecosystem to roll-your-own, import and use additional libraries inside the `<script>` tag.
 
 You may also use any other language which can be transpiled to JavaScript. As an example, see [this blog post](https://hash.dev/blog/build-blocks-in-any-language) on writing a block using F#. This block uses React – you can use transpiled JavaScript in blocks defined as HTML files or custom elements too.

--- a/apps/site/src/_pages/docs/1_developing-blocks.mdx
+++ b/apps/site/src/_pages/docs/1_developing-blocks.mdx
@@ -23,7 +23,9 @@ In practice, most block developers will not need to know the lower-level details
 
 ### I want to use a different technology
 
-If you want to write blocks **using other technologies or frameworks**, you may pass a template parameter to the above command: `npx create-block-app@latest your-block-name --template <TEMPLATE>`. For the template, there are several options:
+If you want to write blocks **using other technologies or frameworks**, we provide three templates to choose from which allow you to define the entry point for your block in different ways. To change the template, pass a parameter to the above command as follows: `npx create-block-app@latest your-block-name --template <TEMPLATE>`. 
+
+Currently the three templates are:
 
 1.  use the `react` template and use React to create your block (default).
 1.  use the `html` template and import and use your additional libraries inside the `<script>` tag.

--- a/apps/site/src/_pages/docs/1_developing-blocks.mdx
+++ b/apps/site/src/_pages/docs/1_developing-blocks.mdx
@@ -28,7 +28,7 @@ Currently the three templates are:
 
 1.  `react` - the default template which uses React and has a suite of helpful hooks you can use.
 1.  `custom-element` - create a block defined as a custom element (also known as Web Components), which is based on [Lit](https://lit.dev/). You can also use different approaches when constructing the element-i.e. use a custom element as a wrapper for anything else you like.
-1.  `html` - give up some of the ecosystem to roll-your-own, import and use additional libraries inside the `<script>` tag.
+1.  `html` - plain HTML and JavaScript. Import and use additional libraries inside the `<script>` tag.
 
 You may also use any other language which can be transpiled to JavaScript. As an example, see [this blog post](https://hash.dev/blog/build-blocks-in-any-language) on writing a block using F#. This block uses React – you can use transpiled JavaScript in blocks defined as HTML files or custom elements too.
 

--- a/apps/site/src/_pages/docs/1_developing-blocks.mdx
+++ b/apps/site/src/_pages/docs/1_developing-blocks.mdx
@@ -419,7 +419,7 @@ To publish a block on the Hub take the following steps.
 
 ### Publish from your terminal
 
-- Run `npm run build` or `yarn build` to create a production build of your block (it will appear in the `dist` folder)
+- Run `yarn build` or `npm run build` to create a production build of your block (it will appear in the `dist` folder)
 - run `npx blockprotocol@latest publish` to generate a `.blockprotocolrc` file when prompted
 - Replace the placeholder key in that file with your API key
 - now run `npx blockprotocol@latest publish` again
@@ -428,7 +428,7 @@ To publish a block on the Hub take the following steps.
 ### Updating your block
 
 You can update your published block at any time by running
-`npm run build && npx blockprotocol@latest publish` or `yarn build && npx blockprotocol@latest publish`
+`yarn build && npx blockprotocol@latest publish` or `npm run build && npx blockprotocol@latest publish`
 
 ### Have your block verified
 

--- a/apps/site/src/_pages/docs/1_developing-blocks.mdx
+++ b/apps/site/src/_pages/docs/1_developing-blocks.mdx
@@ -33,7 +33,7 @@ Currently the three templates are:
 
 You may also use any other language which can be transpiled to JavaScript. As an example, see [this blog post](https://hash.dev/blog/build-blocks-in-any-language) on writing a block using F#. This block uses React – you can use transpiled JavaScript in blocks defined as HTML files or custom elements too.
 
-The sections below assume, that you're using the `react` template.
+The sections below assume that you're using the `react` template.
 
 ### I don’t want to use TypeScript
 

--- a/apps/site/src/_pages/docs/1_developing-blocks.mdx
+++ b/apps/site/src/_pages/docs/1_developing-blocks.mdx
@@ -22,7 +22,7 @@ In practice, most block developers will not need to know the lower-level details
 
 ### I want to use a different technology
 
-If you want to write blocks **using other technologies or frameworks**, we provide three templates to choose from which allow you to define the entry point for your block in different ways. To change the template, pass a parameter to the above command as follows: `npx create-block-app@latest your-block-name --template <TEMPLATE>`.
+By default, `create-block-app` uses React. If you want to write blocks **using another technology or framework**, we provide template options for you to choose from which allow you to define the entry point for your block in different ways. To change the template, pass a parameter to the above command as follows: `npx create-block-app@latest your-block-name --template <TEMPLATE>`.
 
 Currently the three templates are:
 

--- a/apps/site/src/_pages/docs/1_developing-blocks.mdx
+++ b/apps/site/src/_pages/docs/1_developing-blocks.mdx
@@ -27,9 +27,9 @@ If you want to write blocks **using other technologies or frameworks**, we provi
 
 Currently the three templates are:
 
-1.  use the `react` template and use React to create your block (default).
-1.  use the `html` template and import and use your additional libraries inside the `<script>` tag.
-1.  use the `custom-element` template and use different approaches when constructing the element-i.e. use a custom element as a wrapper for anything else you like.
+1.  `react` - the default template which uses React and has a suite of helpful hooks you can use.
+1.  `custom-element` - create a block defined as a custom element (also known as Web Components). You can use this with different approaches when constructing the element-i.e. use a custom element as a wrapper for anything else you like.
+1.  `html` - give up some of the ecosystem to roll-your-own, import and use additional libraries inside the `<script>` tag.
 
 You may also use any other language which can be transpiled to JavaScript. As an example, see [this blog post](https://hash.dev/blog/build-blocks-in-any-language) on writing a block using F#. This block uses React – you can use transpiled JavaScript in blocks defined as HTML files or custom elements too.
 

--- a/apps/site/src/_pages/docs/1_developing-blocks.mdx
+++ b/apps/site/src/_pages/docs/1_developing-blocks.mdx
@@ -20,10 +20,9 @@ In practice, most block developers will not need to know the lower-level details
 1.  Run `yarn install && yarn dev` or `npm install && npm run dev`.
 1.  Open [http://localhost:63212](http://localhost:63212/) in your browser to see the starter template.
 
-
 ### I want to use a different technology
 
-If you want to write blocks **using other technologies or frameworks**, we provide three templates to choose from which allow you to define the entry point for your block in different ways. To change the template, pass a parameter to the above command as follows: `npx create-block-app@latest your-block-name --template <TEMPLATE>`. 
+If you want to write blocks **using other technologies or frameworks**, we provide three templates to choose from which allow you to define the entry point for your block in different ways. To change the template, pass a parameter to the above command as follows: `npx create-block-app@latest your-block-name --template <TEMPLATE>`.
 
 Currently the three templates are:
 

--- a/apps/site/src/_pages/docs/1_developing-blocks.mdx
+++ b/apps/site/src/_pages/docs/1_developing-blocks.mdx
@@ -46,7 +46,7 @@ The `create-block-app` package and provides everything you need to develop a blo
 - `yarn dev` or `npm run dev` will run your block in development mode, serving it locally with hot reloading at [http://localhost:63212](http://localhost:63212).
   - This uses the file at `src/dev.tsx` to render your block within a mock embedding application called `MockBlockDock`.
   - By default, dev mode will also show you the properties that are being passed to your block and the contents of the mock datastore. Remove `debug` from `MockBlockDock` to turn this off, or toggle it via the provided switch in the UI.
-- `yarn build` or `npm run build` will:
+- `yarn build` or `npm run build` will (except for the HTML template):
   - Bundle the component into a single source file (without any dependencies listed as `peerDependencies`).
   - Generate a `block-metadata.json` file which:
     - points to the bundled `source` file.
@@ -59,6 +59,7 @@ The `create-block-app` package and provides everything you need to develop a blo
       - `icon`: an icon to be associated with your block (in place of `public/omega.svg`)
       - `name`: a slugified name for your block (which may differ to the package `name` in package.json); it can be defined as `blockname` or `@namespace/blockname`, where `namespace` must be your username on blockprotocol.org if you intend to publish it there
     - list the `externals`, which are generated from `peerDependencies` in package.json.
+- If using the HTML template, `yarn build` simply copies your block source and `block-metadata.json` file to a `dist/` folder.
 
 ### Updating the block schema
 

--- a/apps/site/src/_pages/docs/1_developing-blocks.mdx
+++ b/apps/site/src/_pages/docs/1_developing-blocks.mdx
@@ -12,35 +12,30 @@ This guide helps get you set up and introduces some of the key features of the g
 
 In practice, most block developers will not need to know the lower-level details of the specifications, as the libraries we provide implement them.
 
-## Choosing your approach
+## Creating a block
 
-We provide three templates which allow you to define the entry point for your block in different ways:
+1.  Move to a folder where you want to create your block.
+1.  Run `npx create-block-app@latest your-block-name`.
+1.  Switch to your new folder: `cd [your-block-name]`.
+1.  Run `yarn install && yarn dev` or `npm install && npm run dev`.
+1.  Open [http://localhost:63212](http://localhost:63212/) in your browser to see the starter template.
 
-- `custom-element`: create a block defined as a custom element (also known as Web Components).
-- `html`: create a block defined as an HTML file, with JavaScript added via `<script>` tags.
-- `react`: create a block defined as a React component.
-
-To create a new block, run `npx create-block-app block-name --template template`, replacing `block-name` with the name to give your block, and `template` with one of the template names listed above.
 
 ### I want to use a different technology
 
-If you want to write blocks **using other technologies or frameworks**, you have several options:
+If you want to write blocks **using other technologies or frameworks**, you may pass a template parameter to the above command: `npx create-block-app@latest your-block-name --template <TEMPLATE>`. For the template, there are several options:
 
-1.  use a `custom-element` template and use different approaches when constructing the element-i.e. use a custom element as a wrapper for anything else you like.
-1.  use an `html` template and import and use your additional libraries inside the `<script>` tag.
-1.  use a language which can be transpiled to JavaScript. As an example, see [this blog post](https://hash.dev/blog/build-blocks-in-any-language) on writing a block using F#. This block uses React – you can use transpiled JavaScript in blocks defined as HTML files or custom elements too.
+1.  use the `react` template and use React to create your block (default).
+1.  use the `html` template and import and use your additional libraries inside the `<script>` tag.
+1.  use the `custom-element` template and use different approaches when constructing the element-i.e. use a custom element as a wrapper for anything else you like.
+
+You may also use any other language which can be transpiled to JavaScript. As an example, see [this blog post](https://hash.dev/blog/build-blocks-in-any-language) on writing a block using F#. This block uses React – you can use transpiled JavaScript in blocks defined as HTML files or custom elements too.
+
+The sections below assume, that you're using the `react` template.
 
 ### I don’t want to use TypeScript
 
 You can write your block in regular JavaScript using the methods described above - just rename your files from `*.tsx/*.ts` to `*.jsx/*.js`, remove the types, and get coding.
-
-## Creating a block
-
-1.  Move to a folder where you want to create your block.
-1.  Run `npx create-block-app your-block-name --template react` (or `--template custom-element`).
-1.  Switch to your new folder: `cd [your-block-name]`.
-1.  Run `yarn install && yarn dev` or `npm install && npm run dev`.
-1.  Open [http://localhost:63212](http://localhost:63212/) in your browser to see the starter template.
 
 ## The development environment
 
@@ -425,15 +420,15 @@ To publish a block on the Hub take the following steps.
 ### Publish from your terminal
 
 - Run `npm run build` or `yarn build` to create a production build of your block (it will appear in the `dist` folder)
-- run `npx blockprotocol publish` to generate a `.blockprotocolrc` file when prompted
+- run `npx blockprotocol@latest publish` to generate a `.blockprotocolrc` file when prompted
 - Replace the placeholder key in that file with your API key
-- now run `npx blockprotocol publish` again
+- now run `npx blockprotocol@latest publish` again
 - See your block on the Hub!
 
 ### Updating your block
 
 You can update your published block at any time by running
-`npm run build && npx blockprotocol publish` or `yarn build && npx blockprotocol publish`
+`npm run build && npx blockprotocol@latest publish` or `yarn build && npx blockprotocol@latest publish`
 
 ### Have your block verified
 

--- a/apps/site/src/_pages/docs/1_developing-blocks.mdx
+++ b/apps/site/src/_pages/docs/1_developing-blocks.mdx
@@ -33,15 +33,13 @@ Currently the three templates are:
 
 You may also use any other language which can be transpiled to JavaScript. As an example, see [this blog post](https://hash.dev/blog/build-blocks-in-any-language) on writing a block using F#. This block uses React – you can use transpiled JavaScript in blocks defined as HTML files or custom elements too.
 
-The sections below assume that you're using the `react` template.
-
 ### I don’t want to use TypeScript
 
 You can write your block in regular JavaScript using the methods described above - just rename your files from `*.tsx/*.ts` to `*.jsx/*.js`, remove the types, and get coding.
 
 ## The development environment
 
-The `create-block-app` package and provides everything you need to develop a block.
+The `create-block-app` package and provides everything you need to develop a block. This section assumes you have run `npx create-block-app@latest your-block-name` and are in the resulting folder. For the HTML template, the folder structure is slightly different. The development server is in a `dev/` folder and the block entry point is `app.html`.
 
 - `src/app.tsx` or `src/app.ts` contains your block’s code.
   - You can include dependencies in your block but bear in mind that the more dependencies you add, the bigger your block’s download size will be. Common dependencies which you can reasonably expect an embedding application to provide (e.g. React) can be defined as `peerDependencies` in `package.json`.
@@ -77,7 +75,7 @@ See [working with types](/docs/working-with-types) for more information on the t
 
 Once you have created the type representing the data your block needs, copy its URL, and update the `schema` property
 in the `blockprotocol` object in `package.json`. In TypeScript block templates, you can then run `yarn schema` to
-regenerate the types for your block.
+regenerate the types for your block. When using the HTML template, you need to adjust the types manually.
 
 ## Lifecycle of a block
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

See title

## 🔗 Related links

- [Slack thread](https://hashintel.slack.com/archives/C02LG39FJAU/p1677682385161489) _(internal)_

## 🔍 What does this change?

- Merge sections, which recommends running `npx create-block-app`
- Mention, that the below sections will assume the `--template react` and mention that being the default
