### PR TITLE
Update copy regarding Mapbox Autofill free allowance

### DIFF
--- a/apps/site/src/components/pages/pricing/paid-tiers-section.tsx
+++ b/apps/site/src/components/pages/pricing/paid-tiers-section.tsx
@@ -19,6 +19,7 @@ import Image from "next/legacy/image";
 import { FunctionComponent, ReactNode, useState } from "react";
 
 import proTierBackground from "../../../../public/assets/pricing/pro-tier-background.svg";
+import { externalServiceFreeAllowance } from "../../../pages/settings/billing-settings-panel/external-service-free-allowance";
 import { SubscriptionFeatureList } from "../../../pages/settings/billing-settings-panel/subscription-feature-list";
 import { SubscriptionFeature } from "../../../pages/settings/billing-settings-panel/subscription-feature-list-item";
 import {
@@ -229,7 +230,13 @@ export const paidSubscriptionFeatures: Record<
             component="span"
             sx={{ color: ({ palette }) => palette.purple[30] }}
           >
-            <strong>25</strong> Mapbox Address Autofills
+            <strong>
+              {
+                externalServiceFreeAllowance["Mapbox Address Autofill Session"]
+                  .hobby
+              }
+            </strong>{" "}
+            Mapbox Address Autofills
             <br />
             <Typography
               component="span"
@@ -346,7 +353,12 @@ export const paidSubscriptionFeatures: Record<
                 color: ({ palette }) => palette.purple[60],
               }}
             >
-              e.g. 300k+ words, 100 images, and 50 address autofills
+              e.g. 300k+ words, 100 images, and{" "}
+              {
+                externalServiceFreeAllowance["Mapbox Address Autofill Session"]
+                  .pro
+              }{" "}
+              address autofills
             </Typography>
           </Box>
         ),

--- a/apps/site/src/components/pages/pricing/paid-tiers-section.tsx
+++ b/apps/site/src/components/pages/pricing/paid-tiers-section.tsx
@@ -229,7 +229,7 @@ export const paidSubscriptionFeatures: Record<
             component="span"
             sx={{ color: ({ palette }) => palette.purple[30] }}
           >
-            <strong>20</strong> Mapbox Address Autofills
+            <strong>25</strong> Mapbox Address Autofills
             <br />
             <Typography
               component="span"
@@ -346,7 +346,7 @@ export const paidSubscriptionFeatures: Record<
                 color: ({ palette }) => palette.purple[60],
               }}
             >
-              e.g. 300k+ words, 100 images, and 40 address autofills
+              e.g. 300k+ words, 100 images, and 50 address autofills
             </Typography>
           </Box>
         ),

--- a/apps/site/src/components/pages/pricing/paid-tiers-section.tsx
+++ b/apps/site/src/components/pages/pricing/paid-tiers-section.tsx
@@ -787,7 +787,9 @@ export const PaidTiersSection: FunctionComponent<{
                 />
                 <HobbyTierPerk
                   headerIcon={faLocationDot}
-                  title="20"
+                  title={externalServiceFreeAllowance[
+                    "Mapbox Address Autofill Session"
+                  ].hobby.toString()}
                   description="Address autofills"
                   poweredByIcon={<MapboxLogoIcon sx={{ fontSize: 20 }} />}
                   poweredBy="MAPBOX"

--- a/apps/site/src/pages/settings/billing-settings-panel/external-service-free-allowance.ts
+++ b/apps/site/src/pages/settings/billing-settings-panel/external-service-free-allowance.ts
@@ -13,6 +13,12 @@ const externalServiceNames = [
 
 export type ExternalServicePriceName = (typeof externalServiceNames)[number];
 
+/**
+ * @todo use the internal API as the source of truth for these values, by fetching
+ * them from an internal API endpoint.
+ *
+ * @see https://app.asana.com/0/1203179076056209/1204082150544746/f
+ */
 export const externalServiceFreeAllowance: Record<
   ExternalServicePriceName,
   { free: number; hobby: number; pro: number }

--- a/apps/site/src/pages/settings/billing-settings-panel/external-service-free-allowance.ts
+++ b/apps/site/src/pages/settings/billing-settings-panel/external-service-free-allowance.ts
@@ -1,0 +1,70 @@
+const externalServiceNames = [
+  "Mapbox Address Autofill Session",
+  "Mapbox Isochrone Request",
+  "Mapbox Directions Request",
+  "Mapbox Temporary Geocoding Request",
+  "Mapbox Static Image Request",
+  "OpenAI Create Image Request",
+  "OpenAI Ada Token",
+  "OpenAI Babbage Token",
+  "OpenAI Curie Token",
+  "OpenAI Davinci Token",
+] as const;
+
+export type ExternalServicePriceName = (typeof externalServiceNames)[number];
+
+export const externalServiceFreeAllowance: Record<
+  ExternalServicePriceName,
+  { free: number; hobby: number; pro: number }
+> = {
+  "Mapbox Address Autofill Session": {
+    free: 10,
+    hobby: 25,
+    pro: 50,
+  },
+  "Mapbox Isochrone Request": {
+    free: 5,
+    hobby: 5,
+    pro: 500,
+  },
+  "Mapbox Directions Request": {
+    free: 5,
+    hobby: 5,
+    pro: 500,
+  },
+  "Mapbox Temporary Geocoding Request": {
+    free: 5,
+    hobby: 5,
+    pro: 500,
+  },
+  "Mapbox Static Image Request": {
+    free: 100,
+    hobby: 300,
+    pro: 600,
+  },
+  "OpenAI Create Image Request": {
+    free: 5,
+    hobby: 50,
+    pro: 100,
+  },
+  "OpenAI Ada Token": {
+    free: 0,
+    hobby: 100_000,
+    pro: 200_000,
+  },
+  "OpenAI Babbage Token": {
+    free: 0,
+    hobby: 50_000,
+    pro: 100_000,
+  },
+  "OpenAI Curie Token": {
+    free: 0,
+    hobby: 40_000,
+    pro: 80_000,
+  },
+  "OpenAI Davinci Token": {
+    free: 5_000,
+    hobby: 10_000,
+    pro: 20_000,
+  },
+};

--- a/apps/site/src/pages/settings/billing-settings-panel/free-or-hobby-subscription-tier-overview.tsx
+++ b/apps/site/src/pages/settings/billing-settings-panel/free-or-hobby-subscription-tier-overview.tsx
@@ -32,6 +32,7 @@ import {
   PaidSubscriptionTier,
   priceToHumanReadable,
 } from "../../shared/subscription-utils";
+import { externalServiceFreeAllowance } from "./external-service-free-allowance";
 import { SubscriptionFeatureList } from "./subscription-feature-list";
 import { SubscriptionFeature } from "./subscription-feature-list-item";
 
@@ -66,7 +67,13 @@ export const paidSubscriptionFeatures: Record<
         icon: <MapboxLogoIcon sx={{ fontSize: 18 }} />,
         title: (
           <>
-            <strong>25</strong> Mapbox Address Autofills
+            <strong>
+              {
+                externalServiceFreeAllowance["Mapbox Address Autofill Session"]
+                  .hobby
+              }
+            </strong>{" "}
+            Mapbox Address Autofills
           </>
         ),
       },
@@ -133,7 +140,12 @@ export const paidSubscriptionFeatures: Record<
               component="span"
               sx={{ color: ({ palette }) => palette.gray[60] }}
             >
-              300k+ words, 100 images, 50 address fills, etc.
+              300k+ words, 100 images,{" "}
+              {
+                externalServiceFreeAllowance["Mapbox Address Autofill Session"]
+                  .pro
+              }{" "}
+              address fills, etc.
             </Box>
           </>
         ),

