### PR TITLE
Improved animations & loading on `/hub` page

### DIFF
--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -62,6 +62,7 @@
     "execa": "^6.1.0",
     "express-session": "^1.17.2",
     "express-validator": "^6.14.0",
+    "framer-motion": "10.2.4",
     "fs-extra": "^10.1.0",
     "globby": "^13.1.2",
     "gray-matter": "^4.0.3",

--- a/apps/site/src/components/pages/hub/hub-list-browse.tsx
+++ b/apps/site/src/components/pages/hub/hub-list-browse.tsx
@@ -1,0 +1,142 @@
+import { faAsterisk, IconDefinition } from "@fortawesome/free-solid-svg-icons";
+import { Box, Stack, svgIconClasses, Typography } from "@mui/material";
+import { ReactNode, useMemo, useState } from "react";
+
+import { HUB_SERVICES_ENABLED } from "../../../pages/hub.page";
+import { FontAwesomeIcon } from "../../icons";
+import { faBinary } from "../../icons/fa/binary";
+import { faBoxesStacked } from "../../icons/fa/boxes-stacked";
+import { Link } from "../../link";
+import { useRouteHubBrowseType } from "./hub";
+import { getHubBrowseQuery } from "./hub-utils";
+
+const HubListBrowseType = ({
+  children,
+  type,
+  onClick,
+  active,
+}: {
+  children: ReactNode;
+  type: string;
+  onClick: () => void;
+  active: boolean;
+}) => {
+  return (
+    <Typography
+      onClick={onClick}
+      component={Link}
+      scroll={false}
+      href={{ query: getHubBrowseQuery(type) }}
+      pl={1.5}
+      sx={[
+        (theme) => ({
+          fontWeight: 500,
+          color: theme.palette.gray[90],
+          position: "relative",
+          display: "flex",
+          alignItems: "center",
+          [`.${svgIconClasses.root}`]: {
+            marginRight: 1,
+            fontSize: 15,
+            color: theme.palette.gray[50],
+          },
+        }),
+        active &&
+          ((theme) => ({
+            fontWeight: 600,
+            color: theme.palette.purple[70],
+
+            [`.${svgIconClasses.root}`]: {
+              color: "inherit",
+            },
+          })),
+      ]}
+    >
+      {children}
+    </Typography>
+  );
+};
+
+type BrowseItem = {
+  icon: IconDefinition;
+  title: string;
+  type: string;
+};
+
+const getBrowseItems = (): BrowseItem[] => [
+  { icon: faBoxesStacked, type: "blocks", title: "Blocks" },
+  { icon: faAsterisk, type: "types", title: "Types" },
+  ...(HUB_SERVICES_ENABLED
+    ? [{ icon: faBinary, type: "services", title: "Services" }]
+    : []),
+];
+
+export const HubListBrowse = ({
+  onBrowseClick,
+}: {
+  onBrowseClick: () => void;
+}) => {
+  const [overriddenActiveTypeIndex, setOverriddenActiveTypeIndex] =
+    useState<number>();
+
+  const browseItems = getBrowseItems();
+  const currentType = useRouteHubBrowseType();
+
+  const activeTypeIndex = useMemo(() => {
+    if (typeof overriddenActiveTypeIndex === "number") {
+      return overriddenActiveTypeIndex;
+    }
+
+    return browseItems.findIndex((item) => item.type === currentType) ?? 0;
+  }, [browseItems, overriddenActiveTypeIndex, currentType]);
+
+  return (
+    <Stack spacing={1.25}>
+      <Typography
+        variant="bpSmallCaps"
+        fontSize={14}
+        color="#000"
+        fontWeight={500}
+      >
+        Browse
+      </Typography>
+      <Box sx={{ position: "relative" }}>
+        {browseItems.map(({ icon, title, type }, index) => (
+          <HubListBrowseType
+            active={index === activeTypeIndex}
+            key={type}
+            type={type}
+            onClick={() => {
+              setOverriddenActiveTypeIndex(index);
+              onBrowseClick();
+            }}
+          >
+            <FontAwesomeIcon icon={icon} /> {title}
+          </HubListBrowseType>
+        ))}
+        <Box
+          sx={{
+            position: "absolute",
+            left: 0,
+            top: 0,
+            height: `calc(100% / ${browseItems.length})`,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            transform: `translateY(${100 * activeTypeIndex}%)`,
+            transition: (theme) => theme.transitions.create("transform"),
+          }}
+        >
+          <Box
+            sx={{
+              background: (theme) => theme.palette.purple[70],
+              height: 12,
+              width: 3,
+              borderRadius: "8px",
+            }}
+          />
+        </Box>
+      </Box>
+    </Stack>
+  );
+};

