### PR TITLE
Use shared cache for Rust jobs

### DIFF
--- a/.github/actions/warm-up-repo/action.yml
+++ b/.github/actions/warm-up-repo/action.yml
@@ -26,6 +26,7 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         workspaces: libs/@blockprotocol/type-system/crate
+        shared-key: "shared"
 
     - run: yarn install
       shell: bash


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The Rust jobs is the same for all kind of jobs, we can share the cache