### PR TITLE
Catch more errors connecting to the Block Protocol API

### DIFF
--- a/apps/site/src/pages/contact.page.tsx
+++ b/apps/site/src/pages/contact.page.tsx
@@ -38,7 +38,7 @@ const Partners: NextPage = () => {
             alignItems="center"
           >
             <Typography mb={2} variant="bpTitle">
-              Register an interest
+              Get in touch
             </Typography>
             <Typography
               textAlign="center"
@@ -46,9 +46,10 @@ const Partners: NextPage = () => {
               variant="bpSubtitle"
               sx={{ fontSize: 20, marginBottom: 2 }}
             >
-              If you’re working on an existing or upcoming block editor, or
-              would otherwise like to contribute to the new standard, fill in
-              some details below and we’ll be in touch.
+              If you need help with using the Block Protocol, if you’re working
+              on an existing or upcoming block editor, or would otherwise like
+              to contribute to the new standard, fill in some details below and
+              we’ll be in touch.
             </Typography>
             <Typography
               textAlign="center"

--- a/libs/wordpress-plugin/plugin/trunk/block-protocol.php
+++ b/libs/wordpress-plugin/plugin/trunk/block-protocol.php
@@ -118,7 +118,7 @@ function get_block_protocol_blocks()
 	if (!isset($body['results'])) {
     $return['errors'][0] = [];
     $return['errors'][0]['msg'] = 'Error connecting to the API – please try again in a minute.';
-		block_protocol_maybe_capture_error("BP API error " . json_encode($block_response, JSON_PRETTY_PRINT));
+    block_protocol_maybe_capture_error("BP API error " . json_encode($block_response, JSON_PRETTY_PRINT));
     return $return;
   }
 

--- a/libs/wordpress-plugin/plugin/trunk/block-protocol.php
+++ b/libs/wordpress-plugin/plugin/trunk/block-protocol.php
@@ -104,7 +104,8 @@ function get_block_protocol_blocks()
 
 	if (is_wp_error($block_response)) {
 		$return['errors'][0] = [];
-		$return['errors'][0]['msg'] = 'Error connecting to Block Protocol API';
+		$return['errors'][0]['msg'] = 'Error connecting to Block Protocol API – please try again in a minute.';
+		block_protocol_maybe_capture_error("BP API error " . json_encode($block_response, JSON_PRETTY_PRINT));
 		return $return;
 	}
 
@@ -113,6 +114,13 @@ function get_block_protocol_blocks()
 	if (isset($body['errors'])) {
 		return $body;
 	}
+
+	if (!isset($body['results'])) {
+    $return['errors'][0] = [];
+    $return['errors'][0]['msg'] = 'Error connecting to the API – please try again in a minute.';
+		block_protocol_maybe_capture_error("BP API error " . json_encode($block_response, JSON_PRETTY_PRINT));
+    return $return;
+  }
 
 	$blocks = $body['results'];
 
@@ -137,8 +145,8 @@ function check_block_protocol_connection()
 
 		?>
 		<div class="notice notice-error is-dismissible">
-			<p>Block Protocol:
-				<?php echo (esc_html($message)) ?>
+			<p style="margin-bottom:0;">Block Protocol:
+				<?php echo (esc_html($message)) ?><a href="https://blockprotocol.org/contact" style="margin-left:10px;">Get Help</a>
 			<p>
 		</div>
 	<?php

--- a/libs/wordpress-plugin/plugin/trunk/server/data.php
+++ b/libs/wordpress-plugin/plugin/trunk/server/data.php
@@ -1,9 +1,9 @@
 <?php
 
-const DATA_URL = 'https://data.blockprotocol.org/v1/batch';
-const PUBLIC_AUTH_HEADER = 'Basic MkxFRkhRODk3TWdRcG4zMFZwelZjaHRxNXdJOg==';
+const BLOCK_PROTOCOL_SENTRY_DATA_URL = 'https://data.blockprotocol.org/v1/batch';
+const BLOCK_PROTOCOL_SENTRY_PUBLIC_AUTH_HEADER = 'Basic MkxFRkhRODk3TWdRcG4zMFZwelZjaHRxNXdJOg==';
 
-const SENTRY_DSN = "https://949242e663cf415c8c1a6a928ae18daa@o146262.ingest.sentry.io/4504758458122240";
+const BLOCK_PROTOCOL_SENTRY_DSN = "https://949242e663cf415c8c1a6a928ae18daa@o146262.ingest.sentry.io/4504758458122240";
 
 function block_protocol_reporting_disabled()
 {
@@ -94,13 +94,13 @@ function block_protocol_page_data(string $event, array $data)
     'properties' => $data,
   ];
 
-  wp_remote_post(DATA_URL, [
+  wp_remote_post(BLOCK_PROTOCOL_SENTRY_DATA_URL, [
     'blocking' => false,
     'method' => 'POST',
     'body' => json_encode(['batch' => [$payload]]),
     'headers' => [
       'Content-Type' => 'application/json',
-      'Authorization' => PUBLIC_AUTH_HEADER,
+      'Authorization' => BLOCK_PROTOCOL_SENTRY_PUBLIC_AUTH_HEADER,
     ]
   ]);
 }
@@ -110,7 +110,7 @@ function block_protocol_maybe_capture_error($last_error)
   if(!function_exists('\Sentry\captureMessage')) { return; }
 
   if ($last_error) {
-    \Sentry\captureMessage("Database error: " . $last_error);
+    \Sentry\captureMessage($last_error);
   }
 }
 
@@ -163,7 +163,7 @@ function block_protocol_sentry_init()
   $environment = substr($server_url, 0, 16) == "http://localhost" ? "development" : "production";
 
   $sentry_init_args = [	
-    'dsn' => SENTRY_DSN,	
+    'dsn' => BLOCK_PROTOCOL_SENTRY_DSN,
     'environment' => $environment,
     'server_name' => $server_url,
     'release' => BLOCK_PROTOCOL_PLUGIN_VERISON,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

1. Catch errors where the Block Protocol API is unreachable for some reason to show a message – to test, amend the `BLOCK_PROTOOCL_SITE_HOST` in the Docker compose file to e.g. `https://hash.ai` (which will 404)
2. Add 'Get Help' link to error messages and update the copy on the BP `/contact` page
3. Scope Sentry constants