### PR TITLE
Handle service module blocks in the hub (part 1)

### DIFF
--- a/apps/site/src/components/pages/hub/sandboxed-block-demo.tsx
+++ b/apps/site/src/components/pages/hub/sandboxed-block-demo.tsx
@@ -33,6 +33,10 @@ export const SandboxedBlockDemo: FunctionComponent<SandboxedBlockProps> = ({
 
   useEffect(() => {
     const listener = (message: MessageEvent) => {
+      if (sandboxBaseUrl && message.origin !== sandboxBaseUrl) {
+        return;
+      }
+
       if (message.data.type === "serviceModule") {
         const { providerName, methodName, payload } = message.data;
         setServiceModuleMessage({ providerName, methodName, payload });
@@ -44,7 +48,7 @@ export const SandboxedBlockDemo: FunctionComponent<SandboxedBlockProps> = ({
     return () => {
       window.removeEventListener("message", listener);
     };
-  }, []);
+  }, [sandboxBaseUrl]);
 
   useEffect(() => {
     postBlockProps();

--- a/apps/site/src/components/pages/hub/sandboxed-block-demo.tsx
+++ b/apps/site/src/components/pages/hub/sandboxed-block-demo.tsx
@@ -1,6 +1,14 @@
-import { FunctionComponent, useCallback, useEffect, useRef } from "react";
+import { ExternalServiceMethodRequest } from "@local/internal-api-client/api";
+import {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 import { ExpandedBlockMetadata } from "../../../lib/blocks";
+import { ServiceModuleModal } from "./sandboxed-block-demo/service-module-modal";
 
 export interface SandboxedBlockProps {
   metadata: ExpandedBlockMetadata;
@@ -16,9 +24,27 @@ export const SandboxedBlockDemo: FunctionComponent<SandboxedBlockProps> = ({
   const loadedRef = useRef(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
+  const [serviceModuleMessage, setServiceModuleMessage] =
+    useState<ExternalServiceMethodRequest | null>(null);
+
   const postBlockProps = useCallback(() => {
     iframeRef.current?.contentWindow?.postMessage(JSON.stringify(props), "*");
   }, [props]);
+
+  useEffect(() => {
+    const listener = (message: MessageEvent) => {
+      if (message.data.type === "serviceModule") {
+        const { providerName, methodName, payload } = message.data;
+        setServiceModuleMessage({ providerName, methodName, payload });
+      }
+    };
+
+    window.addEventListener("message", listener);
+
+    return () => {
+      window.removeEventListener("message", listener);
+    };
+  }, []);
 
   useEffect(() => {
     postBlockProps();
@@ -30,26 +56,33 @@ export const SandboxedBlockDemo: FunctionComponent<SandboxedBlockProps> = ({
   )}/sandboxed-demo`;
 
   return (
-    <iframe
-      ref={iframeRef}
-      title="block"
-      src={sandboxedDemoUrl}
-      sandbox="allow-forms allow-scripts allow-same-origin"
-      allow="clipboard-write"
-      onLoad={() => {
-        // @todo-0.3 this isn't triggering – why not?
-        loadedRef.current = true;
-        postBlockProps();
-      }}
-      // todo: remove 100% after implementing viewport negotiation
-      style={{
-        position: "absolute",
-        top: 0,
-        left: 0,
-        right: 0,
-        width: "100%",
-        height: "100%",
-      }}
-    />
+    <>
+      <ServiceModuleModal
+        onClose={() => setServiceModuleMessage(null)}
+        serviceModuleMessage={serviceModuleMessage}
+      />
+
+      <iframe
+        ref={iframeRef}
+        title="block"
+        src={sandboxedDemoUrl}
+        sandbox="allow-forms allow-scripts allow-same-origin"
+        allow="clipboard-write"
+        onLoad={() => {
+          // @todo-0.3 this isn't triggering – why not?
+          loadedRef.current = true;
+          postBlockProps();
+        }}
+        // todo: remove 100% after implementing viewport negotiation
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          width: "100%",
+          height: "100%",
+        }}
+      />
+    </>
   );
 };

--- a/apps/site/src/components/pages/hub/sandboxed-block-demo/service-module-modal.tsx
+++ b/apps/site/src/components/pages/hub/sandboxed-block-demo/service-module-modal.tsx
@@ -56,7 +56,7 @@ export const ServiceModuleModal = ({
             <>Your Block Protocol account gives you</>
           ) : (
             <>
-              <Link href="/signup">Sign up for a Block Protocol account</Link>
+              <Link href="/signup">Sign up for a Block Protocol account</Link>{" "}
               to get
             </>
           )}{" "}

--- a/apps/site/src/components/pages/hub/sandboxed-block-demo/service-module-modal.tsx
+++ b/apps/site/src/components/pages/hub/sandboxed-block-demo/service-module-modal.tsx
@@ -38,7 +38,7 @@ export const ServiceModuleModal = ({
             textAlign: "center",
           }}
         >
-          This block uses <br />
+          This block uses the <br />
           <strong>
             {serviceModuleMessage?.providerName}{" "}
             {serviceModuleMessage?.methodName}

--- a/apps/site/src/components/pages/hub/sandboxed-block-demo/service-module-modal.tsx
+++ b/apps/site/src/components/pages/hub/sandboxed-block-demo/service-module-modal.tsx
@@ -38,12 +38,11 @@ export const ServiceModuleModal = ({
             textAlign: "center",
           }}
         >
-          This block called the <br />
+          This block uses <br />
           <strong>
             {serviceModuleMessage?.providerName}{" "}
             {serviceModuleMessage?.methodName}
-          </strong>{" "}
-          service
+          </strong>
         </Typography>
         <Typography
           sx={{

--- a/apps/site/src/components/pages/hub/sandboxed-block-demo/service-module-modal.tsx
+++ b/apps/site/src/components/pages/hub/sandboxed-block-demo/service-module-modal.tsx
@@ -1,0 +1,86 @@
+import { ExternalServiceMethodRequest } from "@local/internal-api-client";
+import { Box, Typography } from "@mui/material";
+
+import { useUser } from "../../../../context/user-context";
+import { Button } from "../../../button";
+import { Link } from "../../../link";
+import { Modal } from "../../../modal/modal";
+
+type ServiceModuleModalProps = {
+  onClose: () => void;
+  serviceModuleMessage: ExternalServiceMethodRequest | null;
+};
+
+export const ServiceModuleModal = ({
+  onClose,
+  serviceModuleMessage,
+}: ServiceModuleModalProps) => {
+  const { user } = useUser();
+
+  return (
+    <Modal
+      open={!!serviceModuleMessage}
+      onClose={onClose}
+      contentStyle={{
+        top: "40%",
+        "&:focus": {
+          outline: "none",
+        },
+      }}
+    >
+      <Box width="100%">
+        <Typography
+          variant="bpHeading4"
+          sx={{
+            mb: 2,
+            display: "block",
+            lineHeight: 1.5,
+            textAlign: "center",
+          }}
+        >
+          This block called the <br />
+          <strong>
+            {serviceModuleMessage?.providerName}{" "}
+            {serviceModuleMessage?.methodName}
+          </strong>{" "}
+          service
+        </Typography>
+        <Typography
+          sx={{
+            mt: 2,
+            fontSize: 16,
+            lineHeight: 2,
+          }}
+        >
+          {user ? (
+            <>Your Block Protocol account gives you</>
+          ) : (
+            <>
+              <Link href="/signup">Sign up for a Block Protocol account</Link>
+              to get
+            </>
+          )}{" "}
+          free credits for services like this when you use blocks in real
+          applications.
+        </Typography>
+        <Typography
+          sx={{
+            mt: 1,
+            mb: 3,
+            fontSize: 16,
+            lineHeight: 2,
+          }}
+        >
+          <strong>Þ</strong> blocks can be used within various different
+          block-based applications, including{" "}
+          <Link href="/wordpress">WordPress</Link>.
+        </Typography>
+        <Box display="flex" justifyContent="center">
+          <Button onClick={onClose} sx={{ width: 160 }}>
+            Close
+          </Button>
+        </Box>
+      </Box>
+    </Modal>
+  );
+};


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Some blocks now call services that incur usage costs (in the form of BP credits or real money if the user is on a paid account and has exhausted their credits). This normally requires an API key, which isn't present in the Block Hub. Those blocks are therefore non-functional for the time being.

This PR shows a modal if a block tries to call an external service informing the user of the fact. 

A follow-up PR tomorrow will offer logged-in users the chance to use their credits (or money) on testing the block.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203623179643287/1204086167143590) _(internal)_

## 🐾 Next steps

- Part 2 will offer logged-in users the chance to allow this block to make calls, so they can test it properly.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  In the preview deployment, go to a service-calling block's page (e.g. AI Text, AI Image, Address)
2. Use it
3. See modal

## 📹 Demo

![Screenshot 2023-03-01 at 19 54 54](https://user-images.githubusercontent.com/37743469/222251423-647604eb-9e9e-4570-a307-e2b5c84e7848.png)