--- a/apps/site/src/pages/settings/billing-settings-panel/free-or-hobby-subscription-tier-overview.tsx
+++ b/apps/site/src/pages/settings/billing-settings-panel/free-or-hobby-subscription-tier-overview.tsx
@@ -66,7 +66,7 @@ export const paidSubscriptionFeatures: Record<
         icon: <MapboxLogoIcon sx={{ fontSize: 18 }} />,
         title: (
           <>
-            <strong>20</strong> Mapbox Address Autofills
+            <strong>25</strong> Mapbox Address Autofills
           </>
         ),
       },
@@ -133,7 +133,7 @@ export const paidSubscriptionFeatures: Record<
               component="span"
               sx={{ color: ({ palette }) => palette.gray[60] }}
             >
-              300k+ words, 100 images, 40 address fills, etc.
+              300k+ words, 100 images, 50 address fills, etc.
             </Box>
           </>
         ),

--- a/apps/site/src/pages/settings/billing-settings-panel/pro-subscription-tier-overview.tsx
+++ b/apps/site/src/pages/settings/billing-settings-panel/pro-subscription-tier-overview.tsx
@@ -51,7 +51,7 @@ export const proSubscriptionFeatures: Record<
       icon: <MapboxLogoIcon sx={{ fontSize: 18 }} />,
       title: (
         <>
-          <strong>40</strong> Mapbox Address Autofills
+          <strong>50</strong> Mapbox Address Autofills
         </>
       ),
     },

--- a/apps/site/src/pages/settings/billing-settings-panel/pro-subscription-tier-overview.tsx
+++ b/apps/site/src/pages/settings/billing-settings-panel/pro-subscription-tier-overview.tsx
@@ -15,6 +15,7 @@ import { MicrophoneLogoIcon } from "../../../components/icons/microphone-icon";
 import { TagIcon } from "../../../components/icons/tag-icon";
 import { TrophyStarIcon } from "../../../components/icons/trophy-star-icon";
 import { priceToHumanReadable } from "../../shared/subscription-utils";
+import { externalServiceFreeAllowance } from "./external-service-free-allowance";
 import {
   SubscriptionFeature,
   SubscriptionFeatureListItem,
@@ -51,7 +52,13 @@ export const proSubscriptionFeatures: Record<
       icon: <MapboxLogoIcon sx={{ fontSize: 18 }} />,
       title: (
         <>
-          <strong>50</strong> Mapbox Address Autofills
+          <strong>
+            {
+              externalServiceFreeAllowance["Mapbox Address Autofill Session"]
+                .pro
+            }
+          </strong>{" "}
+          Mapbox Address Autofills
         </>
       ),
     },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR updates copy in the BP site to reflect the updated Mapbox Autofill free allowances:
- 10 sessions for free users
- 25 sessions for Hobby users
- 50 sessions for Pro users

It also re-defines the external service free allowance in a re-usable way, by introducing a `externalServiceFreeAllowance` object. In follow-up we should replace all references to free usage with usages of the `externalServiceFreeAllowance` object.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203623179643287/1204092897972678/f) _(internal)_
