### PR TITLE
Create GH cache after merging a Pull Request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ env:
 jobs:
   linting:
     name: Linting
-    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-20.04
 
     steps:
@@ -166,7 +165,6 @@ jobs:
 
   packages:
     name: NPM Packages
-    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-20.04
     timeout-minutes: 60
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

GH Actions uses the cache from the same branch and falls back to the base branch. The base branch after creating a PR is the `main` branch, so if the CI is not running on a `push` to main it cannot be created

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203623179643290/1204099711044327/f) _(internal)_

## 🔍 What does this change?

- Run CI on `push` to main