### PR TITLE
Don't include source maps in production block build

### DIFF
--- a/.changeset/sharp-hotels-deliver.md
+++ b/.changeset/sharp-hotels-deliver.md
@@ -1,0 +1,5 @@
+---
+"block-scripts": patch
+---
+
+don't include sourcemaps in production build

--- a/libs/block-scripts/shared/webpack-config.js
+++ b/libs/block-scripts/shared/webpack-config.js
@@ -108,7 +108,7 @@ export const generateBuildWebpackConfig = async (mode) => {
   return {
     ...baseWebpackConfig,
     watch: mode === "development",
-    devtool: mode === "development" ? "inline-source-map" : "source-map",
+    devtool: mode === "development" ? "inline-source-map" : undefined,
     plugins: [
       ...(baseWebpackConfig.plugins ?? []),
       ...(mode === "production" ? [new BlockAssetsPlugin()] : []),


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Updates the webpack config in `block-scripts` so that it does not generate source maps in production.

This is for two reasons:
1. source maps blow up the block's `dist/` folder, which makes upload a lot slower (and risks hitting a ~4MB upload limit in the Vercel lambda we're currently using to process block publishing)

2. Generates console warnings when the source maps aren't available when loading a block from an embedding application, since the source maps aren't in a location relative to the embedding application (we could fix this in [config](https://webpack.js.org/plugins/source-map-dev-tool-plugin/) if we ever need to)