### PR TITLE
WordPress ChatGPT support, tweak usage exceeded error message

### DIFF
--- a/apps/site/src/components/pages/hub/block-data-container/sandboxed-block-demo/service-module-modal.tsx
+++ b/apps/site/src/components/pages/hub/block-data-container/sandboxed-block-demo/service-module-modal.tsx
@@ -4,6 +4,7 @@ import { Box, Typography } from "@mui/material";
 import { useUser } from "../../../../../context/user-context";
 import { Button } from "../../../../button";
 import { Link } from "../../../../link";
+import { LinkButton } from "../../../../link-button";
 import { Modal } from "../../../../modal/modal";
 
 type ServiceModuleModalProps = {
@@ -12,9 +13,7 @@ type ServiceModuleModalProps = {
   serviceModuleMessage: ExternalServiceMethodRequest | null;
 };
 
-const AnonymousUserContent = ({
-  onClose,
-}: Pick<ServiceModuleModalProps, "onClose">) => (
+const AnonymousUserContent = () => (
   <>
     <Typography
       sx={{
@@ -39,9 +38,12 @@ const AnonymousUserContent = ({
       applications, including <Link href="/wordpress">WordPress</Link>.
     </Typography>
     <Box display="flex" justifyContent="center">
-      <Button onClick={onClose} sx={{ width: 160 }}>
-        Close
-      </Button>
+      <LinkButton sx={{ width: 160, mr: 4, fontWeight: 600 }} href="/signup">
+        Sign up
+      </LinkButton>
+      <LinkButton sx={{ width: 160, mr: 4, fontWeight: 600 }} href="/login">
+        Log in
+      </LinkButton>
     </Box>
   </>
 );
@@ -129,9 +131,7 @@ export const ServiceModuleModal = ({
           }}
         >
           This block uses
-          <strong>
-            {serviceModuleMessage?.providerName}
-          </strong>
+          <strong> {serviceModuleMessage?.providerName}</strong>
         </Typography>
         {user ? (
           <AuthenticatedUserContent
@@ -141,7 +141,7 @@ export const ServiceModuleModal = ({
             }}
           />
         ) : (
-          <AnonymousUserContent onClose={onClose} />
+          <AnonymousUserContent />
         )}
       </Box>
     </Modal>

--- a/apps/site/src/components/pages/hub/block-data-container/sandboxed-block-demo/service-module-modal.tsx
+++ b/apps/site/src/components/pages/hub/block-data-container/sandboxed-block-demo/service-module-modal.tsx
@@ -128,10 +128,9 @@ export const ServiceModuleModal = ({
             textAlign: "center",
           }}
         >
-          This block uses <br />
+          This block uses
           <strong>
-            {serviceModuleMessage?.providerName}{" "}
-            {serviceModuleMessage?.methodName}
+            {serviceModuleMessage?.providerName}
           </strong>
         </Typography>
         {user ? (

--- a/libs/wordpress-plugin/package.json
+++ b/libs/wordpress-plugin/package.json
@@ -31,7 +31,7 @@
     "@blockprotocol/core": "0.1.0",
     "@blockprotocol/graph": "0.1.0",
     "@blockprotocol/hook": "0.1.0",
-    "@blockprotocol/service": "0.1.0",
+    "@blockprotocol/service": "0.1.1",
     "@lit-labs/react": "1.1.1",
     "@rjsf/core": "5.0.1",
     "@rjsf/utils": "5.0.1",

--- a/libs/wordpress-plugin/plugin/trunk/block/edit-or-preview/edit/service-callbacks.ts
+++ b/libs/wordpress-plugin/plugin/trunk/block/edit-or-preview/edit/service-callbacks.ts
@@ -92,6 +92,13 @@ export const constructServiceModuleCallbacks =
           data,
         }),
 
+      openaiCompleteChat: async ({ data }) =>
+        callService({
+          providerName: "openai",
+          methodName: "completeChat",
+          data,
+        }),
+
       openaiCompleteText: async ({ data }) =>
         callService({
           providerName: "openai",

--- a/libs/wordpress-plugin/plugin/trunk/block/edit-or-preview/edit/service-callbacks.ts
+++ b/libs/wordpress-plugin/plugin/trunk/block/edit-or-preview/edit/service-callbacks.ts
@@ -60,7 +60,7 @@ export const callService = async ({
         url: billingUrl,
         label: "Upgrade",
       });
-      errorMessage = `You have exceeded your monthly free API calls for ${providerName} ${methodName} requests. Please upgrade your Block Protocol account to make more API calls this month.`;
+      errorMessage = `You have exceeded your monthly free API calls for this ${providerName} service. Please upgrade your Block Protocol account to use this service again, this month.`;
     }
 
     dispatch("core/notices").createNotice("error", errorMessage, {

--- a/libs/wordpress-plugin/plugin/trunk/changelog.txt
+++ b/libs/wordpress-plugin/plugin/trunk/changelog.txt
@@ -1,6 +1,7 @@
 == Changelog ==
 
 = 0.0.3 =
+* Add support for ChatGPT blocks
 * Notification when using unsupported database version
 * Fix rich text rendering
 * Icon for block category

--- a/libs/wordpress-plugin/plugin/trunk/readme.txt
+++ b/libs/wordpress-plugin/plugin/trunk/readme.txt
@@ -85,6 +85,7 @@ Please [contact us](https://blockprotocol.org/contact) or say 'hi!' on our [Disc
 <!-- The latest release should be found here, and older ones moved to changelog.txt -->
 
 = 0.0.3 =
+* Add support for ChatGPT blocks
 * Notification when using unsupported database version
 * Fix rich text rendering
 * Icon for block category
@@ -93,7 +94,7 @@ Please [contact us](https://blockprotocol.org/contact) or say 'hi!' on our [Disc
 == Upgrade Notice ==
 
 = 0.0.3 =
-Upgrade for improved text rendering in Block Protocol blocks
+Upgrade for ChatGPT support and improved text rendering in Block Protocol blocks
 
 <!--
 = 1.0 =

--- a/libs/wordpress-plugin/yarn.lock
+++ b/libs/wordpress-plugin/yarn.lock
@@ -1083,10 +1083,10 @@
     "@blockprotocol/core" "0.1.0"
     "@blockprotocol/graph" "0.1.0"
 
-"@blockprotocol/service@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@blockprotocol/service/-/service-0.1.0.tgz#d9aaa3b1694ee4a6184aa48b3a10e67042d89b52"
-  integrity sha512-5H73nuBDKewIpstSPaqqdRKTpbMIFNEGI6q5pBGbfnDgAHiH9bVSIz1uiDobtApKRrwwbRTpku42j9Cw+7VqLg==
+"@blockprotocol/service@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@blockprotocol/service/-/service-0.1.1.tgz#8513255b94af747e52cde70288d75cbfa2a53ffd"
+  integrity sha512-9N5A0adwLTKNDwy29/xnWzmWTyig5YyVBgBw9ydHazJZAlfZZWQfgsWGgOw3J8dSIaqTfv5U/LvvaUa4wxeL3g==
   dependencies:
     "@blockprotocol/core" "0.1.0"
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

1. Introduce support for ChatGPT BP blocks (and note in changelog)

2. Tweak the WP plugin's error message when exceeding a service's free credits – it previously used the method name, which may not be equivalent to the service. e.g `Davinci` is a service, but the method name is `completeText`, which covers other services (language models, in this case).

3. Update the modal shown to users when trying to use a service-using block in the Hub to include login/signup buttons for anonymous viewers