### PR TITLE
Implement blur & priority for few homepage images

### DIFF
--- a/apps/site/src/components/pages/home/confined-blocks.tsx
+++ b/apps/site/src/components/pages/home/confined-blocks.tsx
@@ -108,7 +108,7 @@ export const ConfinedBlocks = () => {
             width: { xs: "100%", md: "55%" },
           }}
         >
-          <Image src={darkBoxImage} />
+          <Image src={darkBoxImage} placeholder="blur" />
         </Box>
       </Box>
     </Box>

--- a/apps/site/src/components/pages/home/header.tsx
+++ b/apps/site/src/components/pages/home/header.tsx
@@ -93,7 +93,16 @@ export const Header = () => {
           with interoperable components known as blocks
         </Typography>
       </Container>
-      <Image layout="responsive" src={helixBoxes} style={{ zIndex: 999 }} />
+      <Image
+        layout="responsive"
+        src={helixBoxes}
+        style={{ zIndex: 999 }}
+        /**
+         * not using placeholder="blur" on this image, since it's transparent, making it blur looks weird
+         * `priority` makes sure this image is loaded ASAP, because this is the first image in the homepage
+         */
+        priority
+      />
     </Box>
   );
 };

--- a/apps/site/src/components/pages/home/supported-applications.tsx
+++ b/apps/site/src/components/pages/home/supported-applications.tsx
@@ -461,7 +461,11 @@ export const SupportedApplications = () => {
           pb: { xs: 3, sm: 5 },
         }}
       >
-        <Image layout="responsive" src={supportedApplicationsFullImage} />
+        <Image
+          layout="responsive"
+          src={supportedApplicationsFullImage}
+          placeholder="blur"
+        />
       </Box>
     </>
   );


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To improve UX, this PR uses blur & prioritization on homepage images.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203623179643290/1204086167143735/f) _(internal)_

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Checkout the branch / view the deployment
2. Enable throttling (e.g. Fast 3G) to test slower internet
3. Confirm that images at /blog and /blog/[blog-post-id] has blurred previews

## 📹 Demo

See the difference using `priority` on the header image makes in this demo

https://user-images.githubusercontent.com/39553853/224346603-44356ada-b010-4160-a8f6-b528f3d71c7a.mov

