### PR TITLE
Add "GPT-3.5 Turbo" copy to the BP site

### DIFF
--- a/apps/site/src/_pages/legal/terms/1_products.mdx
+++ b/apps/site/src/_pages/legal/terms/1_products.mdx
@@ -47,7 +47,7 @@ External Services provide access to free and paid APIs and endpoints from the Bl
 
 | Third-Party Provider | External Services                                                               | Applicable Terms                                                         |
 | -------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| OpenAI               | DALL-E, GPT-3 Ada, GPT-3 Babbage, GPT-3 Curie, GPT-3 Davinci                    | [OpenAI Terms of Use](https://openai.com/terms/)                         |
+| OpenAI               | DALL-E, GPT-3 Ada, GPT-3 Babbage, GPT-3 Curie, GPT-3 Davinci, GPT-3.5 Turbo     | [OpenAI Terms of Use](https://openai.com/terms/)                         |
 | Mapbox               | Address Autofill, Static Map Images, Isochrone, Directions, Temporary Geocoding | [Mapbox Terms of Service](https://www.mapbox.com/legal/tos)              |
 | Block Protocol       | OpenAI Whisper                                                                  | [Block Protocol Terms of Service](https://blockprotocol.org/legal/terms) |
 | HASH                 | HASH, HASH Engine                                                               | [HASH Terms of Service](https://hash.ai/legal/terms)                     |

--- a/apps/site/src/components/pages/pricing/free-tier-section.tsx
+++ b/apps/site/src/components/pages/pricing/free-tier-section.tsx
@@ -207,7 +207,7 @@ export const FreeTierSection: FunctionComponent<{
                 icon: faWandMagicSparkles,
                 text: (
                   <>
-                    <strong>Free credits</strong> for use of OpenAI GPT-3,
+                    <strong>Free credits</strong> for use of OpenAI GPT-3.5,
                     Mapbox and more
                   </>
                 ),

--- a/apps/site/src/components/pages/pricing/paid-addons-section.tsx
+++ b/apps/site/src/components/pages/pricing/paid-addons-section.tsx
@@ -114,6 +114,25 @@ const API_USAGE_ROWS = [
     ),
     provider: "OpenAI",
     serviceTooltip:
+      "GPT-3.5 Turbo is the latest model from OpenAI. It is the best current language model for many use cases, including chat. It is also ten times cheaper than GPT-3 Davinci, and much faster.",
+    serviceIcon: faText,
+    service: "GPT-3.5 Turbo",
+    price: "$0.0020",
+    unitTooltip:
+      "Text provided to GPT-3.5 turbo models is split into tokens. 1,000 tokens equates to roughly 750 words (i.e. approximately 4000 characters) in English",
+    unit: "/1k tokens",
+  },
+  {
+    providerIcon: (
+      <AbstractAiIcon
+        sx={{
+          fontSize: 16,
+        }}
+        fill={theme.palette.gray[50]}
+      />
+    ),
+    provider: "OpenAI",
+    serviceTooltip:
       "Davinci is the most advanced GPT-3 large language model, providing the highest-quality, longest-length outputs.",
     serviceIcon: faText,
     service: "GPT-3 Davinci",

--- a/apps/site/src/components/pages/pricing/paid-tiers-section.tsx
+++ b/apps/site/src/components/pages/pricing/paid-tiers-section.tsx
@@ -64,6 +64,32 @@ type PaidSubscription = {
   additionalFeatures: SubscriptionFeature[];
 };
 
+const openaiLanguageFreeAllowances = [
+  externalServiceFreeAllowance["OpenAI GPT-3.5 Turbo Token"],
+  externalServiceFreeAllowance["OpenAI Ada Token"],
+  externalServiceFreeAllowance["OpenAI Babbage Token"],
+  externalServiceFreeAllowance["OpenAI Curie Token"],
+  externalServiceFreeAllowance["OpenAI Davinci Token"],
+];
+
+const numberOfOpenaiHobbyLanguageTokens = openaiLanguageFreeAllowances.reduce(
+  (prev, { hobby }) => prev + hobby,
+  0,
+);
+
+const numberOfOpenaiProLanguageTokens = openaiLanguageFreeAllowances.reduce(
+  (prev, { pro }) => prev + pro,
+  0,
+);
+
+const numberOfOpenaiHobbyWords = numberOfOpenaiHobbyLanguageTokens * 0.75;
+
+const numberOfOpenaiProWords = numberOfOpenaiProLanguageTokens * 0.75;
+
+const numberOfThousandOpenaiHobbyWords = numberOfOpenaiHobbyWords * 0.001;
+
+const numberOfThousandOpenaiProWords = numberOfOpenaiProWords * 0.001;
+
 export const paidSubscriptionFeatures: Record<
   PaidSubscriptionTier,
   PaidSubscription
@@ -94,7 +120,13 @@ export const paidSubscriptionFeatures: Record<
             component="span"
             sx={{ color: ({ palette }) => palette.purple[30] }}
           >
-            <strong>50</strong> OpenAI DALL-E images
+            <strong>
+              {
+                externalServiceFreeAllowance["OpenAI Create Image Request"]
+                  .hobby
+              }
+            </strong>{" "}
+            OpenAI DALL-E images
             <br />
             <Typography
               component="span"
@@ -134,7 +166,10 @@ export const paidSubscriptionFeatures: Record<
             component="span"
             sx={{ color: ({ palette }) => palette.purple[30] }}
           >
-            <strong>200,000</strong> OpenAI GPT-3 tokens
+            <strong>
+              {numberOfOpenaiHobbyLanguageTokens.toLocaleString()}
+            </strong>{" "}
+            OpenAI GPT language tokens
             <br />
             <Typography
               component="span"
@@ -145,7 +180,7 @@ export const paidSubscriptionFeatures: Record<
                 fontWeight: 400,
               }}
             >
-              Equating to ~150k words
+              Equating to ~{numberOfThousandOpenaiHobbyWords.toFixed(1)}k words
             </Typography>
           </Box>
         ),
@@ -178,7 +213,12 @@ export const paidSubscriptionFeatures: Record<
                       component="span"
                       sx={{ color: ({ palette }) => palette.purple[30] }}
                     >
-                      <strong>10k</strong> OpenAI Davinci tokens
+                      <strong>
+                        {externalServiceFreeAllowance["OpenAI Davinci Token"]
+                          .hobby / 1000}
+                        k
+                      </strong>{" "}
+                      OpenAI GPT-3 Davinci tokens
                     </Box>
                   ),
                   iconCentered: true,
@@ -190,7 +230,12 @@ export const paidSubscriptionFeatures: Record<
                       component="span"
                       sx={{ color: ({ palette }) => palette.purple[30] }}
                     >
-                      <strong>40k</strong> OpenAI Curie tokens
+                      <strong>
+                        {externalServiceFreeAllowance["OpenAI Curie Token"]
+                          .hobby / 1000}
+                        k
+                      </strong>{" "}
+                      OpenAI GPT-3 Curie tokens
                     </Box>
                   ),
                   iconCentered: true,
@@ -202,7 +247,12 @@ export const paidSubscriptionFeatures: Record<
                       component="span"
                       sx={{ color: ({ palette }) => palette.purple[30] }}
                     >
-                      <strong>50k</strong> OpenAI Babbage tokens
+                      <strong>
+                        {externalServiceFreeAllowance["OpenAI Babbage Token"]
+                          .hobby / 1000}
+                        k
+                      </strong>{" "}
+                      OpenAI GPT-3 Babbage tokens
                     </Box>
                   ),
                   iconCentered: true,
