### PR TITLE
Hide entity editor for certain blocks in the WordPress plugin

### DIFF
--- a/libs/wordpress-plugin/plugin/trunk/block/edit-or-preview/edit/block-controls.tsx
+++ b/libs/wordpress-plugin/plugin/trunk/block/edit-or-preview/edit/block-controls.tsx
@@ -52,6 +52,28 @@ const EntityEditor = lazy(() => import("./block-controls/entity-editor"));
 
 export const CONTROLS_LOADING_IMAGE_HEIGHT = "400px";
 
+/**
+ * The entity editor for these blocks is hidden as editing their properties directly
+ * may cause unexpected behavior.
+ *
+ * @todo allow blocks to specify which properties in their schema should be editable
+ *   from outside the block itself
+ */
+const schemasToHideEditorFor = [
+  "https://blockprotocol.org/@hash/types/entity-type/ai-image-block/",
+  "https://blockprotocol.org/@hash/types/entity-type/ai-text-block/",
+  "https://blockprotocol.org/@hash/types/entity-type/address-block/",
+  "https://blockprotocol.org/@hash/types/entity-type/callout-block/",
+  "https://blockprotocol.org/@hash/types/entity-type/heading-block/",
+  "https://blockprotocol.org/@hash/types/entity-type/paragraph-block/",
+  "https://blockprotocol.org/@hash/types/entity-type/shuffle-block/v/2",
+  "https://blockprotocol.org/@tldraw/types/entity-type/drawing-block/",
+];
+
+const shouldEditorBeHidden = (schema: VersionedUrl) => {
+  return schemasToHideEditorFor.find((option) => schema.startsWith(option));
+};
+
 export const CustomBlockControls = ({
   entityId,
   entitySubgraph,
@@ -113,15 +135,19 @@ export const CustomBlockControls = ({
           />
         </PanelBody>
         <PanelBody>
-          <Suspense
-            fallback={<LoadingImage height={CONTROLS_LOADING_IMAGE_HEIGHT} />}
-          >
-            <EntityEditor
-              entityProperties={entityProperties}
-              entityTypeId={entityTypeId}
-              updateProperties={updateEntityProperties}
-            />
-          </Suspense>
+          {shouldEditorBeHidden(entityTypeId) ? (
+            <p>Please use the controls in the block to update its data.</p>
+          ) : (
+            <Suspense
+              fallback={<LoadingImage height={CONTROLS_LOADING_IMAGE_HEIGHT} />}
+            >
+              <EntityEditor
+                entityProperties={entityProperties}
+                entityTypeId={entityTypeId}
+                updateProperties={updateEntityProperties}
+              />
+            </Suspense>
+          )}
         </PanelBody>
       </InspectorControls>
     </>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We show a form in the WordPress plugin settings sidebar which is generated from the block's schema.

For some blocks, this form is potentially confusing and may lead to the block breaking if properties are edited in unexpected ways when it is in certain states.

The best solution to this is for blocks to be able to specify which properties should be editable externally, so that the plugin needs no knowledge of any particular block, but in the short term this hides the editor for blocks where it may be a problem.