### PR TITLE
Make the inclusion of mock data optional in MockBlockDock

### DIFF
--- a/.changeset/twelve-spies-whisper.md
+++ b/.changeset/twelve-spies-whisper.md
@@ -5,4 +5,4 @@
 "mock-block-dock": patch
 ---
 
-Introduce `includeProvidedMockData` toggle on MockBlockDock
+Introduce `includeDefaultMockData` toggle on MockBlockDock

--- a/.changeset/twelve-spies-whisper.md
+++ b/.changeset/twelve-spies-whisper.md
@@ -1,0 +1,8 @@
+---
+"block-template-custom-element": patch
+"block-template-react": patch
+"block-template-html": patch
+"mock-block-dock": patch
+---
+
+Introduce `includeProvidedMockData` toggle on MockBlockDock

--- a/libs/block-template-custom-element/src/dev.tsx
+++ b/libs/block-template-custom-element/src/dev.tsx
@@ -55,6 +55,7 @@ const DevApp = () => {
       initialData={{
         initialEntities: [testEntity],
       }}
+      includeProvidedMockData // this seeds the datastore with sample entities and links, remove this to start with just the contents of `initialData`
       // hideDebugToggle <- uncomment this to disable the debug UI entirely
       // initialEntities={[]} <- customise the entities in the datastore (blockEntity is always added, if you provide it)
       // initialEntityTypes={[]} <- customise the entity types in the datastore

--- a/libs/block-template-custom-element/src/dev.tsx
+++ b/libs/block-template-custom-element/src/dev.tsx
@@ -55,7 +55,7 @@ const DevApp = () => {
       initialData={{
         initialEntities: [testEntity],
       }}
-      includeProvidedMockData // this seeds the datastore with sample entities and links, remove this to start with just the contents of `initialData`
+      includeDefaultMockData // this seeds the datastore with sample entities and links, remove this to start with just the contents of `initialData`
       // hideDebugToggle <- uncomment this to disable the debug UI entirely
       // initialEntities={[]} <- customise the entities in the datastore (blockEntity is always added, if you provide it)
       // initialEntityTypes={[]} <- customise the entity types in the datastore

--- a/libs/block-template-html/dev/index.html
+++ b/libs/block-template-html/dev/index.html
@@ -53,10 +53,12 @@
               },
             }}
             initialData=${initialData}
+            includeProvidedMockData
             blockEntityRecordId=${blockEntity.metadata.recordId}
             debug
           />
         `;
+        // `includeProvidedMockData` seeds the datastore with sample entities and links, remove it to start with just the contents of `initialData`
         // remove 'debug' above to start with the debug UI minimised. You can also toggle it in the UI
         // hideDebugToggle <- add 'hideDebugToggle' to disable the debug UI entirely
         // readonly <- add this above to start your block in readonly mode. You can also toggle it in the UI

--- a/libs/block-template-html/dev/index.html
+++ b/libs/block-template-html/dev/index.html
@@ -53,12 +53,12 @@
               },
             }}
             initialData=${initialData}
-            includeProvidedMockData
+            includeDefaultMockData
             blockEntityRecordId=${blockEntity.metadata.recordId}
             debug
           />
         `;
-        // `includeProvidedMockData` seeds the datastore with sample entities and links, remove it to start with just the contents of `initialData`
+        // `includeDefaultMockData` seeds the datastore with sample entities and links, remove it to start with just the contents of `initialData`
         // remove 'debug' above to start with the debug UI minimised. You can also toggle it in the UI
         // hideDebugToggle <- add 'hideDebugToggle' to disable the debug UI entirely
         // readonly <- add this above to start your block in readonly mode. You can also toggle it in the UI

