### PR TITLE
Run CI on any Pull Request (or merge queue event)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, 0.3]
+  merge_group:
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The CI currently runs only on pull request targeting `0.3` and `main` while the former does not exist anymore.
When stacking PR, it's currently not possible to check linting as the CI does not run at all.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203623179643290/1204099711044327/f) _(internal)_

## 🔍 What does this change?

- Enable CI runs for all pull request
- Drive-by: Add `merge_group` as target, **this should enable us to use the merge queue**