### PR TITLE
Add helper function for fully recomputing edges in Subgraph

### DIFF
--- a/libs/@blockprotocol/graph/src/non-temporal/stdlib.ts
+++ b/libs/@blockprotocol/graph/src/non-temporal/stdlib.ts
@@ -32,6 +32,7 @@ import {
   getRightEntityForLinkEntity as getRightEntityForLinkEntityGeneral,
   getRoots as getRootsGeneral,
   getVertexIdForRecordId as getVertexIdForRecordIdGeneral,
+  inferSubgraphEdges as inferSubgraphEdgesGeneral,
   isDataTypeRootedSubgraph as isDataTypeRootedSubgraphGeneral,
   isEntityRootedSubgraph as isEntityRootedSubgraphGeneral,
   isEntityTypeRootedSubgraph as isEntityTypeRootedSubgraphGeneral,
@@ -101,6 +102,8 @@ export const buildSubgraph = (
   rootRecordIds: (EntityRecordId | OntologyTypeRecordId)[],
   depths: GraphResolveDepths,
 ) => buildSubgraphGeneral<false>(data, rootRecordIds, depths, undefined);
+export const inferSubgraphEdges = (subgraph: Subgraph) =>
+  inferSubgraphEdgesGeneral<false>(subgraph);
 
 export const getPropertyTypesReferencedByEntityType =
   getPropertyTypesReferencedByEntityTypeGeneral;

--- a/libs/@blockprotocol/graph/src/shared/stdlib.ts
+++ b/libs/@blockprotocol/graph/src/shared/stdlib.ts
@@ -18,7 +18,10 @@ export {
   sortIntervals,
   unionOfIntervals,
 } from "./stdlib/interval.js";
-export { buildSubgraph } from "./stdlib/subgraph/builder.js";
+export {
+  buildSubgraph,
+  inferSubgraphEdges,
+} from "./stdlib/subgraph/builder.js";
 export { getPropertyTypesReferencedByEntityType } from "./stdlib/subgraph/edge/entity-type.js";
 export {
   getIncomingLinksForEntity,

--- a/libs/@blockprotocol/graph/src/shared/stdlib/subgraph/builder.ts
+++ b/libs/@blockprotocol/graph/src/shared/stdlib/subgraph/builder.ts
@@ -26,7 +26,7 @@ import {
   Subgraph,
   SubgraphTemporalAxes,
 } from "../../types.js";
-import { typedEntries, typedKeys } from "../../util.js";
+import { typedEntries } from "../../util.js";
 import { getVertexIdForRecordId } from "./vertex-id-for-element";
 
 /**

--- a/libs/@blockprotocol/graph/src/shared/stdlib/subgraph/builder.ts
+++ b/libs/@blockprotocol/graph/src/shared/stdlib/subgraph/builder.ts
@@ -184,35 +184,12 @@ export const inferSubgraphEdges = <Temporal extends boolean>(
       },
       [baseId, revisionObject],
     ) => {
-      const revisionIds = typedKeys(revisionObject);
-      let firstEntry = null;
-      if (revisionIds[0] && revisionIds[0] in revisionObject) {
-        firstEntry = revisionObject[revisionIds[0]];
-      }
-
-      const newVertexIds = revisionIds.map((revisionId) => ({
-        baseId,
-        revisionId,
-      }));
-
-      switch (firstEntry?.kind) {
-        case "dataType":
-          acc.dataTypeVertexIds.push(...newVertexIds);
-          break;
-        case "propertyType":
-          acc.propertyTypeVertexIds.push(...newVertexIds);
-          break;
-        case "entityType":
-          acc.entityTypeVertexIds.push(...newVertexIds);
-          break;
-        case "entity":
-          acc.entityVertexIds.push(...newVertexIds);
-          break;
-        default:
-          throw new Error(
-            `Internal implementation error, unexpected vertex: ${firstEntry}`,
-          );
-      }
+      typedEntries(revisionObject).forEach(([revisionId, vertex]) => {
+        acc[`${vertex.kind}VertexIds`].push({
+          baseId,
+          revisionId,
+        });
+      });
 
       return acc;
     },

--- a/libs/@blockprotocol/graph/src/shared/stdlib/subgraph/builder.ts
+++ b/libs/@blockprotocol/graph/src/shared/stdlib/subgraph/builder.ts
@@ -182,12 +182,12 @@ export const inferSubgraphEdges = <Temporal extends boolean>(
         entityTypeVertexIds: OntologyTypeVertexId[];
         entityVertexIds: EntityVertexId[];
       },
-      [baseId, entry],
+      [baseId, revisionObject],
     ) => {
-      const revisionIds = typedKeys(entry);
+      const revisionIds = typedKeys(revisionObject);
       let firstEntry = null;
-      if (revisionIds[0] && revisionIds[0] in entry) {
-        firstEntry = entry[revisionIds[0]];
+      if (revisionIds[0] && revisionIds[0] in revisionObject) {
+        firstEntry = revisionObject[revisionIds[0]];
       }
 
       const newVertexIds = revisionIds.map((revisionId) => ({

--- a/libs/@blockprotocol/graph/src/shared/stdlib/subgraph/builder.ts
+++ b/libs/@blockprotocol/graph/src/shared/stdlib/subgraph/builder.ts
@@ -16,14 +16,17 @@ import {
   EntityRecordId,
   EntityRootType,
   EntityTypeWithMetadata,
+  EntityVertexId,
   GraphResolveDepths,
   isEntityRecordId,
   isOntologyTypeRecordId,
   OntologyTypeRecordId,
+  OntologyTypeVertexId,
   PropertyTypeWithMetadata,
   Subgraph,
   SubgraphTemporalAxes,
 } from "../../types.js";
+import { typedEntries, typedKeys } from "../../util.js";
 import { getVertexIdForRecordId } from "./vertex-id-for-element";
 
 /**
@@ -150,4 +153,85 @@ export const buildSubgraph = <Temporal extends boolean>(
   }
 
   return subgraph;
+};
+
+/**
+ * Looking to build a subgraph? You probably want {@link buildSubgraph} from `@blockprotocol/graph/stdlib`
+ *
+ * This function will infer/add edges to a subgraph based on the vertices that are already present.
+ * The {@link Subgraph} must not have any edges already present, as this would result in invalid state.
+ * It will add edges for:
+ *  - data type vertices
+ *  - property type vertices
+ *  - entity type vertices
+ *  - entity vertices
+ *
+ * This operation MUTATES the given {@link Subgraph} - you should know why you need to do it.
+ *
+ * @param {Subgraph} subgraph – the subgraph to mutate by adding edges
+ */
+export const inferSubgraphEdges = <Temporal extends boolean>(
+  subgraph: Subgraph<Temporal, EntityRootType<Temporal>>,
+): void => {
+  // Construct object with vertex ids for each vertex kind
+  const vertexIds = typedEntries(subgraph.vertices).reduce(
+    (
+      acc: {
+        dataTypeVertexIds: OntologyTypeVertexId[];
+        propertyTypeVertexIds: OntologyTypeVertexId[];
+        entityTypeVertexIds: OntologyTypeVertexId[];
+        entityVertexIds: EntityVertexId[];
+      },
+      [baseId, entry],
+    ) => {
+      const revisionIds = typedKeys(entry);
+      let firstEntry = null;
+      if (revisionIds[0] && revisionIds[0] in entry) {
+        firstEntry = entry[revisionIds[0]];
+      }
+
+      const newVertexIds = revisionIds.map((revisionId) => ({
+        baseId,
+        revisionId,
+      }));
+
+      switch (firstEntry?.kind) {
+        case "dataType":
+          acc.dataTypeVertexIds.push(...newVertexIds);
+          break;
+        case "propertyType":
+          acc.propertyTypeVertexIds.push(...newVertexIds);
+          break;
+        case "entityType":
+          acc.entityTypeVertexIds.push(...newVertexIds);
+          break;
+        case "entity":
+          acc.entityVertexIds.push(...newVertexIds);
+          break;
+        default:
+          throw new Error(
+            `Internal implementation error, unexpected vertex: ${firstEntry}`,
+          );
+      }
+
+      return acc;
+    },
+    {
+      dataTypeVertexIds: [],
+      propertyTypeVertexIds: [],
+      entityTypeVertexIds: [],
+      entityVertexIds: [],
+    },
+  );
+
+  inferDataTypeEdgesInSubgraphByMutation(subgraph, vertexIds.dataTypeVertexIds);
+  inferPropertyTypeEdgesInSubgraphByMutation(
+    subgraph,
+    vertexIds.propertyTypeVertexIds,
+  );
+  inferEntityTypeEdgesInSubgraphByMutation(
+    subgraph,
+    vertexIds.entityTypeVertexIds,
+  );
+  inferEntityEdgesInSubgraphByMutation(subgraph, vertexIds.entityVertexIds);
 };

--- a/libs/@blockprotocol/graph/src/temporal/stdlib.ts
+++ b/libs/@blockprotocol/graph/src/temporal/stdlib.ts
@@ -32,6 +32,7 @@ import {
   getRightEntityForLinkEntity as getRightEntityForLinkEntityGeneral,
   getRoots as getRootsGeneral,
   getVertexIdForRecordId as getVertexIdForRecordIdGeneral,
+  inferSubgraphEdges as inferSubgraphEdgesGeneral,
   intervalCompareWithInterval as intervalCompareWithIntervalGeneral,
   intervalContainsInterval as intervalContainsIntervalGeneral,
   intervalContainsTimestamp as intervalContainsTimestampGeneral,
@@ -102,6 +103,8 @@ export const buildSubgraph = (
   subgraphTemporalAxes: SubgraphTemporalAxes,
 ) =>
   buildSubgraphGeneral<true>(data, rootRecordIds, depths, subgraphTemporalAxes);
+export const inferSubgraphEdges = (subgraph: Subgraph) =>
+  inferSubgraphEdgesGeneral<true>(subgraph);
 
 export const getPropertyTypesReferencedByEntityType =
   getPropertyTypesReferencedByEntityTypeGeneral;

--- a/libs/mock-block-dock/src/datastore/use-mock-datastore/non-temporal.ts
+++ b/libs/mock-block-dock/src/datastore/use-mock-datastore/non-temporal.ts
@@ -15,7 +15,10 @@ import {
   addEntityVerticesToSubgraphByMutation,
   inferEntityEdgesInSubgraphByMutation,
 } from "@blockprotocol/graph/internal";
-import { getEntityRevision } from "@blockprotocol/graph/stdlib";
+import {
+  getEntityRevision,
+  inferSubgraphEdges,
+} from "@blockprotocol/graph/stdlib";
 import {
   GetEntityData as GetEntityDataTemporal,
   QueryEntitiesData as QueryEntitiesDataTemporal,
@@ -296,6 +299,11 @@ export const useMockDatastore = (
             newSubgraph.vertices[entityId]![
               Object.keys(newSubgraph.vertices[entityId]!).pop()!
             ]!.inner = updatedEntity;
+
+            // Clear the subgraph edges in preparation for inferring edges again
+            newSubgraph.edges = {};
+
+            inferSubgraphEdges(newSubgraph);
 
             resolve({ data: updatedEntity });
 

--- a/libs/mock-block-dock/src/datastore/use-mock-datastore/temporal.ts
+++ b/libs/mock-block-dock/src/datastore/use-mock-datastore/temporal.ts
@@ -351,9 +351,6 @@ export const useMockDatastore = (
 
             resolve({ data: updatedEntity });
 
-            /**
-             * @todo this update logic may be incorrect, we have to do some
-             * testing to ensure it behaves as expected */
             addEntityVerticesToSubgraphByMutation(newSubgraph, [updatedEntity]);
 
             // Clear the subgraph edges in preparation for inferring edges again

--- a/libs/mock-block-dock/src/datastore/use-mock-datastore/temporal.ts
+++ b/libs/mock-block-dock/src/datastore/use-mock-datastore/temporal.ts
@@ -15,7 +15,10 @@ import {
   RemoteFileEntityProperties,
   Subgraph,
 } from "@blockprotocol/graph/temporal";
-import { getEntityRevision } from "@blockprotocol/graph/temporal/stdlib";
+import {
+  getEntityRevision,
+  inferSubgraphEdges,
+} from "@blockprotocol/graph/temporal/stdlib";
 import mime from "mime/lite";
 import { useCallback } from "react";
 import { v4 as uuid } from "uuid";
@@ -351,11 +354,12 @@ export const useMockDatastore = (
             /**
              * @todo this update logic may be incorrect, we have to do some
              * testing to ensure it behaves as expected */
-            const entityVertexIds = addEntityVerticesToSubgraphByMutation(
-              newSubgraph,
-              [updatedEntity],
-            );
-            inferEntityEdgesInSubgraphByMutation(newSubgraph, entityVertexIds);
+            addEntityVerticesToSubgraphByMutation(newSubgraph, [updatedEntity]);
+
+            // Clear the subgraph edges in preparation for inferring edges again
+            newSubgraph.edges = {};
+
+            inferSubgraphEdges(newSubgraph);
 
             return newSubgraph;
           });


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This PR changes how we update entities to take into account that edges may need to recompute. It does so by removing all edges and recompute them through the `infer` functions.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203623179643290/1204145497706392/f) _(internal)_

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Added new `inferSubgraphEdges` helper to recompute all edges of the graph given the vertices
- Delete edges on update
- Recompute the edges on update through `inferSubgraphEdges`

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

I suggest the following test setup:
- checkout `asa/temp-updateentity-mbd` at commit `5c8668d98716c0431939df090ddb323c7a3dedbd`
- Build `@blockprotocol/graph` and `mock-block-dock`
- `yarn dev` from the block at `blocks/aio-demo` 

Operations on the subgraph through the dev block should result in the right edges being present.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
This demo may be hard to follow without a description.
What happens here is I've seeded entity types into the demo and added 1 person, 1 org and a link between them.
I show the state of the edges where the `Person` has `IS_OF_TYPE` edges pointing to the `Person` entity type in the beginning. I am going to change the `Person` to have the `Thing` entity type instead. When this update happens, the edges are fully recomputed. The, previously, `Person`  entity is now a `Thing` with its edges adjusted.

https://user-images.githubusercontent.com/6988668/224391588-09598f52-2e9f-4ac7-9d6a-0899f76fe562.mp4