@@ -214,7 +264,12 @@ export const paidSubscriptionFeatures: Record<
                       component="span"
                       sx={{ color: ({ palette }) => palette.purple[30] }}
                     >
-                      <strong>100k</strong> OpenAI Ada tokens
+                      <strong>
+                        {externalServiceFreeAllowance["OpenAI Ada Token"]
+                          .hobby / 1000}
+                        k
+                      </strong>{" "}
+                      OpenAI GPT-3 Ada tokens
                     </Box>
                   ),
                   iconCentered: true,
@@ -294,7 +349,13 @@ export const paidSubscriptionFeatures: Record<
             component="span"
             sx={{ color: ({ palette }) => palette.purple[30] }}
           >
-            <strong>300</strong> Mapbox Static Images
+            <strong>
+              {
+                externalServiceFreeAllowance["Mapbox Static Image Request"]
+                  .hobby
+              }
+            </strong>{" "}
+            Mapbox Static Images
             <br />
             <Typography
               component="span"
@@ -371,7 +432,9 @@ export const paidSubscriptionFeatures: Record<
                 color: ({ palette }) => palette.purple[60],
               }}
             >
-              e.g. 300k+ words, 100 images, and{" "}
+              e.g. {numberOfThousandOpenaiProWords}k+ words,{" "}
+              {externalServiceFreeAllowance["OpenAI Create Image Request"].pro}{" "}
+              images, and{" "}
               {
                 externalServiceFreeAllowance["Mapbox Address Autofill Session"]
                   .pro
@@ -388,7 +451,10 @@ export const paidSubscriptionFeatures: Record<
             component="span"
             sx={{ color: ({ palette }) => palette.purple[30] }}
           >
-            <strong>500</strong> Mapbox Isochrone API calls
+            <strong>
+              {externalServiceFreeAllowance["Mapbox Isochrone Request"].pro}
+            </strong>{" "}
+            Mapbox Isochrone API calls
           </Box>
         ),
       },
