### PR TITLE
Use `wasm-opt` from `wasm-pack`

### DIFF
--- a/libs/@blockprotocol/type-system/crate/Cargo.toml
+++ b/libs/@blockprotocol/type-system/crate/Cargo.toml
@@ -32,6 +32,3 @@ wasm-bindgen-test = "0.3.13"
 [profile.release]
 lto = true
 opt-level = 's'
-
-[package.metadata.wasm-pack.profile.release]
-wasm-opt = false

--- a/libs/@blockprotocol/type-system/crate/Makefile.toml
+++ b/libs/@blockprotocol/type-system/crate/Makefile.toml
@@ -70,7 +70,7 @@ args = ["build", "--profile", "${CARGO_MAKE_CARGO_PROFILE}", "@@split(CARGO_BUIL
 extend = "node"
 cwd = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}"
 args = ["--loader", "ts-node/esm", "./../scripts/build-wasm.ts"]
-dependencies = ["install-wasm-pack", "install-wasm-opt"]
+dependencies = ["install-wasm-pack"]
 
 ################################################################################
 ## Lints                                                                      ##
@@ -178,5 +178,4 @@ private = true
 install_crate = { crate_name = "wasm-pack", version = "0.10.3", binary = "wasm-pack", test_arg = ["--version"] }
 
 [tasks.install-wasm-opt]
-private = true
 install_crate = { crate_name = "wasm-opt", version = "0.110.2", binary = "wasm-opt", test_arg = ["--version"] }

--- a/libs/@blockprotocol/type-system/crate/Makefile.toml
+++ b/libs/@blockprotocol/type-system/crate/Makefile.toml
@@ -176,6 +176,3 @@ install_crate = { crate_name = "cargo-nextest", version = "0.9.28", binary = "ca
 [tasks.install-wasm-pack]
 private = true
 install_crate = { crate_name = "wasm-pack", version = "0.10.3", binary = "wasm-pack", test_arg = ["--version"] }
-
-[tasks.install-wasm-opt]
-install_crate = { crate_name = "wasm-opt", version = "0.110.2", binary = "wasm-opt", test_arg = ["--version"] }

--- a/libs/@blockprotocol/type-system/package.json
+++ b/libs/@blockprotocol/type-system/package.json
@@ -45,7 +45,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn build:wasm && yarn optimize && yarn build:bundle",
+    "build": "yarn clean && yarn build:wasm && yarn build:bundle",
     "build:bundle": "rollup -c --bundleConfigAsCjs",
     "build:wasm": "cd crate && cargo make build",
     "clean": "rimraf ./dist/",

--- a/libs/@blockprotocol/type-system/package.json
+++ b/libs/@blockprotocol/type-system/package.json
@@ -53,8 +53,7 @@
     "fix:eslint": "eslint --fix .",
     "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
-    "optimize": "(cd crate && cargo make install-wasm-opt) && wasm-opt -Os wasm/type-system_bg.wasm -o tmp.wasm && mv tmp.wasm wasm/type-system_bg.wasm",
-    "prepublishOnly": "yarn build:wasm && yarn test && yarn optimize && yarn build:bundle",
+    "prepublishOnly": "yarn build:wasm && yarn test && yarn build:bundle",
     "test": "jest"
   },
   "devDependencies": {

--- a/libs/@blockprotocol/type-system/package.json
+++ b/libs/@blockprotocol/type-system/package.json
@@ -53,7 +53,7 @@
     "fix:eslint": "eslint --fix .",
     "lint:eslint": "eslint --report-unused-disable-directives .",
     "lint:tsc": "tsc --noEmit",
-    "optimize": "wasm-opt -Os wasm/type-system_bg.wasm -o tmp.wasm && mv tmp.wasm wasm/type-system_bg.wasm",
+    "optimize": "(cd crate && cargo make install-wasm-opt) && wasm-opt -Os wasm/type-system_bg.wasm -o tmp.wasm && mv tmp.wasm wasm/type-system_bg.wasm",
     "prepublishOnly": "yarn build:wasm && yarn test && yarn optimize && yarn build:bundle",
     "test": "jest"
   },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

There is no point in compiling a huge binary to reduce the size of the WASM file by 300 kb, if it's only used locally. This significantly slows down CI times. This PR adjusts the `build` command to not optimize the WASM file. The optimization is still run by the `prepublishOnly` job.