### PR TITLE
Disable codecov reporting status requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,9 @@ jobs:
         if: ${{ success() || failure() }}
         name: Upload coverage to https://app.codecov.io/gh/blockprotocol/blockprotocol
         with:
-          fail_ci_if_error: true
+          ## Temporarily disabled until https://github.com/codecov/codecov-action/issues/932 is resolved, and/or we rely
+          ## on coverage reports more strictly
+          fail_ci_if_error: false
           files: coverage/lcov.info
           flags: site-integration-${{ matrix.device }}
           token: ${{ secrets.CODECOV_TOKEN }} ## not required for public repos, can be removed when https://github.com/codecov/codecov-action/issues/837 is resolved


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Especially in the merge queue, I encounter many errors related to this. In HASH we disabled this due to flakiness as well.