@@ -399,7 +465,10 @@ export const paidSubscriptionFeatures: Record<
             component="span"
             sx={{ color: ({ palette }) => palette.purple[30] }}
           >
-            <strong>500</strong> Mapbox Directions API calls
+            <strong>
+              {externalServiceFreeAllowance["Mapbox Directions Request"].pro}
+            </strong>{" "}
+            Mapbox Directions API calls
           </Box>
         ),
       },
@@ -410,7 +479,14 @@ export const paidSubscriptionFeatures: Record<
             component="span"
             sx={{ color: ({ palette }) => palette.purple[30] }}
           >
-            <strong>500</strong> Mapbox Temporary Geocoding API calls
+            <strong>
+              {
+                externalServiceFreeAllowance[
+                  "Mapbox Temporary Geocoding Request"
+                ].pro
+              }
+            </strong>{" "}
+            Mapbox Temporary Geocoding API calls
           </Box>
         ),
       },
@@ -791,14 +867,16 @@ export const PaidTiersSection: FunctionComponent<{
               <Stack flexDirection="row" flexWrap="wrap" gap={1} mt={2.25}>
                 <HobbyTierPerk
                   headerIcon={faText}
-                  title="150k"
+                  title={`${numberOfThousandOpenaiHobbyWords.toFixed(1)}k`}
                   description="AI-generated words"
                   poweredByIcon={<AbstractAiIcon sx={{ fontSize: 20 }} />}
                   poweredBy="GPT-3"
                 />
                 <HobbyTierPerk
                   headerIcon={faImage}
-                  title="50"
+                  title={externalServiceFreeAllowance[
+                    "OpenAI Create Image Request"
+                  ].hobby.toString()}
                   description="AI-generated images"
                   poweredByIcon={<AbstractAiIcon sx={{ fontSize: 20 }} />}
                   poweredBy="DALL-E"
@@ -814,7 +892,9 @@ export const PaidTiersSection: FunctionComponent<{
                 />
                 <HobbyTierPerk
                   headerIcon={faMapLocationDot}
-                  title="300"
+                  title={externalServiceFreeAllowance[
+                    "Mapbox Static Image Request"
+                  ].hobby.toString()}
                   description="Unique maps created"
                   poweredByIcon={<MapboxLogoIcon sx={{ fontSize: 20 }} />}
                   poweredBy="MAPBOX"

--- a/apps/site/src/components/pages/pricing/paid-tiers-section.tsx
+++ b/apps/site/src/components/pages/pricing/paid-tiers-section.tsx
@@ -19,7 +19,12 @@ import Image from "next/legacy/image";
 import { FunctionComponent, ReactNode, useState } from "react";
 
 import proTierBackground from "../../../../public/assets/pricing/pro-tier-background.svg";
-import { externalServiceFreeAllowance } from "../../../pages/settings/billing-settings-panel/external-service-free-allowance";
+import {
+  externalServiceFreeAllowance,
+  numberOfOpenaiHobbyLanguageTokens,
+  numberOfThousandOpenaiHobbyWords,
+  numberOfThousandOpenaiProWords,
+} from "../../../pages/settings/billing-settings-panel/external-service-free-allowance";
 import { SubscriptionFeatureList } from "../../../pages/settings/billing-settings-panel/subscription-feature-list";
 import { SubscriptionFeature } from "../../../pages/settings/billing-settings-panel/subscription-feature-list-item";
 import {
@@ -63,32 +68,6 @@ type PaidSubscription = {
   coreFeatures: SubscriptionFeature[];
   additionalFeatures: SubscriptionFeature[];
 };
-
-const openaiLanguageFreeAllowances = [
-  externalServiceFreeAllowance["OpenAI GPT-3.5 Turbo Token"],
-  externalServiceFreeAllowance["OpenAI Ada Token"],
-  externalServiceFreeAllowance["OpenAI Babbage Token"],
-  externalServiceFreeAllowance["OpenAI Curie Token"],
-  externalServiceFreeAllowance["OpenAI Davinci Token"],
-];
-
-const numberOfOpenaiHobbyLanguageTokens = openaiLanguageFreeAllowances.reduce(
-  (prev, { hobby }) => prev + hobby,
-  0,
-);
-
-const numberOfOpenaiProLanguageTokens = openaiLanguageFreeAllowances.reduce(
-  (prev, { pro }) => prev + pro,
-  0,
-);
-
-const numberOfOpenaiHobbyWords = numberOfOpenaiHobbyLanguageTokens * 0.75;
-
-const numberOfOpenaiProWords = numberOfOpenaiProLanguageTokens * 0.75;
-
-const numberOfThousandOpenaiHobbyWords = numberOfOpenaiHobbyWords * 0.001;
-
-const numberOfThousandOpenaiProWords = numberOfOpenaiProWords * 0.001;
 
 export const paidSubscriptionFeatures: Record<
   PaidSubscriptionTier,
@@ -432,7 +411,7 @@ export const paidSubscriptionFeatures: Record<
                 color: ({ palette }) => palette.purple[60],
               }}
             >
-              e.g. {numberOfThousandOpenaiProWords}k+ words,{" "}
+              e.g. ~{numberOfThousandOpenaiProWords}k+ words,{" "}
               {externalServiceFreeAllowance["OpenAI Create Image Request"].pro}{" "}
               images, and{" "}
               {
@@ -867,7 +846,7 @@ export const PaidTiersSection: FunctionComponent<{
               <Stack flexDirection="row" flexWrap="wrap" gap={1} mt={2.25}>
                 <HobbyTierPerk
                   headerIcon={faText}
-                  title={`${numberOfThousandOpenaiHobbyWords.toFixed(1)}k`}
+                  title={`~${numberOfThousandOpenaiHobbyWords.toFixed(1)}k`}
                   description="AI-generated words"
                   poweredByIcon={<AbstractAiIcon sx={{ fontSize: 20 }} />}
                   poweredBy="GPT-3"

--- a/apps/site/src/components/pages/pricing/paid-tiers-section.tsx
+++ b/apps/site/src/components/pages/pricing/paid-tiers-section.tsx
@@ -1146,7 +1146,7 @@ export const PaidTiersSection: FunctionComponent<{
             </Box>
             {lg ? (
               <Collapse in={fullPlanDetailsOpen}>
-                <Box sx={{ mt: 6.25 }}>
+                <Box sx={{ mt: 10.75 }}>
                   <Image
                     layout="responsive"
                     src={proTierBackground}

--- a/apps/site/src/components/pages/pricing/paid-tiers-section.tsx
+++ b/apps/site/src/components/pages/pricing/paid-tiers-section.tsx
@@ -160,6 +160,24 @@ export const paidSubscriptionFeatures: Record<
                       component="span"
                       sx={{ color: ({ palette }) => palette.purple[30] }}
                     >
+                      <strong>
+                        {externalServiceFreeAllowance[
+                          "OpenAI GPT-3.5 Turbo Token"
+                        ].hobby / 1000}
+                        k
+                      </strong>{" "}
+                      OpenAI GPT-3.5 Turbo tokens
+                    </Box>
+                  ),
+                  iconCentered: true,
+                },
+                {
+                  icon: <GradientFontAwesomeIcon icon={faArrowRight} light />,
+                  title: (
+                    <Box
+                      component="span"
+                      sx={{ color: ({ palette }) => palette.purple[30] }}
+                    >
                       <strong>10k</strong> OpenAI Davinci tokens
                     </Box>
                   ),

--- a/apps/site/src/pages/settings/billing-settings-panel/external-service-free-allowance.ts
+++ b/apps/site/src/pages/settings/billing-settings-panel/external-service-free-allowance.ts
@@ -80,3 +80,27 @@ export const externalServiceFreeAllowance: Record<
     pro: 20_000,
   },
 };
+
+const openaiLanguageFreeAllowances = [
+  externalServiceFreeAllowance["OpenAI GPT-3.5 Turbo Token"],
+  externalServiceFreeAllowance["OpenAI Ada Token"],
+  externalServiceFreeAllowance["OpenAI Babbage Token"],
+  externalServiceFreeAllowance["OpenAI Curie Token"],
+  externalServiceFreeAllowance["OpenAI Davinci Token"],
+];
+
+export const numberOfOpenaiHobbyLanguageTokens =
+  openaiLanguageFreeAllowances.reduce((prev, { hobby }) => prev + hobby, 0);
+
+export const numberOfOpenaiProLanguageTokens =
+  openaiLanguageFreeAllowances.reduce((prev, { pro }) => prev + pro, 0);
+
+export const numberOfOpenaiHobbyWords =
+  numberOfOpenaiHobbyLanguageTokens * 0.75;
+
+export const numberOfOpenaiProWords = numberOfOpenaiProLanguageTokens * 0.75;
+
+export const numberOfThousandOpenaiHobbyWords =
+  numberOfOpenaiHobbyWords * 0.001;
+
+export const numberOfThousandOpenaiProWords = numberOfOpenaiProWords * 0.001;

--- a/apps/site/src/pages/settings/billing-settings-panel/external-service-free-allowance.ts
+++ b/apps/site/src/pages/settings/billing-settings-panel/external-service-free-allowance.ts
@@ -5,6 +5,7 @@ const externalServiceNames = [
   "Mapbox Temporary Geocoding Request",
   "Mapbox Static Image Request",
   "OpenAI Create Image Request",
+  "OpenAI GPT-3.5 Turbo Token",
   "OpenAI Ada Token",
   "OpenAI Babbage Token",
   "OpenAI Curie Token",
@@ -52,6 +53,11 @@ export const externalServiceFreeAllowance: Record<
     free: 5,
     hobby: 50,
     pro: 100,
+  },
+  "OpenAI GPT-3.5 Turbo Token": {
+    free: 10_000,
+    hobby: 50_000,
+    pro: 100_000,
   },
   "OpenAI Ada Token": {
     free: 0,

--- a/apps/site/src/pages/settings/billing-settings-panel/free-or-hobby-subscription-tier-overview.tsx
+++ b/apps/site/src/pages/settings/billing-settings-panel/free-or-hobby-subscription-tier-overview.tsx
@@ -32,7 +32,11 @@ import {
   PaidSubscriptionTier,
   priceToHumanReadable,
 } from "../../shared/subscription-utils";
-import { externalServiceFreeAllowance } from "./external-service-free-allowance";
+import {
+  externalServiceFreeAllowance,
+  numberOfThousandOpenaiHobbyWords,
+  numberOfThousandOpenaiProWords,
+} from "./external-service-free-allowance";
 import { SubscriptionFeatureList } from "./subscription-feature-list";
 import { SubscriptionFeature } from "./subscription-feature-list-item";
 
@@ -51,7 +55,8 @@ export const paidSubscriptionFeatures: Record<
         icon: <AbstractAiIcon sx={{ fontSize: 18 }} />,
         title: (
           <>
-            <strong>150k</strong> AI-generated words (powered by GPT-3)
+            <strong>~{numberOfThousandOpenaiHobbyWords}k</strong> AI-generated
+            words (powered by GPT-3)
           </>
         ),
       },
@@ -59,7 +64,13 @@ export const paidSubscriptionFeatures: Record<
         icon: <AbstractAiIcon sx={{ fontSize: 18 }} />,
         title: (
           <>
-            <strong>50</strong> AI-generated images (powered by DALL-E)
+            <strong>
+              {
+                externalServiceFreeAllowance["OpenAI Create Image Request"]
+                  .hobby
+              }
+            </strong>{" "}
+            AI-generated images (powered by DALL-E)
           </>
         ),
       },
@@ -81,7 +92,13 @@ export const paidSubscriptionFeatures: Record<
         icon: <MapLocationDotIcon sx={{ fontSize: 18 }} />,
         title: (
           <>
-            <strong>300</strong> Mapbox Static Maps
+            <strong>
+              {
+                externalServiceFreeAllowance["Mapbox Static Image Request"]
+                  .hobby
+              }
+            </strong>{" "}
+            Mapbox Static Maps
           </>
         ),
       },
@@ -140,7 +157,9 @@ export const paidSubscriptionFeatures: Record<
               component="span"
               sx={{ color: ({ palette }) => palette.gray[60] }}
             >
-              300k+ words, 100 images,{" "}
+              ~{numberOfThousandOpenaiProWords}k+ words,{" "}
+              {externalServiceFreeAllowance["OpenAI Create Image Request"].pro}{" "}
+              images,{" "}
               {
                 externalServiceFreeAllowance["Mapbox Address Autofill Session"]
                   .pro
@@ -154,7 +173,10 @@ export const paidSubscriptionFeatures: Record<
         icon: <LocationIcon sx={{ fontSize: 18 }} />,
         title: (
           <>
-            <strong>500</strong> Mapbox Isochrone API calls
+            <strong>
+              {externalServiceFreeAllowance["Mapbox Isochrone Request"].pro}
+            </strong>{" "}
+            Mapbox Isochrone API calls
           </>
         ),
       },
@@ -162,7 +184,10 @@ export const paidSubscriptionFeatures: Record<
         icon: <LocationArrowIcon sx={{ fontSize: 18 }} />,
         title: (
           <>
-            <strong>500</strong> Mapbox Directions API calls
+            <strong>
+              {externalServiceFreeAllowance["Mapbox Directions Request"].pro}
+            </strong>{" "}
+            Mapbox Directions API calls
           </>
         ),
       },