--- a/apps/site/src/components/pages/hub/hub-utils.tsx
+++ b/apps/site/src/components/pages/hub/hub-utils.tsx
@@ -1,5 +1,8 @@
 import { Entity } from "@blockprotocol/graph";
+import { Variants } from "framer-motion";
 import { NextParsedUrlQuery } from "next/dist/server/request-meta";
+import { useRouter } from "next/router";
+import { useState } from "react";
 
 /** @todo type as JSON Schema. */
 export type BlockSchema = Record<string, any>;
@@ -16,3 +19,44 @@ export const getRouteHubBrowseType = (query: NextParsedUrlQuery) =>
 
 export const getHubBrowseQuery = (type: string) =>
   type === defaultBrowseType ? {} : { type };
+
+export const fadeInWrapper: Variants = {
+  hidden: { opacity: 0 },
+  show: {
+    opacity: 1,
+    transition: {
+      staggerChildren: 0.1,
+    },
+  },
+};
+
+export const fadeInChildren: Variants = {
+  hidden: { opacity: 0 },
+  show: { opacity: 1 },
+};
+
+/**
+ * A hook to track the route changing state via adding a manual listener with the route change trigger
+ * @returns
+ * `routeChanging`: whether the route is changing
+ * `listenRouteChange`: function to execute along with the route change trigger
+ */
+export const useRouteChangingWithTrigger = () => {
+  const router = useRouter();
+  const [routeChanging, setRouteChanging] = useState(false);
+
+  const listenRouteChange = () => {
+    setRouteChanging(true);
+
+    const handleStop = () => {
+      router.events.off("routeChangeComplete", handleStop);
+      router.events.off("routeChangeError", handleStop);
+      setRouteChanging(false);
+    };
+
+    router.events.on("routeChangeComplete", handleStop);
+    router.events.on("routeChangeError", handleStop);
+  };
+
+  return [routeChanging, listenRouteChange] as const;
+};

--- a/apps/site/src/components/pages/hub/hub.tsx
+++ b/apps/site/src/components/pages/hub/hub.tsx
@@ -1,28 +1,22 @@
-import { faAsterisk } from "@fortawesome/free-solid-svg-icons";
 import {
   Box,
   Container,
   Grid,
   Skeleton,
   Stack,
-  svgIconClasses,
   Typography,
 } from "@mui/material";
 import { motion } from "framer-motion";
 import { useRouter } from "next/router";
 import { ReactNode } from "react";
 
-import { HUB_SERVICES_ENABLED } from "../../../pages/hub.page";
-import { FontAwesomeIcon } from "../../icons";
-import { faBinary } from "../../icons/fa/binary";
-import { faBoxesStacked } from "../../icons/fa/boxes-stacked";
 import { ClientOnlyLastUpdated } from "../../last-updated";
 import { Link } from "../../link";
 import { VerifiedBadge } from "../../verified-badge";
+import { HubListBrowse } from "./hub-list-browse";
 import {
   fadeInChildren,
   fadeInWrapper,
-  getHubBrowseQuery,
   getRouteHubBrowseType,
   useRouteChangingWithTrigger as useRouteChangingWithListener,
 } from "./hub-utils";
@@ -121,93 +115,6 @@ const HubItemLoading = () => (
     </Stack>
   </Stack>
 );
