### PR TITLE
Abort on `panic!`

### DIFF
--- a/libs/@blockprotocol/type-system/crate/Cargo.toml
+++ b/libs/@blockprotocol/type-system/crate/Cargo.toml
@@ -32,6 +32,7 @@ wasm-bindgen-test = "0.3.13"
 [profile.release]
 lto = true
 opt-level = 's'
+panic = 'abort'
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/libs/@blockprotocol/type-system/scripts/build-wasm.ts
+++ b/libs/@blockprotocol/type-system/scripts/build-wasm.ts
@@ -30,6 +30,9 @@ const runWasmPack = () => {
     "--scope",
     "blockprotocol",
     "--release",
+    ".",
+    "-Zbuild-std=panic_abort,std",
+    "-Zbuild-std-features=panic_immediate_abort"
   ]);
 
   if (result.status !== 0) {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We don't `panic!` in our code. We only have a few location where we `.expect()` that a (previously validated) URL is a valid URL.

This reduces the size of the WASM binary by 74 KB