### PR TITLE
Better error reporting for the WordPress plugin

### DIFF
--- a/libs/wordpress-plugin/plugin/trunk/block-protocol.php
+++ b/libs/wordpress-plugin/plugin/trunk/block-protocol.php
@@ -25,10 +25,10 @@ if (is_readable(__DIR__ . '/vendor/autoload.php')) {
 require_once __DIR__ . "/server/data.php";
 add_action('init', 'block_protocol_sentry_init');
 
+require_once __DIR__ . "/server/settings.php";
 require_once __DIR__ . "/server/block-db-table.php";
 require_once __DIR__ . "/server/query.php";
 require_once __DIR__ . "/server/block-api-endpoints.php";
-require_once __DIR__ . "/server/settings.php";
 require_once __DIR__ . "/server/util.php";
 
 // str_starts_with introduces a minimum WP version of 5.9.0 - we can avoid it by using this instead

--- a/libs/wordpress-plugin/plugin/trunk/server/block-db-table.php
+++ b/libs/wordpress-plugin/plugin/trunk/server/block-db-table.php
@@ -16,8 +16,8 @@ function block_protocol_migration_1()
     updated_at datetime NOT NULL,
 
     -- metadata for entities which represent links only
-    left_entity_id char(36),
-    right_entity_id char(36),
+    left_entity_id char(36) REFERENCES `{$wpdb->prefix}block_protocol_entities` (entity_id) ON DELETE CASCADE,
+    right_entity_id char(36) REFERENCES `{$wpdb->prefix}block_protocol_entities` (entity_id) ON DELETE CASCADE,
     left_to_right_order int UNSIGNED,
     right_to_left_order int UNSIGNED,
 
@@ -31,13 +31,8 @@ function block_protocol_migration_1()
 
   require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
 
-  // Some MariaDB versions doesn't support recursive references within the table itself,
-  // so we add the references after the table creation
-  $sql .= "ALTER TABLE `{$wpdb->prefix}block_protocol_entities` 
-    ADD FOREIGN KEY (left_entity_id) REFERENCES `{$wpdb->prefix}block_protocol_entities` (entity_id) ON DELETE CASCADE,
-    ADD FOREIGN KEY (right_entity_id) REFERENCES `{$wpdb->prefix}block_protocol_entities` (entity_id) ON DELETE CASCADE;
-  ";
   dbDelta($sql);
+  block_protocol_maybe_capture_error($wpdb->last_error);
 }
 
 function block_protocol_migrate()

--- a/libs/wordpress-plugin/plugin/trunk/server/data.php
+++ b/libs/wordpress-plugin/plugin/trunk/server/data.php
@@ -63,7 +63,7 @@ function block_protocol_debounced_view_data(bool $skip_check = false)
     update_option('block_protocol_view_count', $view_count + 1);
   }
 
-  if ($skip_check || $view_count % 100 == 0) {
+  if ($skip_check || $view_count % 30 == 0) {
     block_protocol_page_data("viewed", array_merge(block_protocol_aggregate_numbers(), [
       'viewCount' => (int) $view_count,
     ]));
@@ -183,4 +183,8 @@ function block_protocol_sentry_init()
         $scope->setUser(['id' => $public_id]);
     });
   }
+
+  \Sentry\configureScope(function (\Sentry\State\Scope $scope) use ($public_id) {
+    $scope->setContext('versions', block_protocol_report_version_info());
+  });
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR adds some information that has been missing from the client error reports we've received. I've also decreased the `view` event to send more regularly as the previous value was too high.

Settings are required/loaded up front so we don't misread the user's telemetry setting or the default.

Also the MariaDB fix wasn't necessary, we just had to add the column name to the foreign key (tested with MariaDB 10.6.12)

These changes together will allow us to better figure out exception reasons in the future.

##  Blocked by 
- #1123 