@@ -170,7 +195,14 @@ export const paidSubscriptionFeatures: Record<
         icon: <MapLocationDotIcon sx={{ fontSize: 18 }} />,
         title: (
           <>
-            <strong>500</strong> Mapbox Temporary Geocoding API calls
+            <strong>
+              {
+                externalServiceFreeAllowance[
+                  "Mapbox Temporary Geocoding Request"
+                ].pro
+              }
+            </strong>{" "}
+            Mapbox Temporary Geocoding API calls
           </>
         ),
       },

--- a/apps/site/src/pages/settings/billing-settings-panel/pro-subscription-tier-overview.tsx
+++ b/apps/site/src/pages/settings/billing-settings-panel/pro-subscription-tier-overview.tsx
@@ -15,7 +15,10 @@ import { MicrophoneLogoIcon } from "../../../components/icons/microphone-icon";
 import { TagIcon } from "../../../components/icons/tag-icon";
 import { TrophyStarIcon } from "../../../components/icons/trophy-star-icon";
 import { priceToHumanReadable } from "../../shared/subscription-utils";
-import { externalServiceFreeAllowance } from "./external-service-free-allowance";
+import {
+  externalServiceFreeAllowance,
+  numberOfThousandOpenaiProWords,
+} from "./external-service-free-allowance";
 import {
   SubscriptionFeature,
   SubscriptionFeatureListItem,
@@ -36,7 +39,8 @@ export const proSubscriptionFeatures: Record<
       icon: <AbstractAiIcon sx={{ fontSize: 18 }} />,
       title: (
         <>
-          <strong>300k</strong> AI-generated words (powered by GPT-3)
+          <strong>~{numberOfThousandOpenaiProWords}k</strong> AI-generated words
+          (powered by GPT-3)
         </>
       ),
     },
