### PR TITLE
Move `docker-compose.yml` for the WordPress plugin to `infra/docker/wordpress`

### DIFF
--- a/infra/docker/wordpress/docker-compose.yml
+++ b/infra/docker/wordpress/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     volumes:
       # Mount the plugin folder inside our plugins directory so that WP automatically picks up our work.
       - type: bind
-        source: ../plugin/trunk
+        source: ../../../libs/wordpress-plugin/plugin/trunk
         target: /var/www/html/wp-content/plugins/blockprotocol
 
 volumes:

--- a/libs/wordpress-plugin/README.md
+++ b/libs/wordpress-plugin/README.md
@@ -9,7 +9,7 @@ If you are looking to install it on your own WordPress server, please visit http
 ### First time set up
 
 - run `yarn`
-- run `yarn dev:wordpress`
+- run `yarn dev:wordpress up`
 - run `yarn dev:plugin`
 - visit [http://localhost:8000](http://localhost:8000)
 - go through the WordPress set up flow
@@ -19,7 +19,7 @@ If you are looking to install it on your own WordPress server, please visit http
 ### Regular development
 
 - `yarn dev:plugin` to run the plugin
-- `yarn dev:wordpress` (WP server logs are visible in the output)
+- `yarn dev:wordpress up` (WP server logs are visible in the output)
 - visit [http://localhost:8000](http://localhost:8000)
 - amend `BLOCK_PROTOCOL_SITE_HOST` in `docker-compose.yml` if you want to test against a staging Block Hub
 
@@ -35,7 +35,7 @@ Some changes (e.g. switching or patching dependencies) may require killing and r
 
 ### Folder structure
 
-`wordpress` contains a Docker compose file for a local WordPress (run on `yarn dev:wordpress`)
+`wordpress` contains a Docker compose file for a local WordPress (run on `yarn dev:wordpress up`)
 The `plugin` folder follows the same structure as in its [Subversion release repository](https://plugins.trac.wordpress.org/browser/blockprotocol), i.e.:
 
 - an `assets` folder which contains images for use on its [plugin directory page](https://wordpress.org/plugins/blockprotocol/)

--- a/libs/wordpress-plugin/package.json
+++ b/libs/wordpress-plugin/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "build": "composer install -d plugin/trunk && wp-scripts build",
     "dev:plugin": "wp-scripts start",
-    "dev:wordpress": "docker compose -f wordpress/docker-compose.yml  up",
+    "dev:wordpress": "docker compose -f ../../infra/docker/wordpress/docker-compose.yml",
     "fix:eslint": "eslint --fix .",
     "postinstall": "patch-package  --error-on-warn",
     "lint:eslint": "eslint --report-unused-disable-directives .",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR moves the `docker-compose.yml` used for developing the wordpress plugin into the `infra/docker/wordpress` directory. I've updated the `package.json` to reflect this and updated the readme as I've removed the `up` from the yarn script.

The change to the yarn script is so we can more easily shut down the server and delete the volume by doing `yarn dev:wordpress down -v`
## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203623179643290/1204086165607416/f) _(internal)_

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- See PR purpose

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

- I've updated the README to reflect the `yarn script` being `yarn dev:wordpress up` now

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None, this would be part of the dev workflow

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->
Checkout branch, run readme instructions, there should be no change