--- a/libs/block-template-react/src/dev.tsx
+++ b/libs/block-template-react/src/dev.tsx
@@ -43,7 +43,7 @@ const DevApp = () => {
       initialData={{
         initialEntities: [testEntity],
       }}
-      includeProvidedMockData // this seeds the datastore with sample entities and links, remove this to start with just the contents of `initialData`
+      includeDefaultMockData // this seeds the datastore with sample entities and links, remove this to start with just the contents of `initialData`
       // hideDebugToggle <- uncomment this to disable the debug UI entirely
       // initialEntities={[]} <- customise the entities in the datastore (blockEntity is always added, if you provide it)
       // initialEntityTypes={[]} <- customise the entity types in the datastore

--- a/libs/block-template-react/src/dev.tsx
+++ b/libs/block-template-react/src/dev.tsx
@@ -43,6 +43,7 @@ const DevApp = () => {
       initialData={{
         initialEntities: [testEntity],
       }}
+      includeProvidedMockData // this seeds the datastore with sample entities and links, remove this to start with just the contents of `initialData`
       // hideDebugToggle <- uncomment this to disable the debug UI entirely
       // initialEntities={[]} <- customise the entities in the datastore (blockEntity is always added, if you provide it)
       // initialEntityTypes={[]} <- customise the entity types in the datastore

--- a/libs/mock-block-dock/dev/dev-app.tsx
+++ b/libs/mock-block-dock/dev/dev-app.tsx
@@ -157,7 +157,7 @@ const DevApp: FunctionComponent = () => {
         initialData={{
           initialEntities: Object.values(blockEntityMap),
         }}
-        includeProvidedMockData
+        includeDefaultMockData
         temporal={false}
       />
     </>

--- a/libs/mock-block-dock/dev/dev-app.tsx
+++ b/libs/mock-block-dock/dev/dev-app.tsx
@@ -157,6 +157,7 @@ const DevApp: FunctionComponent = () => {
         initialData={{
           initialEntities: Object.values(blockEntityMap),
         }}
+        includeProvidedMockData
         temporal={false}
       />
     </>

--- a/libs/mock-block-dock/src/mock-block-dock.tsx
+++ b/libs/mock-block-dock/src/mock-block-dock.tsx
@@ -58,6 +58,7 @@ type MockBlockDockProps<Temporal extends boolean> = {
   debug?: boolean;
   hideDebugToggle?: boolean;
   initialData?: InitialData<Temporal>;
+  includeProvidedMockData?: boolean;
   readonly?: boolean;
   serviceModuleCallbacks?: ServiceEmbedderMessageCallbacks;
   blockInfo?: {
@@ -83,6 +84,7 @@ const MockBlockDockNonTemporal: FunctionComponent<
   debug: initialDebug = false,
   hideDebugToggle = false,
   initialData,
+  includeProvidedMockData,
   readonly: initialReadonly = false,
   serviceModuleCallbacks: serviceModuleCallbacksFromProps,
 }: Omit<MockBlockDockProps<false>, "temporal">) => {
@@ -96,6 +98,7 @@ const MockBlockDockNonTemporal: FunctionComponent<
   } = useMockBlockPropsNonTemporal({
     blockEntityRecordId: initialBlockEntityRecordId,
     initialData: initialData as InitialData<false>,
+    includeProvidedMockData,
     readonly: !!initialReadonly,
   });
 
@@ -333,6 +336,7 @@ const MockBlockDockTemporal: FunctionComponent<
   debug: initialDebug = false,
   hideDebugToggle = false,
   initialData,
+  includeProvidedMockData,
   readonly: initialReadonly = false,
   serviceModuleCallbacks: serviceModuleCallbacksFromProps,
 }: Omit<MockBlockDockProps<true>, "temporal">) => {
@@ -346,6 +350,7 @@ const MockBlockDockTemporal: FunctionComponent<
   } = useMockBlockPropsTemporal({
     blockEntityRecordId: initialBlockEntityRecordId,
     initialData: initialData as InitialData<true>,
+    includeProvidedMockData,
     readonly: !!initialReadonly,
   });
 
@@ -603,6 +608,7 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps<boolean>> = <
   debug: initialDebug = false,
   hideDebugToggle = false,
   initialData,
+  includeProvidedMockData,
   readonly: initialReadonly = false,
   serviceModuleCallbacks,
 }: MockBlockDockProps<Temporal>) => {
@@ -616,6 +622,7 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps<boolean>> = <
       debug={initialDebug}
       hideDebugToggle={hideDebugToggle}
       initialData={initialData as InitialData<true>}
+      includeProvidedMockData={includeProvidedMockData}
       readonly={initialReadonly}
       serviceModuleCallbacks={serviceModuleCallbacks}
     />
@@ -629,6 +636,7 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps<boolean>> = <
       debug={initialDebug}
       hideDebugToggle={hideDebugToggle}
       initialData={initialData}
+      includeProvidedMockData={includeProvidedMockData}
       readonly={initialReadonly}
       serviceModuleCallbacks={serviceModuleCallbacks}
     />

--- a/libs/mock-block-dock/src/mock-block-dock.tsx
+++ b/libs/mock-block-dock/src/mock-block-dock.tsx
@@ -595,6 +595,7 @@ const MockBlockDockTemporal: FunctionComponent<
  * @param [props.initialData.initialLinkedQueries] - The linkedQuery DEFINITIONS to include in the data store (results will be resolved automatically)
  * @param [props.readonly=false] whether the block should display in readonly mode or not
  * @param [props.serviceModuleCallbacks] overrides the default service module callbacks
+ * @param [props.includeProvidedMockData] whether to populate the datastore with mock data provided by MBD (in addition to the user-provided data through the `initialData` prop)
  */
 export const MockBlockDock: FunctionComponent<MockBlockDockProps<boolean>> = <
   Temporal extends boolean,

--- a/libs/mock-block-dock/src/mock-block-dock.tsx
+++ b/libs/mock-block-dock/src/mock-block-dock.tsx
@@ -58,7 +58,7 @@ type MockBlockDockProps<Temporal extends boolean> = {
   debug?: boolean;
   hideDebugToggle?: boolean;
   initialData?: InitialData<Temporal>;
-  includeProvidedMockData?: boolean;
+  includeDefaultMockData?: boolean;
   readonly?: boolean;
   serviceModuleCallbacks?: ServiceEmbedderMessageCallbacks;
   blockInfo?: {
@@ -84,7 +84,7 @@ const MockBlockDockNonTemporal: FunctionComponent<
   debug: initialDebug = false,
   hideDebugToggle = false,
   initialData,
-  includeProvidedMockData,
+  includeDefaultMockData,
   readonly: initialReadonly = false,
   serviceModuleCallbacks: serviceModuleCallbacksFromProps,
 }: Omit<MockBlockDockProps<false>, "temporal">) => {
@@ -98,7 +98,7 @@ const MockBlockDockNonTemporal: FunctionComponent<
   } = useMockBlockPropsNonTemporal({
     blockEntityRecordId: initialBlockEntityRecordId,
     initialData: initialData as InitialData<false>,
-    includeProvidedMockData,
+    includeDefaultMockData,
     readonly: !!initialReadonly,
   });
 
@@ -336,7 +336,7 @@ const MockBlockDockTemporal: FunctionComponent<
   debug: initialDebug = false,
   hideDebugToggle = false,
   initialData,
-  includeProvidedMockData,
+  includeDefaultMockData,
   readonly: initialReadonly = false,
   serviceModuleCallbacks: serviceModuleCallbacksFromProps,
 }: Omit<MockBlockDockProps<true>, "temporal">) => {
@@ -350,7 +350,7 @@ const MockBlockDockTemporal: FunctionComponent<
   } = useMockBlockPropsTemporal({
     blockEntityRecordId: initialBlockEntityRecordId,
     initialData: initialData as InitialData<true>,
-    includeProvidedMockData,
+    includeDefaultMockData,
     readonly: !!initialReadonly,
   });
 