@@ -44,7 +48,10 @@ export const proSubscriptionFeatures: Record<
       icon: <AbstractAiIcon sx={{ fontSize: 18 }} />,
       title: (
         <>
-          <strong>100</strong> AI-generated images (powered by DALL-E)
+          <strong>
+            {externalServiceFreeAllowance["OpenAI Create Image Request"].pro}
+          </strong>{" "}
+          AI-generated images (powered by DALL-E)
         </>
       ),
     },
@@ -66,7 +73,10 @@ export const proSubscriptionFeatures: Record<
       icon: <MapLocationDotIcon sx={{ fontSize: 18 }} />,
       title: (
         <>
-          <strong>600</strong> Mapbox Static Maps
+          <strong>
+            {externalServiceFreeAllowance["Mapbox Static Image Request"].pro}
+          </strong>{" "}
+          Mapbox Static Maps
         </>
       ),
     },
@@ -74,7 +84,10 @@ export const proSubscriptionFeatures: Record<
       icon: <LocationIcon sx={{ fontSize: 18 }} />,
       title: (
         <>
-          <strong>500</strong> Mapbox Isochrone API calls
+          <strong>
+            {externalServiceFreeAllowance["Mapbox Isochrone Request"].pro}
+          </strong>{" "}
+          Mapbox Isochrone API calls
         </>
       ),
     },
