### PR TITLE
Copy over `codecov.yml` from HASH repository

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,8 +2,16 @@ coverage:
   status:
     project:
       default:
+        informational: true
         target: auto
         threshold: 1%
     patch:
       default:
         informational: true
+comment: # Only post a comment if the coverage changes
+  require_changes: true
+flag_management:
+  default_rules:
+    carryforward: true
+github_checks:
+  annotations: false


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We updated the codecov file in HASH a while back to tweak the default values. This copies over the configuration.