### PR TITLE
Explicitly set 'verified' status on blocks when created

### DIFF
--- a/apps/site/src/lib/blocks.ts
+++ b/apps/site/src/lib/blocks.ts
@@ -94,6 +94,8 @@ export const getRepositoryUrl = (
   return undefined;
 };
 
+const trustedAuthors = ["blockprotocol", "hash", "tldraw"];
+
 export const expandBlockMetadata = ({
   timestamps,
   includesExampleGraph,
@@ -140,9 +142,11 @@ export const expandBlockMetadata = ({
   // eslint-disable-next-line no-param-reassign -- could make a new object, but would need to update for any new metadata fields
   delete metadata.devReloadEndpoint;
 
+  const author = namespace.replace(/^@/, "");
+
   return {
     ...metadata,
-    author: namespace.replace(/^@/, ""),
+    author,
     blockSitePath: `/${namespace}/blocks/${name}`,
     // fallback while not all blocks have blockType defined
     blockType: metadata.blockType ?? { entryPoint: "react" },
@@ -170,6 +174,7 @@ export const expandBlockMetadata = ({
       includesExampleGraph ? "example-graph.json" : null,
       blockDistributionFolderUrl,
     ),
+    verified: trustedAuthors.includes(author),
     version: metadata.version ?? "0.0.0",
   };
 };

--- a/apps/site/src/lib/config.ts
+++ b/apps/site/src/lib/config.ts
@@ -6,9 +6,6 @@ export const FRONTEND_URL = process.env.NEXT_PUBLIC_FRONTEND_URL
 
 export const isUsingHttps = new URL(FRONTEND_URL).protocol === "https";
 
-// eslint-disable-next-line no-console
-console.log("NEXT_PUBLIC_VERCEL_ENV: ", process.env.NEXT_PUBLIC_VERCEL_ENV);
-
 export const isProduction = process.env.NEXT_PUBLIC_VERCEL_ENV === "production";
 
 export const isFork =


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Make sure a `verified` status is set on block creation. Lists some starting trusted authors whose blocks are automatically verified. See https://blockprotocol.org/docs/faq#how-does-block-verification-work