### PR TITLE
Fix block message init retry and custom element rendering

### DIFF
--- a/.changeset/plenty-camels-crash.md
+++ b/.changeset/plenty-camels-crash.md
@@ -1,0 +1,5 @@
+---
+"block-template-custom-element": patch
+---
+
+correct property key in example object

--- a/.changeset/sharp-stingrays-scream.md
+++ b/.changeset/sharp-stingrays-scream.md
@@ -1,0 +1,5 @@
+---
+"@blockprotocol/core": patch
+---
+
+update block init message retry from microtask to macrotask

--- a/.changeset/sharp-tools-bow.md
+++ b/.changeset/sharp-tools-bow.md
@@ -1,0 +1,5 @@
+---
+"mock-block-dock": patch
+---
+
+fix handling of duplicate tag names in custom element renderer

--- a/.changeset/swift-countries-arrive.md
+++ b/.changeset/swift-countries-arrive.md
@@ -1,0 +1,5 @@
+---
+"block-template-react": patch
+---
+
+fix key name in package.json example

--- a/libs/@blockprotocol/core/src/core-block-handler.ts
+++ b/libs/@blockprotocol/core/src/core-block-handler.ts
@@ -34,11 +34,19 @@ export class CoreBlockHandler extends CoreHandler {
       sender: this,
     });
 
