### PR TITLE
Cancel previous jobs when newer commits were added

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
   merge_group:
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: hashintel

--- a/.github/workflows/site-deployment.yml
+++ b/.github/workflows/site-deployment.yml
@@ -6,6 +6,10 @@ on:
     - cron: "*/10 * * * *" ## Every 10 minutes
     - cron: "0 4 * * *" ## Around 4am every night (UTC time)
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   warm_up_vercel:
     ## Vercel uses AWS Lambda. When we call getStaticProps in fallback mode or getServerSideProps,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We don't need to run CI checks for commits which are outdated.

## 🔗 Related links

- [Slack thread](https://hashintel.slack.com/archives/C02TWBTT3ED/p1677854234827139) _(internal)_