-
-const HubListBrowseType = ({
-  children,
-  type,
-  onClick,
-}: {
-  children: ReactNode;
-  type: string;
-  onClick: () => void;
-}) => {
-  const currentType = useRouteHubBrowseType();
-  const active = type === currentType;
-
-  return (
-    <Typography
-      onClick={onClick}
-      component={Link}
-      scroll={false}
-      href={{ query: getHubBrowseQuery(type) }}
-      pl={1.5}
-      sx={[
-        (theme) => ({
-          fontWeight: 500,
-          color: theme.palette.gray[90],
-          position: "relative",
-          display: "flex",
-          alignItems: "center",
-          [`.${svgIconClasses.root}`]: {
-            marginRight: 1,
-            fontSize: 15,
-            color: theme.palette.gray[50],
-          },
-        }),
-        active &&
-          ((theme) => ({
-            fontWeight: 600,
-            color: theme.palette.purple[70],
-
-            [`.${svgIconClasses.root}`]: {
-              color: "inherit",
-            },
-
-            "&:before": {
-              position: "absolute",
-              content: `""`,
-              display: "block",
-              background: "currentColor",
-              height: 12,
-              top: "50%",
-              transform: "translateY(-50%)",
-              left: 0,
-              width: 3,
-              borderRadius: "8px",
-            },
-          })),
-      ]}
-    >
-      {children}
-    </Typography>
-  );
-};
-
-const HubListBrowse = ({ onBrowseClick }: { onBrowseClick: () => void }) => {
-  return (
-    <Stack spacing={1.25}>
-      <Typography
-        variant="bpSmallCaps"
-        fontSize={14}
-        color="#000"
-        fontWeight={500}
-      >
-        Browse
-      </Typography>
-      <HubListBrowseType type="blocks" onClick={onBrowseClick}>
-        <FontAwesomeIcon icon={faBoxesStacked} /> Blocks
-      </HubListBrowseType>
-      <HubListBrowseType type="types" onClick={onBrowseClick}>
-        <FontAwesomeIcon icon={faAsterisk} /> Types
-      </HubListBrowseType>
-      {HUB_SERVICES_ENABLED ? (
-        <HubListBrowseType type="services" onClick={onBrowseClick}>
-          <FontAwesomeIcon icon={faBinary} /> Services
-        </HubListBrowseType>
-      ) : null}
-    </Stack>
-  );
-};
 
 const AnimatedTypography = motion(Typography);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2394,15 +2394,10 @@
   dependencies:
     "@emotion/memoize" "^0.8.0"
 
-"@emotion/memoize@0.7.4":
+"@emotion/memoize@0.7.4", "@emotion/memoize@^0.7.4":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
-
-"@emotion/memoize@^0.7.4":
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
-  integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
 
 "@emotion/memoize@^0.8.0":
   version "0.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2380,12 +2380,24 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.0.tgz#c5153d50401ee3c027a57a177bc269b16d889cb7"
   integrity sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==
 
+"@emotion/is-prop-valid@^0.8.2":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
+
 "@emotion/is-prop-valid@^1.1.2", "@emotion/is-prop-valid@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-1.2.0.tgz#7f2d35c97891669f7e276eb71c83376a5dc44c83"
   integrity sha512-3aDpDprjM0AwaxGE09bOPkNxHpBd+kA6jty3RnaEXdweX1DF1U3VQpPYb0g1IStAuK7SVQ1cy+bNBBKp4W3Fjg==
   dependencies:
     "@emotion/memoize" "^0.8.0"
+
+"@emotion/memoize@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
 
 "@emotion/memoize@^0.7.4":
   version "0.7.5"
@@ -7937,6 +7949,15 @@ forwarded@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
   integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
+
+framer-motion@10.2.4:
+  version "10.2.4"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-10.2.4.tgz#e728a34c5c208aef4ee2b829409e0f59c7d6405c"
+  integrity sha512-0a5yR1jwOfSO0jJEpZUrgWYEa1EPU2yGVmytSu+uMYWV7bcFHwaHVYz2GchzWPH1rW7nXg8zmw8cp4+zNJJaUA==
+  dependencies:
+    tslib "^2.4.0"
+  optionalDependencies:
+    "@emotion/is-prop-valid" "^0.8.2"
 
 fresh@0.5.2:
   version "0.5.2"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Improve `/hub` list loading UX using skeleton loaders and staggered fade-in animation
## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203179076056186/1204062182948733/f) _(internal)_


## 🔍 What does this change?

- Add `framer-motion` as a dependency

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Checkout the branch / view the deployment
1.  Open `/hub`
1. Test the behavior shown in the demo below

## 📹 Demo


https://user-images.githubusercontent.com/39553853/224712447-48ca0910-8ca2-44b2-bbf6-b517e909d01c.mov