+    // In case the embedding application's handler is set up after the block's,
+    // retry the init message.
     return Promise.race([
       resp,
 
       new Promise<void>((resolve) => {
-        queueMicrotask(resolve);
+        // using queueMicrotask here leads to an infinite loop with some rendering strategies
+        // we could consider using setImmediate instead, but it would add a dependency.
+        // the 'time to init message exchange' is only material for:
+        // 1) HTML blocks, which depend on the exchange of init messages to receive init data
+        // 2) any block which sends other messages immediately after the init exchange
+        // React and Custom Element blocks receive their initial data as properties.
+        setTimeout(resolve);
       }),
     ]).then((response) => {
       if (!response) {

--- a/libs/block-template-custom-element/package.json
+++ b/libs/block-template-custom-element/package.json
@@ -57,7 +57,7 @@
     "displayName": "Template",
     "examples": [
       {
-        "name": "World"
+        "https://blockprotocol.org/@blockprotocol/types/property-type/name/": "World"
       }
     ],
     "icon": "public/omega.svg",

--- a/libs/block-template-react/package.json
+++ b/libs/block-template-react/package.json
@@ -59,7 +59,7 @@
     "displayName": "Template",
     "examples": [
       {
-        "name": "World"
+        "https://blockprotocol.org/@blockprotocol/types/property-type/name/": "World"
       }
     ],
     "icon": "public/omega.svg",

--- a/libs/mock-block-dock/package.json
+++ b/libs/mock-block-dock/package.json
@@ -43,7 +43,7 @@
     "@blockprotocol/service": "0.1.1",
     "@emotion/react": "^11.10.0",
     "@emotion/styled": "^11.10.0",
-    "@lit-labs/react": "^1.0.4",
+    "@lit-labs/react": "1.1.1",
     "@mui/material": "5.11.8",
     "ajv": "^8.11.2",
     "axios": "^1.3.2",

--- a/libs/mock-block-dock/src/block-renderer/custom-element.tsx
+++ b/libs/mock-block-dock/src/block-renderer/custom-element.tsx
@@ -29,7 +29,7 @@ export const CustomElementLoader: FunctionComponent<
    * This may break elements that rely on being defined with a specific tag.
    */
   while (existingCustomElement && existingCustomElement !== elementClass) {
-    tagName = `${tagName}${i}`;
+    tagName = `${originalTagName}${i}`;
     existingCustomElement = customElements.get(tagName);
     i++;
   }

--- a/libs/mock-block-dock/src/block-renderer/custom-element.tsx
+++ b/libs/mock-block-dock/src/block-renderer/custom-element.tsx
@@ -10,14 +10,30 @@ type CustomElementLoaderProps = {
 
 /**
  * Registers (if not already registered) and loads a custom element.
+ *
+ * @todo share this between wordpress-plugin and mock-block-dock (currently duplicated)
  */
 export const CustomElementLoader: FunctionComponent<
   CustomElementLoaderProps
-> = ({ elementClass, properties, tagName }) => {
+> = ({ elementClass, properties, tagName: originalTagName }) => {
   /**
    * Register the element with the CustomElementsRegistry, if not already registered.
    */
+  let tagName = originalTagName;
   let existingCustomElement = customElements.get(tagName);
+  let i = 1;
+
+  /**
+   * If an element with a different constructor is already registered with this tag,
+   * rename until we find a free tag or the tag this element is already registered with.
+   * This may break elements that rely on being defined with a specific tag.
+   */
+  while (existingCustomElement && existingCustomElement !== elementClass) {
+    tagName = `${tagName}${i}`;
+    existingCustomElement = customElements.get(tagName);
+    i++;
+  }
+
   if (!existingCustomElement) {
     try {
       customElements.define(tagName, elementClass);
@@ -26,28 +42,10 @@ export const CustomElementLoader: FunctionComponent<
       console.error(`Error defining custom element: ${(err as Error).message}`);
       throw err;
     }
-  } else if (existingCustomElement !== elementClass) {
-    /**
-     * If an element with a different constructor is already registered with this name,
-     * give this element a different name.
-     * This may break elements that rely on being defined with a specific name.
-     */
-    let i = 0;
-    do {
-      existingCustomElement = customElements.get(tagName);
-      i++;
-    } while (existingCustomElement);
-    try {
-      customElements.define(`${tagName}${i}`, elementClass);
-    } catch (err) {
-      // eslint-disable-next-line no-console -- TODO: consider using logger
-      console.error(`Error defining custom element: ${(err as Error).message}`);
-      throw err;
-    }
   }
 
   const CustomElement = useMemo(
-    () => createComponent(React, tagName, elementClass),
+    () => createComponent({ react: React, tagName, elementClass }),
     [elementClass, tagName],
   );
 

--- a/libs/wordpress-plugin/plugin/trunk/block/shared/block-loader/block-renderer/custom-element.tsx
+++ b/libs/wordpress-plugin/plugin/trunk/block/shared/block-loader/block-renderer/custom-element.tsx
@@ -29,7 +29,7 @@ export const CustomElementLoader: FunctionComponent<
    * This may break elements that rely on being defined with a specific tag.
    */
   while (existingCustomElement && existingCustomElement !== elementClass) {
-    tagName = `${tagName}${i}`;
+    tagName = `${originalTagName}${i}`;
     existingCustomElement = customElements.get(tagName);
     i++;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3027,10 +3027,10 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz#0300943770e04231041a51bd39f0439b5c7ab4f0"
   integrity sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg==
 
-"@lit-labs/react@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@lit-labs/react/-/react-1.0.4.tgz#e87a620338955a4e12163b0f3bee18a99c651174"
-  integrity sha512-Sy4RCxTZpTE2TwByjVac6gC7jzr8bCQC6s9bJhhJDKos4ZlN2cqcuVz63n0mpSSr1zxFh+Z0o0VR223l36Y4Ag==
+"@lit-labs/react@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@lit-labs/react/-/react-1.1.1.tgz#88a4320d357dcdfd7c7e276f809e3453a124cbbc"
+  integrity sha512-9TC+/ZWb6BJlWCyUr14FKFlaGnyKpeEDorufXozQgke/VoVrslUQNaL7nBmrAWdNrmzx5jWgi8lFmWwrxMjnlA==
 
 "@lit/reactive-element@^1.3.0", "@lit/reactive-element@^1.4.0":
   version "1.4.1"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes a few issues I noticed while building a custom element block:

1. The `CoreBlockHandler` includes a retry on its `init` message if it doesn't receive an immediate response, but this can cause an infinite loop with rendering custom elements (not while running them in dev mode, but once built). This PR fixes that by moving the retry from a `queueMicrotask` to a `setTimeout`. I chose not to bring a dependency to make it `setImmediate`, which would be a bit quicker middleground, on the basis that for most use cases it isn't vital that init messages are exchanged in the fastest possible time, and avoiding `setImmediate` saves adding another 1KB to every block.

2. The logic for renaming custom element tags was broken – I haven't actually encountered any duplication of custom element tag names but spotted this while looking for loops.

3. The property name key in the example object in the custom element template was not a base URI

## ❓ How to test this?

1.  You can test fix (1) by building the custom element template and then publishing it to a locally-running Hub, and checking its page works. Compared to doing the same thing in `main`, where the Hub will freeze.

2. You can test (2) by running `yarn dev` in `mock-block-dock`, and then (before selecting the custom element block) registering something to occupy its name:
```js
// browser console
customElements.define("test-custom-element-block", HTMLElement);
// you can repeat this with `test-custom-element-block1" etc 
// but will need to choose a different HTMLXElement for each
```
now switch to the custom element block, and inspect the DOM to see that it's had a number appended.

3. You can probably just look at 3 to check its correctness


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204164203672391