### PR TITLE
Add unsupported database version notice to WordPress plugin

### DIFF
--- a/libs/wordpress-plugin/plugin/trunk/block-protocol.php
+++ b/libs/wordpress-plugin/plugin/trunk/block-protocol.php
@@ -196,6 +196,11 @@ function block_dynamic_render_callback($block_attributes)
 //    - register each BP block as a variation of the plugin block
 function block_protocol_init()
 {
+	// DB is unsupported - bail
+  if (!block_protocol_is_database_supported()) {
+    return;
+  }
+
 	$response = get_block_protocol_blocks();
 	if (isset($response['errors'])) {
 		// user needs to set a valid API key – bail

--- a/libs/wordpress-plugin/plugin/trunk/block-protocol.php
+++ b/libs/wordpress-plugin/plugin/trunk/block-protocol.php
@@ -153,7 +153,15 @@ function block_protocol_database_unsupported()
 		?>
 		<div class="notice notice-error is-dismissible">
 			<p>Block Protocol:
-				<?php echo (esc_html("The database you are using is not supported by the plugin. Please use MySQL " . MINIMUM_MYSQL_VERSION . "+ or MariaDB " . MINIMUM_MARIADB_VERSION . "+")) ?>
+				<?php 
+				
+				echo (esc_html(
+					"The database you are using is not supported by the plugin. Please use MySQL " 
+					. BLOCK_PROTOCOL_MINIMUM_MYSQL_VERSION 
+					. "+ or MariaDB " 
+					. BLOCK_PROTOCOL_MINIMUM_MARIADB_VERSION 
+					. "+"));
+				?>
 			<p>
 		</div>
 	<?php

--- a/libs/wordpress-plugin/plugin/trunk/block-protocol.php
+++ b/libs/wordpress-plugin/plugin/trunk/block-protocol.php
@@ -145,9 +145,25 @@ function check_block_protocol_connection()
 	}
 }
 
+function block_protocol_database_unsupported()
+{
+	$supported = block_protocol_is_database_supported();
+
+	if (!$supported) {
+		?>
+		<div class="notice notice-error is-dismissible">
+			<p>Block Protocol:
+				<?php echo (esc_html("The database you are using is not supported by the plugin. Please use MySQL " . MINIMUM_MYSQL_VERSION . "+ or MariaDB " . MINIMUM_MARIADB_VERSION . "+")) ?>
+			<p>
+		</div>
+	<?php
+	}
+}
+
 global $pagenow;
 if ($pagenow == 'index.php' || $pagenow == 'plugins.php' || ($pagenow == 'admin.php' && ('block_protocol' === $_GET['page']))) {
 	add_action('admin_notices', 'check_block_protocol_connection');
+	add_action('admin_notices', 'block_protocol_database_unsupported');
 }
 
 /*

--- a/libs/wordpress-plugin/plugin/trunk/server/block-db-table.php
+++ b/libs/wordpress-plugin/plugin/trunk/server/block-db-table.php
@@ -63,6 +63,11 @@ function block_protocol_migrate()
 {
   $saved_version = (int) get_site_option('block_protocol_db_migration_version');
 
+  // Don't apply migrations if the DB version is unsupported.
+  if (!block_protocol_is_database_supported()) {
+    return;
+  }
+
   if ($saved_version < 2) {
     block_protocol_migration_1();
     update_site_option('block_protocol_db_migration_version', 2);

--- a/libs/wordpress-plugin/plugin/trunk/server/block-db-table.php
+++ b/libs/wordpress-plugin/plugin/trunk/server/block-db-table.php
@@ -1,7 +1,7 @@
 <?php
 
-const MINIMUM_MYSQL_VERSION = "8.0.0";
-const MINIMUM_MARIADB_VERSION = "10.2.7";
+const BLOCK_PROTOCOL_MINIMUM_MYSQL_VERSION = "8.0.0";
+const BLOCK_PROTOCOL_MINIMUM_MARIADB_VERSION = "10.2.7";
 
 function block_protocol_is_database_supported()
 {
@@ -12,10 +12,10 @@ function block_protocol_is_database_supported()
 
   if (strpos($db_server_info, 'MariaDB') != false) {
     // site is using MariaDB
-    return $db_version >= MINIMUM_MARIADB_VERSION;
+    return $db_version >= BLOCK_PROTOCOL_MINIMUM_MARIADB_VERSION;
   } else {
     // site is using MySQL
-    return $db_version >= MINIMUM_MYSQL_VERSION;
+    return $db_version >= BLOCK_PROTOCOL_MINIMUM_MYSQL_VERSION;
   }
 }
 

--- a/libs/wordpress-plugin/plugin/trunk/server/block-db-table.php
+++ b/libs/wordpress-plugin/plugin/trunk/server/block-db-table.php
@@ -1,5 +1,24 @@
 <?php
 
+const MINIMUM_MYSQL_VERSION = "8.0.0";
+const MINIMUM_MARIADB_VERSION = "10.2.7";
+
+function block_protocol_is_database_supported()
+{
+  global $wpdb;
+  
+  $db_version = $wpdb->db_version();
+  $db_server_info = $wpdb->db_server_info();
+
+  if (strpos($db_server_info, 'MariaDB') != false) {
+    // site is using MariaDB
+    return $db_version >= MINIMUM_MARIADB_VERSION;
+  } else {
+    // site is using MySQL
+    return $db_version >= MINIMUM_MYSQL_VERSION;
+  }
+}
+
 function block_protocol_migration_1()
 {
   global $wpdb;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR adds a notice if the database used for WordPress is unsupported in the admin settings - we also totally disable the migrations and admin-part of the post viewing to disable any issues. If the admin can't even make blocks, the user-facing post won't run into errors.
We use a generic message to prevent any abuse in exposing the exact DB version through the notice.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203623179643290/1204120050952648/f) _(internal)_

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

- #1123 

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Adds a new check for the DB version using our documented versions
- Adds early bails for admin init and migrations
- Adds `admin_notice` for when the DB version is unsupported

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->
Change docker compose "db" service to 
```yaml
  db:
    platform: linux/amd64
    image: mariadb:10.2.6
    ports:
      - "3306:3306"
    volumes:
      - db_data:/var/lib/mysql
    restart: always
    environment:
      MYSQL_ROOT_PASSWORD: somewordpress
      MYSQL_DATABASE: wordpress
      MYSQL_USER: wordpress
      MYSQL_PASSWORD: wordpress
```
(Yes that MariaDB version uses MYSQL for the env vars)
Start the plugin dev env as usual using the readme instructions

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
Using MariaDB 10.2.6, should be the same for MySQL < 8
![image](https://user-images.githubusercontent.com/6988668/223174543-7bf4d32b-6064-41c2-a562-983ce27119aa.png)
