### PR TITLE
Add verified badge to blocks on block hub

### DIFF
--- a/apps/site/src/components/pages/hub/hub.tsx
+++ b/apps/site/src/components/pages/hub/hub.tsx
@@ -16,6 +16,7 @@ import { faBinary } from "../../icons/fa/binary";
 import { faBoxesStacked } from "../../icons/fa/boxes-stacked";
 import { ClientOnlyLastUpdated } from "../../last-updated";
 import { Link } from "../../link";
+import { VerifiedBadge } from "../../verified-badge";
 import { getHubBrowseQuery, getRouteHubBrowseType } from "./hub-utils";
 
 export const useRouteHubBrowseType = () => {
@@ -31,10 +32,11 @@ export type HubItemDescription = {
   version: string;
   updated?: string;
   url: string;
+  verified?: boolean;
 };
 
 const HubItem = ({
-  item: { image, title, description, author, version, updated, url },
+  item: { image, title, description, author, version, updated, url, verified },
 }: {
   item: HubItemDescription;
 }) => (
@@ -54,6 +56,7 @@ const HubItem = ({
         color={(theme) => theme.palette.gray[90]}
       >
         {title}
+        {!!verified && <VerifiedBadge compact />}
       </Typography>
       {description ? (
         <Typography

--- a/apps/site/src/pages/hub.page.tsx
+++ b/apps/site/src/pages/hub.page.tsx
@@ -44,6 +44,7 @@ const getHubItems: Record<string, () => Promise<HubItemDescription[] | null>> =
           updated: item.lastUpdated ?? "",
           version: item.version,
           url: item.blockSitePath,
+          verified: item.verified,
         }),
       );
     },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR adds the verified badge to the blocks listed in the block hub.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203623179643290/1204086167143859/f) _(internal)_

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch / view the deployment
1.  Open block hub
2. Confirm the screenshot below

## 📹 Demo
<img width="856" alt="Screenshot 2023-03-09 at 20 10 11" src="https://user-images.githubusercontent.com/39553853/224103124-62823b65-048e-4c2b-bc6e-9b5bb8966f09.png">