@@ -82,7 +95,10 @@ export const proSubscriptionFeatures: Record<
       icon: <LocationArrowIcon sx={{ fontSize: 18 }} />,
       title: (
         <>
-          <strong>500</strong> Mapbox Directions API calls
+          <strong>
+            {externalServiceFreeAllowance["Mapbox Directions Request"].pro}
+          </strong>{" "}
+          Mapbox Directions API calls
         </>
       ),
     },
@@ -90,7 +106,13 @@ export const proSubscriptionFeatures: Record<
       icon: <MapLocationDotIcon sx={{ fontSize: 18 }} />,
       title: (
         <>
-          <strong>500</strong> Mapbox Temporary Geocoding API calls
+          <strong>
+            {
+              externalServiceFreeAllowance["Mapbox Temporary Geocoding Request"]
+                .pro
+            }
+          </strong>{" "}
+          Mapbox Temporary Geocoding API calls
         </>
       ),
     },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR adds "GPT-3.5 Turbo" copy to the BP site, informing users of the price and free allowance of the "GPT-3.5 Turbo" OpenAI model.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203623179643290/1204092897972686/f) _(internal)_

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

<img width="688" alt="image" src="https://user-images.githubusercontent.com/42802102/223414909-bf77ec1e-7e16-4833-8903-0879ccc444b0.png">

<img width="444" alt="image" src="https://user-images.githubusercontent.com/42802102/223414899-015360c0-0cdb-4bae-93b0-4debd241cca9.png">

