### PR TITLE
Disable Sentry Replay sticky session

### DIFF
--- a/apps/site/sentry.client.config.ts
+++ b/apps/site/sentry.client.config.ts
@@ -8,7 +8,7 @@ Sentry.init({
   dsn,
   enabled: !!dsn,
   environment: process.env.NEXT_PUBLIC_VERCEL_ENV ?? "unset",
-  integrations: [new Sentry.Replay({ stickySession: true })],
+  integrations: [new Sentry.Replay({ stickySession: false })],
   replaysOnErrorSampleRate: 1,
   replaysSessionSampleRate: parseFloat(
     process.env.NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE ?? "0",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Visiting a block's page in incognito, if you have third-party cookies disabled in incognito, will result in the following error and the iFrame code not working:
```
Failed to read the 'sessionStorage' property from 'Window': Access is denied for this document.
```
This is because Chrome treats `sessionStorage` access on the same basis as third-party cookies, at least this case (i.e. deny access if third-party cookies are denied).

I [previously thought ](https://github.com/blockprotocol/blockprotocol/pull/768) this was to do with Sentry Replay, but they patched the unchecked access to `sessionStorage`. I'm a bit perplexed now, so this is an attempt to fix. This branch's preview deployment does not have the issue, but then nor does any preview deployment (probably due to the difference in the iFrame's origin between preview and deployment).. The first step is to see if merging this into production will fix the issue in production.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1201095311341924/1203387365176395/f) _(internal)_

## ⚠️ Known issues

Disabling `stickySession` will mean that we will not be able to track a user's behaviour _after_ a crash which forces them to refresh, because it will become a new session. If this change does indeed fix the issue, at least we will have isolated the problem and can investigate further in the hopes of re-enabling `stickySession`.

## 🐾 Next steps

See if the issue is fixed when this merges.
If so, try and figure out why it is occuring despite error handling in Sentry Replay.
If not, investigate other possible causes.
