### PR TITLE
Disable yarn caching

### DIFF
--- a/.github/actions/warm-up-repo/action.yml
+++ b/.github/actions/warm-up-repo/action.yml
@@ -14,7 +14,6 @@ runs:
     - uses: actions/setup-node@v3
       with:
         node-version: 16 ## aligned with Node version on Vercel
-        cache: yarn
 
     - name: Install Cargo-Make
       shell: bash


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Downloading the yarn cache is only by about 20s to 30s faster, however, pollutes the cache we have available on GitHub. Also, uploading that cache takes at least that long, usually longer (the cache currently is about 1.2 GB per yarn cache).