### PR TITLE
Download `wasm-pack` instead of compiling it

### DIFF
--- a/.github/actions/warm-up-repo/action.yml
+++ b/.github/actions/warm-up-repo/action.yml
@@ -16,11 +16,12 @@ runs:
         node-version: 16 ## aligned with Node version on Vercel
         cache: yarn
 
-    - name: Install Cargo-Make
+    - name: Install Rust tools
       shell: bash
       run: |
         cargo install cargo-quickinstall
         cargo quickinstall cargo-make --version 0.35.15
+        curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2

--- a/.github/actions/warm-up-repo/action.yml
+++ b/.github/actions/warm-up-repo/action.yml
@@ -16,12 +16,11 @@ runs:
         node-version: 16 ## aligned with Node version on Vercel
         cache: yarn
 
-    - name: Install Rust tools
+    - name: Install Cargo-Make
       shell: bash
       run: |
         cargo install cargo-quickinstall
         cargo quickinstall cargo-make --version 0.35.15
-        curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2

--- a/libs/@blockprotocol/type-system/crate/Makefile.toml
+++ b/libs/@blockprotocol/type-system/crate/Makefile.toml
@@ -174,8 +174,11 @@ private = true
 install_crate = { crate_name = "cargo-nextest", version = "0.9.28", binary = "cargo", test_arg = ["nextest", "--version"] }
 
 [tasks.install-wasm-pack]
-private = true
-install_crate = { crate_name = "wasm-pack", version = "0.10.3", binary = "wasm-pack", test_arg = ["--version"] }
+script = """
+if [ ! -f ~/.cargo/bin/wasm-pack ]; then
+  curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f
+fi
+"""
 
 [tasks.install-wasm-opt]
 private = true

--- a/libs/@blockprotocol/type-system/crate/Makefile.toml
+++ b/libs/@blockprotocol/type-system/crate/Makefile.toml
@@ -70,7 +70,7 @@ args = ["build", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_BUIL
 extend = "node"
 cwd = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}"
 args = ["--loader", "ts-node/esm", "./../scripts/build-wasm.ts"]
-dependencies = ["install-wasm-pack", "install-wasm-opt"]
+dependencies = ["install-wasm-opt"]
 
 ################################################################################
 ## Lints                                                                      ##
@@ -172,13 +172,6 @@ install_crate = { rustup_component_name = "rustfmt" }
 [tasks.install-cargo-nextest]
 private = true
 install_crate = { crate_name = "cargo-nextest", version = "0.9.28", binary = "cargo", test_arg = ["nextest", "--version"] }
-
-[tasks.install-wasm-pack]
-script = """
-if [ ! -f ~/.cargo/bin/wasm-pack ]; then
-  curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh -s -- -f
-fi
-"""
 
 [tasks.install-wasm-opt]
 private = true

--- a/libs/@blockprotocol/type-system/package.json
+++ b/libs/@blockprotocol/type-system/package.json
@@ -69,6 +69,7 @@
     "rollup": "3.5.1",
     "ts-jest": "29.0.5",
     "tslib": "2.4.1",
-    "typescript": "4.9.4"
+    "typescript": "4.9.4",
+    "wasm-pack": "0.10.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5135,6 +5135,13 @@ axios@0.26.1, axios@^0.26.0:
   dependencies:
     follow-redirects "^1.14.8"
 
+axios@^0.21.1:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+  dependencies:
+    follow-redirects "^1.14.0"
+
 axios@^0.25.0:
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.25.0.tgz#349cfbb31331a9b4453190791760a8d35b093e0a"
@@ -5313,6 +5320,15 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+binary-install@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/binary-install/-/binary-install-0.1.1.tgz#c1b22f174581764e5c52cd16664cf1d287e38bd4"
+  integrity sha512-DqED0D/6LrS+BHDkKn34vhRqOGjy5gTMgvYZsGK2TpNbdPuz4h+MRlNgGv5QBRd7pWq/jylM4eKNCizgAq3kNQ==
+  dependencies:
+    axios "^0.21.1"
+    rimraf "^3.0.2"
+    tar "^6.1.0"
 
 bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
@@ -7851,7 +7867,7 @@ flux@^4.0.1:
     fbemitter "^3.0.0"
     fbjs "^3.0.1"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.7, follow-redirects@^1.14.8, follow-redirects@^1.15.0:
+follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.7, follow-redirects@^1.14.8, follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -15107,6 +15123,13 @@ walker@^1.0.8:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
+
+wasm-pack@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/wasm-pack/-/wasm-pack-0.10.3.tgz#2d7dd78ba539c34b3817e2249c3f30c646c84b69"
+  integrity sha512-dg1PPyp+QwWrhfHsgG12K/y5xzwfaAoK1yuVC/DUAuQsDy5JywWDuA7Y/ionGwQz+JBZVw8jknaKBnaxaJfwTA==
+  dependencies:
+    binary-install "^0.1.0"
 
 watchpack@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Compiling `wasm-pack` is really slow. Instead of compiling it, this will change the behavior of `cargo-make` to download it instead as officially recommended