@@ -595,7 +595,7 @@ const MockBlockDockTemporal: FunctionComponent<
  * @param [props.initialData.initialLinkedQueries] - The linkedQuery DEFINITIONS to include in the data store (results will be resolved automatically)
  * @param [props.readonly=false] whether the block should display in readonly mode or not
  * @param [props.serviceModuleCallbacks] overrides the default service module callbacks
- * @param [props.includeProvidedMockData] whether to populate the datastore with mock data provided by MBD (in addition to the user-provided data through the `initialData` prop)
+ * @param [props.includeDefaultMockData] whether to populate the datastore with mock data provided by MBD (in addition to the user-provided data through the `initialData` prop)
  */
 export const MockBlockDock: FunctionComponent<MockBlockDockProps<boolean>> = <
   Temporal extends boolean,
@@ -609,7 +609,7 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps<boolean>> = <
   debug: initialDebug = false,
   hideDebugToggle = false,
   initialData,
-  includeProvidedMockData,
+  includeDefaultMockData,
   readonly: initialReadonly = false,
   serviceModuleCallbacks,
 }: MockBlockDockProps<Temporal>) => {
@@ -623,7 +623,7 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps<boolean>> = <
       debug={initialDebug}
       hideDebugToggle={hideDebugToggle}
       initialData={initialData as InitialData<true>}
-      includeProvidedMockData={includeProvidedMockData}
+      includeDefaultMockData={includeDefaultMockData}
       readonly={initialReadonly}
       serviceModuleCallbacks={serviceModuleCallbacks}
     />
@@ -637,7 +637,7 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps<boolean>> = <
       debug={initialDebug}
       hideDebugToggle={hideDebugToggle}
       initialData={initialData}
-      includeProvidedMockData={includeProvidedMockData}
+      includeDefaultMockData={includeDefaultMockData}
       readonly={initialReadonly}
       serviceModuleCallbacks={serviceModuleCallbacks}
     />

--- a/libs/mock-block-dock/src/use-mock-block-props.ts
+++ b/libs/mock-block-dock/src/use-mock-block-props.ts
@@ -35,6 +35,7 @@ export type MockBlockHookArgs<Temporal extends boolean> = {
     ? EntityRecordIdTemporal
     : EntityRecordIdNonTemporal;
   initialData?: InitialData<Temporal>;
+  includeProvidedMockData?: boolean;
   readonly: boolean;
 };
 
@@ -90,10 +91,14 @@ export const useMockBlockPropsNonTemporal = (
     return {
       entities: [
         ...(args.initialData?.initialEntities ?? []),
-        ...defaultMockData.entities,
+        ...(args.includeProvidedMockData ? defaultMockData.entities : []),
       ],
     };
-  }, [args.blockEntityRecordId, args.initialData?.initialEntities]);
+  }, [
+    args.blockEntityRecordId,
+    args.initialData?.initialEntities,
+    args.includeProvidedMockData,
+  ]);
 
   const defaultBlockEntity = mockData.entities[0]!;
 
