### PR TITLE
Open "Terms of Service" and "Privacy Statement" links in new tab in checkout page + styling tweaks

### DIFF
--- a/apps/site/src/pages/settings/billing-settings-panel/free-or-hobby-subscription-tier-overview.tsx
+++ b/apps/site/src/pages/settings/billing-settings-panel/free-or-hobby-subscription-tier-overview.tsx
@@ -384,7 +384,7 @@ export const FreeOrHobbySubscriptionTierOverview: FunctionComponent<{
         </Box>
         <Box
           sx={({ spacing }) => ({
-            padding: spacing(2, 4),
+            padding: spacing(2, 2, 2, 4),
             backgroundColor: "#FBF7FF",
             flexGrow: 1,
           })}
@@ -581,7 +581,7 @@ export const FreeOrHobbySubscriptionTierOverview: FunctionComponent<{
         </Box>
         <Box
           sx={({ palette, spacing }) => ({
-            padding: spacing(2, 4),
+            padding: spacing(2, 3, 2, 4),
             backgroundColor: palette.purple[20],
           })}
         >

--- a/apps/site/src/pages/settings/billing/upgrade/index.page.tsx
+++ b/apps/site/src/pages/settings/billing/upgrade/index.page.tsx
@@ -778,8 +778,15 @@ const UpgradePage: AuthWallPageContent<UpgradePageProps> = ({
                       })}
                     >
                       By clicking “Upgrade my account and continue”, you agree
-                      to our <Link href="/legal/terms">Terms of Service</Link>{" "}
-                      and <Link href="/legal/privacy">Privacy Statement</Link>.
+                      to our{" "}
+                      <Link href="/legal/terms" target="_blank">
+                        Terms of Service
+                      </Link>{" "}
+                      and{" "}
+                      <Link href="/legal/privacy" target="_blank">
+                        Privacy Statement
+                      </Link>
+                      .
                     </Typography>
                     {currentSubscriptionTier === "free" ? (
                       <Typography


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR:
- updates the checkout page to open the "Terms of Service" and "Privacy Statement" links in new tab
- reduces the right margin of the feature lists in the `/settings/billing` page to prevent text from wrapping (see attached screenshot)

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203623179643290/1204144201804771/f) _(internal)_

## 📹 Demo

<img width="915" alt="image" src="https://user-images.githubusercontent.com/42802102/224030766-756bdb38-0262-43ca-b8a1-03df9e7a546b.png">