@@ -154,7 +159,9 @@ export const useMockBlockPropsTemporal = (
     return {
       entities: [
         ...(args.initialData?.initialEntities ?? []),
-        ...defaultTemporalMockData.entities,
+        ...(args.includeProvidedMockData
+          ? defaultTemporalMockData.entities
+          : []),
       ],
       subgraphTemporalAxes: args.initialData?.initialTemporalAxes
         ? {
@@ -167,6 +174,7 @@ export const useMockBlockPropsTemporal = (
     args.blockEntityRecordId,
     args.initialData?.initialEntities,
     args.initialData?.initialTemporalAxes,
+    args.includeProvidedMockData,
   ]);
 
   const defaultBlockEntity = mockData.entities[0]!;

--- a/libs/mock-block-dock/src/use-mock-block-props.ts
+++ b/libs/mock-block-dock/src/use-mock-block-props.ts
@@ -35,7 +35,7 @@ export type MockBlockHookArgs<Temporal extends boolean> = {
     ? EntityRecordIdTemporal
     : EntityRecordIdNonTemporal;
   initialData?: InitialData<Temporal>;
-  includeProvidedMockData?: boolean;
+  includeDefaultMockData?: boolean;
   readonly: boolean;
 };
 
@@ -91,13 +91,13 @@ export const useMockBlockPropsNonTemporal = (
     return {
       entities: [
         ...(args.initialData?.initialEntities ?? []),
-        ...(args.includeProvidedMockData ? defaultMockData.entities : []),
+        ...(args.includeDefaultMockData ? defaultMockData.entities : []),
       ],
     };
   }, [
     args.blockEntityRecordId,
     args.initialData?.initialEntities,
-    args.includeProvidedMockData,
+    args.includeDefaultMockData,
   ]);
 
   const defaultBlockEntity = mockData.entities[0]!;
@@ -159,7 +159,7 @@ export const useMockBlockPropsTemporal = (
     return {
       entities: [
         ...(args.initialData?.initialEntities ?? []),
-        ...(args.includeProvidedMockData
+        ...(args.includeDefaultMockData
           ? defaultTemporalMockData.entities
           : []),
       ],
@@ -174,7 +174,7 @@ export const useMockBlockPropsTemporal = (
     args.blockEntityRecordId,
     args.initialData?.initialEntities,
     args.initialData?.initialTemporalAxes,
-    args.includeProvidedMockData,
+    args.includeDefaultMockData,
   ]);
 
   const defaultBlockEntity = mockData.entities[0]!;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

MockBlockDock ships with sample entities and links to help jump-start block development and experimentation. While this is helpful in a lot of cases (especially when getting started and wanting to follow tutorials), it can prove annoying when trying to focus on block logic to do with entity creation. For example, if working with a block which creates links of `Date`s and `Event`s, the completely unrelated mock-data can get in the way.

As such this PR makes the data configurable through a simple toggle on the props of MBD.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203358502199087/1204080201525396/f) _(internal)_

## 🚫 Blocked by

- [ ] N/A

## 🔍 What does this change?

- Adds an `includeProvidedMockData` prop on MBD
- Fills that in as `true` by default in block templates

## 📜 Does this require a change to the docs?

- Unsure if this is mentioned in tutorials or anywhere else.

## ⚠️ Known issues

- This implementation unfortunately splits the definition of the seed data in the datastore between multiple props (`initialData` and `includeProvidedMockData`). We will consider improving this in the near future to try and expose the mock data from the MBD package itself, and then spread that into the `initialData` in the templates. This will allow users to locally modify the mock data before putting it in the datastore, and _should_ help illustrate how to seed the datastore in the first place. This is made more complicated by necessary considerations about incidentally exposing the complexity of temporal versioning.

## 🐾 Next steps

- Try and unify the seed data into a single prop, as described above.

## 🛡 What tests cover this?

- `tsc` and `eslint` 
- Manual testing of MBD and the block templates

## ❓ How to test this?

1. Run `yarn workspace mock-block-dock dev` and see the seed data
2. Edit the `dev-app` of `mock-block-dock` and remove `includeProvidedMockData` and verify seed data is gone
3. Repeat the above for the block templates

## 📹 Demo

<img width="1368" alt="image" src="https://user-images.githubusercontent.com/25749103/224698479-04f6ea76-f37b-4681-a950-e4ea43a4ee1c.png">
<img width="1425" alt="image" src="https://user-images.githubusercontent.com/25749103/224698630-ab6c16c9-b1fe-446f-b9ca-3ccae6926edd.png">

