### PR TITLE
Add latency simulation to `mock-block-dock`

### DIFF
--- a/.changeset/seven-comics-beam.md
+++ b/.changeset/seven-comics-beam.md
@@ -1,0 +1,8 @@
+---
+"block-template-custom-element": patch
+"block-template-react": patch
+"block-template-html": patch
+"mock-block-dock": patch
+---
+
+Add latency simulation

--- a/libs/block-template-custom-element/src/dev.tsx
+++ b/libs/block-template-custom-element/src/dev.tsx
@@ -55,6 +55,11 @@ const DevApp = () => {
       initialData={{
         initialEntities: [testEntity],
       }}
+      simulateLatency={{
+        // configure this to adjust the range of artificial latency (in ms)
+        min: 50,
+        max: 200,
+      }}
       // hideDebugToggle <- uncomment this to disable the debug UI entirely
       // initialEntities={[]} <- customise the entities in the datastore (blockEntity is always added, if you provide it)
       // initialEntityTypes={[]} <- customise the entity types in the datastore

--- a/libs/block-template-custom-element/src/dev.tsx
+++ b/libs/block-template-custom-element/src/dev.tsx
@@ -55,7 +55,7 @@ const DevApp = () => {
       initialData={{
         initialEntities: [testEntity],
       }}
-      simulateLatency={{
+      simulateDatastoreLatency={{
         // configure this to adjust the range of artificial latency (in ms)
         min: 50,
         max: 200,

--- a/libs/block-template-custom-element/src/dev.tsx
+++ b/libs/block-template-custom-element/src/dev.tsx
@@ -56,7 +56,7 @@ const DevApp = () => {
         initialEntities: [testEntity],
       }}
       simulateDatastoreLatency={{
-        // configure this to adjust the range of artificial latency (in ms)
+        // configure this to adjust the range of artificial latency in responses to datastore-related requests (in ms)
         min: 50,
         max: 200,
       }}

--- a/libs/block-template-html/dev/index.html
+++ b/libs/block-template-html/dev/index.html
@@ -55,8 +55,13 @@
             initialData=${initialData}
             blockEntityRecordId=${blockEntity.metadata.recordId}
             debug
+            simulateLatency=${{
+              min: 100,
+              max: 200,
+            }}
           />
         `;
+        // modify `simulateLatency` above to adjust the range of artificial latency (in ms)
         // remove 'debug' above to start with the debug UI minimised. You can also toggle it in the UI
         // hideDebugToggle <- add 'hideDebugToggle' to disable the debug UI entirely
         // readonly <- add this above to start your block in readonly mode. You can also toggle it in the UI

--- a/libs/block-template-html/dev/index.html
+++ b/libs/block-template-html/dev/index.html
@@ -61,7 +61,7 @@
             }}
           />
         `;
-        // modify `simulateDatastoreLatency` above to adjust the range of artificial latency (in ms)
+        // modify `simulateDatastoreLatency` above to adjust the range of artificial latency in responses to datastore-related requests  (in ms)
         // remove 'debug' above to start with the debug UI minimised. You can also toggle it in the UI
         // hideDebugToggle <- add 'hideDebugToggle' to disable the debug UI entirely
         // readonly <- add this above to start your block in readonly mode. You can also toggle it in the UI

--- a/libs/block-template-html/dev/index.html
+++ b/libs/block-template-html/dev/index.html
@@ -55,13 +55,13 @@
             initialData=${initialData}
             blockEntityRecordId=${blockEntity.metadata.recordId}
             debug
-            simulateLatency=${{
+            simulateDatastoreLatency=${{
               min: 100,
               max: 200,
             }}
           />
         `;
-        // modify `simulateLatency` above to adjust the range of artificial latency (in ms)
+        // modify `simulateDatastoreLatency` above to adjust the range of artificial latency (in ms)
         // remove 'debug' above to start with the debug UI minimised. You can also toggle it in the UI
         // hideDebugToggle <- add 'hideDebugToggle' to disable the debug UI entirely
         // readonly <- add this above to start your block in readonly mode. You can also toggle it in the UI

--- a/libs/block-template-react/src/dev.tsx
+++ b/libs/block-template-react/src/dev.tsx
@@ -44,7 +44,7 @@ const DevApp = () => {
         initialEntities: [testEntity],
       }}
       simulateDatastoreLatency={{
-        // configure this to adjust the range of artificial latency (in ms)
+        // configure this to adjust the range of artificial latency in responses to datastore-related requests (in ms)
         min: 50,
         max: 200,
       }}

--- a/libs/block-template-react/src/dev.tsx
+++ b/libs/block-template-react/src/dev.tsx
@@ -43,6 +43,11 @@ const DevApp = () => {
       initialData={{
         initialEntities: [testEntity],
       }}
+      simulateLatency={{
+        // configure this to adjust the range of artificial latency (in ms)
+        min: 50,
+        max: 200,
+      }}
       // hideDebugToggle <- uncomment this to disable the debug UI entirely
       // initialEntities={[]} <- customise the entities in the datastore (blockEntity is always added, if you provide it)
       // initialEntityTypes={[]} <- customise the entity types in the datastore

--- a/libs/block-template-react/src/dev.tsx
+++ b/libs/block-template-react/src/dev.tsx
@@ -43,7 +43,7 @@ const DevApp = () => {
       initialData={{
         initialEntities: [testEntity],
       }}
-      simulateLatency={{
+      simulateDatastoreLatency={{
         // configure this to adjust the range of artificial latency (in ms)
         min: 50,
         max: 200,

--- a/libs/mock-block-dock/dev/dev-app.tsx
+++ b/libs/mock-block-dock/dev/dev-app.tsx
@@ -158,7 +158,7 @@ const DevApp: FunctionComponent = () => {
           initialEntities: Object.values(blockEntityMap),
         }}
         temporal={false}
-        simulateLatency={{ min: 50, max: 200 }}
+        simulateDatastoreLatency={{ min: 50, max: 200 }}
       />
     </>
   );

--- a/libs/mock-block-dock/dev/dev-app.tsx
+++ b/libs/mock-block-dock/dev/dev-app.tsx
@@ -158,6 +158,7 @@ const DevApp: FunctionComponent = () => {
           initialEntities: Object.values(blockEntityMap),
         }}
         temporal={false}
+        simulateLatency={{ min: 50, max: 200 }}
       />
     </>
   );

--- a/libs/mock-block-dock/src/datastore/use-mock-datastore/non-temporal.ts
+++ b/libs/mock-block-dock/src/datastore/use-mock-datastore/non-temporal.ts
@@ -59,7 +59,7 @@ const readonlyErrorReturn: {
 export const useMockDatastore = (
   initialData: MockData<false>,
   readonly?: boolean,
-  simulateLatency?: { min: number; max: number },
+  simulateDatastoreLatency?: { min: number; max: number },
 ): MockDatastore => {
   const mockDataSubgraph = useMockDataToSubgraph(initialData);
   const [graph, setGraph] = useDefaultState(mockDataSubgraph);
@@ -96,7 +96,7 @@ export const useMockDatastore = (
         return { data: queryEntitiesImpl<false>(data, graph) };
       },
       [graph],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   const createEntity: GraphEmbedderMessageCallbacks["createEntity"] =
@@ -151,7 +151,7 @@ export const useMockDatastore = (
         });
       },
       [readonly, setGraph],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   const getEntity: GraphEmbedderMessageCallbacks["getEntity"] =
@@ -195,7 +195,7 @@ export const useMockDatastore = (
         return { data: entitySubgraph };
       },
       [graph],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   const updateEntity: GraphEmbedderMessageCallbacks["updateEntity"] =
@@ -309,7 +309,7 @@ export const useMockDatastore = (
         });
       },
       [readonly, setGraph],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   const deleteEntity: GraphEmbedderMessageCallbacks["deleteEntity"] =
@@ -417,7 +417,7 @@ export const useMockDatastore = (
         });
       },
       [setGraph, readonly],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   const queryEntityTypes: GraphEmbedderMessageCallbacks["queryEntityTypes"] =
@@ -433,7 +433,7 @@ export const useMockDatastore = (
         };
       },
       [],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   const getEntityType: GraphEmbedderMessageCallbacks["getEntityType"] =
@@ -463,7 +463,7 @@ export const useMockDatastore = (
         }
       },
       [],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   const getPropertyType: GraphEmbedderMessageCallbacks["getPropertyType"] =
@@ -479,7 +479,7 @@ export const useMockDatastore = (
         };
       },
       [],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   const queryPropertyTypes: GraphEmbedderMessageCallbacks["queryPropertyTypes"] =
@@ -495,7 +495,7 @@ export const useMockDatastore = (
         };
       },
       [],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   const getDataType: GraphEmbedderMessageCallbacks["getDataType"] =
@@ -511,7 +511,7 @@ export const useMockDatastore = (
         };
       },
       [],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   const queryDataTypes: GraphEmbedderMessageCallbacks["queryDataTypes"] =
@@ -527,7 +527,7 @@ export const useMockDatastore = (
         };
       },
       [],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   /** @todo - Reimplement linkedQueries */
@@ -555,7 +555,7 @@ export const useMockDatastore = (
   //       setLinkedQueries((currentLinkedQueries) => [
   //         ...currentLinkedQueries,
   //         newLinkedQuery,
-  //       ], simulateLatency);
+  //       ], simulateDatastoreLatency);
   //       return { data: newLinkedQuery };
   //     },
   //     [setLinkedQueries, readonly],
@@ -795,7 +795,7 @@ export const useMockDatastore = (
         return Promise.resolve({ data: newEntity as RemoteFileEntity });
       },
       [createEntity, readonly],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   return {

--- a/libs/mock-block-dock/src/datastore/use-mock-datastore/shared.ts
+++ b/libs/mock-block-dock/src/datastore/use-mock-datastore/shared.ts
@@ -1,28 +1,16 @@
-import { DependencyList, useCallback } from "react";
-
 import { randomNumberFromRange } from "../../util";
 
-type AnyAsyncFunction = (...args: any[]) => Promise<any>;
-
-export const useCallbackWithLatency = <T extends AnyAsyncFunction>(
-  callback: T,
-  deps: DependencyList,
-  simulateDatastoreLatency?: { min: number; max: number },
-): T => {
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- it's not smart enough to deal with the cast
-  return useCallback<T>(
-    (async (...args: Parameters<T>): Promise<Awaited<ReturnType<T>>> => {
-      if (simulateDatastoreLatency) {
-        const waitFor = randomNumberFromRange(
-          simulateDatastoreLatency.min,
-          simulateDatastoreLatency.max,
-        );
-        await new Promise((resolve) => {
-          setTimeout(resolve, waitFor);
-        });
-      }
-      return await callback(...args);
-    }) as T,
-    [callback, ...deps, simulateDatastoreLatency],
-  );
+export const waitForRandomLatency = async (simulateDatastoreLatency?: {
+  min: number;
+  max: number;
+}): Promise<void> => {
+  if (simulateDatastoreLatency) {
+    const waitFor = randomNumberFromRange(
+      simulateDatastoreLatency.min,
+      simulateDatastoreLatency.max,
+    );
+    await new Promise((resolve) => {
+      setTimeout(resolve, waitFor);
+    });
+  }
 };

--- a/libs/mock-block-dock/src/datastore/use-mock-datastore/shared.ts
+++ b/libs/mock-block-dock/src/datastore/use-mock-datastore/shared.ts
@@ -1,0 +1,28 @@
+import { DependencyList, useCallback } from "react";
+
+import { randomNumberFromRange } from "../../util";
+
+type AnyAsyncFunction = (...args: any[]) => Promise<any>;
+
+export const useCallbackWithLatency = <T extends AnyAsyncFunction>(
+  callback: T,
+  deps: DependencyList,
+  simulateLatency?: { min: number; max: number },
+): T => {
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- it's not smart enough to deal with the cast
+  return useCallback<T>(
+    (async (...args: Parameters<T>): Promise<Awaited<ReturnType<T>>> => {
+      if (simulateLatency) {
+        const waitFor = randomNumberFromRange(
+          simulateLatency.min,
+          simulateLatency.max,
+        );
+        await new Promise((resolve) => {
+          setTimeout(resolve, waitFor);
+        });
+      }
+      return await callback(...args);
+    }) as T,
+    [callback, ...deps, simulateLatency],
+  );
+};

--- a/libs/mock-block-dock/src/datastore/use-mock-datastore/shared.ts
+++ b/libs/mock-block-dock/src/datastore/use-mock-datastore/shared.ts
@@ -7,15 +7,15 @@ type AnyAsyncFunction = (...args: any[]) => Promise<any>;
 export const useCallbackWithLatency = <T extends AnyAsyncFunction>(
   callback: T,
   deps: DependencyList,
-  simulateLatency?: { min: number; max: number },
+  simulateDatastoreLatency?: { min: number; max: number },
 ): T => {
   // eslint-disable-next-line react-hooks/exhaustive-deps -- it's not smart enough to deal with the cast
   return useCallback<T>(
     (async (...args: Parameters<T>): Promise<Awaited<ReturnType<T>>> => {
-      if (simulateLatency) {
+      if (simulateDatastoreLatency) {
         const waitFor = randomNumberFromRange(
-          simulateLatency.min,
-          simulateLatency.max,
+          simulateDatastoreLatency.min,
+          simulateDatastoreLatency.max,
         );
         await new Promise((resolve) => {
           setTimeout(resolve, waitFor);
@@ -23,6 +23,6 @@ export const useCallbackWithLatency = <T extends AnyAsyncFunction>(
       }
       return await callback(...args);
     }) as T,
-    [callback, ...deps, simulateLatency],
+    [callback, ...deps, simulateDatastoreLatency],
   );
 };

--- a/libs/mock-block-dock/src/datastore/use-mock-datastore/temporal.ts
+++ b/libs/mock-block-dock/src/datastore/use-mock-datastore/temporal.ts
@@ -57,7 +57,7 @@ const readonlyErrorReturn: {
 export const useMockDatastore = (
   initialData: MockData<true>,
   readonly?: boolean,
-  simulateLatency?: { min: number; max: number },
+  simulateDatastoreLatency?: { min: number; max: number },
 ): MockDatastore => {
   const mockDataSubgraph = useMockDataToSubgraph(initialData);
   const [graph, setGraph] = useDefaultState(mockDataSubgraph);
@@ -100,7 +100,7 @@ export const useMockDatastore = (
         };
       },
       [graph],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   const createEntity: GraphEmbedderMessageCallbacks["createEntity"] =
@@ -169,7 +169,7 @@ export const useMockDatastore = (
         });
       },
       [readonly, setGraph],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   const getEntity: GraphEmbedderMessageCallbacks["getEntity"] =
@@ -213,7 +213,7 @@ export const useMockDatastore = (
         return { data: entitySubgraph };
       },
       [graph],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   const updateEntity: GraphEmbedderMessageCallbacks["updateEntity"] =
@@ -367,7 +367,7 @@ export const useMockDatastore = (
         });
       },
       [readonly, setGraph],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   const deleteEntity: GraphEmbedderMessageCallbacks["deleteEntity"] =
@@ -406,7 +406,7 @@ export const useMockDatastore = (
         });
       },
       [setGraph, readonly],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   const queryEntityTypes: GraphEmbedderMessageCallbacks["queryEntityTypes"] =
@@ -422,7 +422,7 @@ export const useMockDatastore = (
         };
       },
       [],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   const getEntityType: GraphEmbedderMessageCallbacks["getEntityType"] =
@@ -452,7 +452,7 @@ export const useMockDatastore = (
         }
       },
       [],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   const getPropertyType: GraphEmbedderMessageCallbacks["getPropertyType"] =
@@ -468,7 +468,7 @@ export const useMockDatastore = (
         };
       },
       [],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   const queryPropertyTypes: GraphEmbedderMessageCallbacks["queryPropertyTypes"] =
@@ -484,7 +484,7 @@ export const useMockDatastore = (
         };
       },
       [],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   const getDataType: GraphEmbedderMessageCallbacks["getDataType"] =
@@ -500,7 +500,7 @@ export const useMockDatastore = (
         };
       },
       [],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   const queryDataTypes: GraphEmbedderMessageCallbacks["queryDataTypes"] =
@@ -516,7 +516,7 @@ export const useMockDatastore = (
         };
       },
       [],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   /** @todo - Reimplement linkedQueries */
@@ -784,7 +784,7 @@ export const useMockDatastore = (
         return Promise.resolve({ data: newEntity as RemoteFileEntity });
       },
       [createEntity, readonly],
-      simulateLatency,
+      simulateDatastoreLatency,
     );
 
   return {

--- a/libs/mock-block-dock/src/datastore/use-mock-datastore/temporal.ts
+++ b/libs/mock-block-dock/src/datastore/use-mock-datastore/temporal.ts
@@ -17,6 +17,7 @@ import {
 } from "@blockprotocol/graph/temporal";
 import { getEntityRevision } from "@blockprotocol/graph/temporal/stdlib";
 import mime from "mime/lite";
+import { useCallback } from "react";
 import { v4 as uuid } from "uuid";
 
 import { useDefaultState } from "../../use-default-state";
@@ -27,7 +28,7 @@ import { getEntity as getEntityImpl } from "../hook-implementations/entity/get-e
 import { queryEntities as queryEntitiesImpl } from "../hook-implementations/entity/query-entities";
 import { MockData } from "../mock-data";
 import { useMockDataToSubgraph } from "../use-mock-data-to-subgraph";
-import { useCallbackWithLatency } from "./shared";
+import { waitForRandomLatency } from "./shared";
 
 export type MockDatastore = {
   graph: Subgraph;
@@ -61,14 +62,20 @@ export const useMockDatastore = (
 ): MockDatastore => {
   const mockDataSubgraph = useMockDataToSubgraph(initialData);
   const [graph, setGraph] = useDefaultState(mockDataSubgraph);
+  const waitForLatency = useCallback(
+    () => waitForRandomLatency(simulateDatastoreLatency),
+    [simulateDatastoreLatency],
+  );
 
   // const [linkedQueries, setLinkedQueries] = useDefaultState<
   //   MockDataStore["linkedQueryDefinitions"]
   // >(initialData.linkedQueryDefinitions);
 
   const queryEntities: GraphEmbedderMessageCallbacks["queryEntities"] =
-    useCallbackWithLatency(
+    useCallback(
       async ({ data }) => {
+        await waitForLatency();
+
         if (!data) {
           return {
             errors: [
@@ -99,13 +106,14 @@ export const useMockDatastore = (
           ),
         };
       },
-      [graph],
-      simulateDatastoreLatency,
+      [graph, waitForLatency],
     );
 
   const createEntity: GraphEmbedderMessageCallbacks["createEntity"] =
-    useCallbackWithLatency(
+    useCallback(
       async ({ data }) => {
+        await waitForLatency();
+
         if (readonly) {
           return readonlyErrorReturn;
         }
@@ -168,57 +176,58 @@ export const useMockDatastore = (
           });
         });
       },
-      [readonly, setGraph],
-      simulateDatastoreLatency,
+      [readonly, setGraph, waitForLatency],
     );
 
-  const getEntity: GraphEmbedderMessageCallbacks["getEntity"] =
-    useCallbackWithLatency(
-      async ({ data }) => {
-        if (!data) {
-          return {
-            errors: [
-              {
-                code: "INVALID_INPUT",
-                message: "getEntity requires 'data' input",
-              },
-            ],
-          };
-        }
+  const getEntity: GraphEmbedderMessageCallbacks["getEntity"] = useCallback(
+    async ({ data }) => {
+      await waitForLatency();
 
-        if ((data as GetEntityDataTemporal).temporalAxes === undefined) {
-          return {
-            data: getEntityImpl<true>(
-              {
-                ...data,
-                temporalAxes: getDefaultTemporalAxes(),
-              },
-              graph,
-            ),
-          };
-        }
+      if (!data) {
+        return {
+          errors: [
+            {
+              code: "INVALID_INPUT",
+              message: "getEntity requires 'data' input",
+            },
+          ],
+        };
+      }
 
-        const entitySubgraph = getEntityImpl<true>(data, graph);
+      if ((data as GetEntityDataTemporal).temporalAxes === undefined) {
+        return {
+          data: getEntityImpl<true>(
+            {
+              ...data,
+              temporalAxes: getDefaultTemporalAxes(),
+            },
+            graph,
+          ),
+        };
+      }
 
-        if (!entitySubgraph) {
-          return {
-            errors: [
-              {
-                code: "NOT_FOUND",
-                message: `Could not find entity with entityId '${data.entityId}'`,
-              },
-            ],
-          };
-        }
-        return { data: entitySubgraph };
-      },
-      [graph],
-      simulateDatastoreLatency,
-    );
+      const entitySubgraph = getEntityImpl<true>(data, graph);
+
+      if (!entitySubgraph) {
+        return {
+          errors: [
+            {
+              code: "NOT_FOUND",
+              message: `Could not find entity with entityId '${data.entityId}'`,
+            },
+          ],
+        };
+      }
+      return { data: entitySubgraph };
+    },
+    [graph, waitForLatency],
+  );
 
   const updateEntity: GraphEmbedderMessageCallbacks["updateEntity"] =
-    useCallbackWithLatency(
+    useCallback(
       async ({ data }) => {
+        await waitForLatency();
+
         if (readonly) {
           return readonlyErrorReturn;
         }
@@ -366,13 +375,14 @@ export const useMockDatastore = (
           });
         });
       },
-      [readonly, setGraph],
-      simulateDatastoreLatency,
+      [readonly, setGraph, waitForLatency],
     );
 
   const deleteEntity: GraphEmbedderMessageCallbacks["deleteEntity"] =
-    useCallbackWithLatency(
+    useCallback(
       async ({ data }) => {
+        await waitForLatency();
+
         return {
           errors: [
             {
@@ -405,13 +415,14 @@ export const useMockDatastore = (
           });
         });
       },
-      [setGraph, readonly],
-      simulateDatastoreLatency,
+      [setGraph, readonly, waitForLatency],
     );
 
   const queryEntityTypes: GraphEmbedderMessageCallbacks["queryEntityTypes"] =
-    useCallbackWithLatency(
+    useCallback(
       async ({ data: _ }) => {
+        await waitForLatency();
+
         return {
           errors: [
             {
@@ -421,13 +432,14 @@ export const useMockDatastore = (
           ],
         };
       },
-      [],
-      simulateDatastoreLatency,
+      [waitForLatency],
     );
 
   const getEntityType: GraphEmbedderMessageCallbacks["getEntityType"] =
-    useCallbackWithLatency(
+    useCallback(
       async ({ data }) => {
+        await waitForLatency();
+
         return {
           errors: [
             {
@@ -451,13 +463,14 @@ export const useMockDatastore = (
           };
         }
       },
-      [],
-      simulateDatastoreLatency,
+      [waitForLatency],
     );
 
   const getPropertyType: GraphEmbedderMessageCallbacks["getPropertyType"] =
-    useCallbackWithLatency(
+    useCallback(
       async ({ data: _ }) => {
+        await waitForLatency();
+
         return {
           errors: [
             {
@@ -467,13 +480,14 @@ export const useMockDatastore = (
           ],
         };
       },
-      [],
-      simulateDatastoreLatency,
+      [waitForLatency],
     );
 
   const queryPropertyTypes: GraphEmbedderMessageCallbacks["queryPropertyTypes"] =
-    useCallbackWithLatency(
+    useCallback(
       async ({ data: _ }) => {
+        await waitForLatency();
+
         return {
           errors: [
             {
@@ -483,29 +497,30 @@ export const useMockDatastore = (
           ],
         };
       },
-      [],
-      simulateDatastoreLatency,
+      [waitForLatency],
     );
 
-  const getDataType: GraphEmbedderMessageCallbacks["getDataType"] =
-    useCallbackWithLatency(
-      async ({ data: _ }) => {
-        return {
-          errors: [
-            {
-              code: "NOT_IMPLEMENTED",
-              message: `getDataType is not currently supported`,
-            },
-          ],
-        };
-      },
-      [],
-      simulateDatastoreLatency,
-    );
+  const getDataType: GraphEmbedderMessageCallbacks["getDataType"] = useCallback(
+    async ({ data: _ }) => {
+      await waitForLatency();
+
+      return {
+        errors: [
+          {
+            code: "NOT_IMPLEMENTED",
+            message: `getDataType is not currently supported`,
+          },
+        ],
+      };
+    },
+    [waitForLatency],
+  );
 
   const queryDataTypes: GraphEmbedderMessageCallbacks["queryDataTypes"] =
-    useCallbackWithLatency(
+    useCallback(
       async ({ data: _ }) => {
+        await waitForLatency();
+
         return {
           errors: [
             {
@@ -515,14 +530,15 @@ export const useMockDatastore = (
           ],
         };
       },
-      [],
-      simulateDatastoreLatency,
+      [waitForLatency],
     );
 
   /** @todo - Reimplement linkedQueries */
   // const createLinkedQuery: GraphEmbedderMessageCallbacks["createLinkedQuery"] =
-  //   useCallbackWithLatency(
+  //   useCallback(
   //     async ({ data }) => {
+  //       await waitForLatency();
+  //
   //       if (readonly) {
   //         return readonlyErrorReturn;
   //       }
@@ -547,12 +563,14 @@ export const useMockDatastore = (
   //       ]);
   //       return { data: newLinkedQuery };
   //     },
-  //     [setLinkedQueries, readonly],
+  //     [setLinkedQueries, readonly, waitForLatency],
   //   );
   //
   // const getLinkedQuery: GraphEmbedderMessageCallbacks["getLinkedQuery"] =
-  //   useCallbackWithLatency(
+  //   useCallback(
   //     async ({ data }) => {
+  //       await waitForLatency();
+
   //       if (!data) {
   //         return {
   //           errors: [
@@ -584,12 +602,14 @@ export const useMockDatastore = (
   //         },
   //       };
   //     },
-  //     [entities, linkedQueries],
+  //     [entities, linkedQueries, waitForLatency],
   //   );
   //
   // const updateLinkedQuery: GraphEmbedderMessageCallbacks["updateLinkedQuery"] =
-  //   useCallbackWithLatency(
+  //   useCallback(
   //     async ({ data }) => {
+  //       await waitForLatency();
+  //
   //       if (readonly) {
   //         return readonlyErrorReturn;
   //       }
@@ -635,12 +655,14 @@ export const useMockDatastore = (
   //         });
   //       });
   //     },
-  //     [setLinkedQueries, readonly],
+  //     [setLinkedQueries, readonly, waitForLatency],
   //   );
   //
   // const deleteLinkedQuery: GraphEmbedderMessageCallbacks["deleteLinkedQuery"] =
-  //   useCallbackWithLatency(
+  //   useCallback(
   //     async ({ data }) => {
+  //       await waitForLatency();
+  //
   //       if (readonly) {
   //         return readonlyErrorReturn;
   //       }
@@ -682,49 +704,49 @@ export const useMockDatastore = (
   //         });
   //       });
   //     },
-  //     [setLinkedQueries, readonly],
+  //     [setLinkedQueries, readonly, waitForLatency],
   //   );
 
-  const uploadFile: GraphEmbedderMessageCallbacks["uploadFile"] =
-    useCallbackWithLatency(
-      async ({ data }) => {
-        if (readonly) {
-          return readonlyErrorReturn;
-        }
+  const uploadFile: GraphEmbedderMessageCallbacks["uploadFile"] = useCallback(
+    async ({ data }) => {
+      await waitForLatency();
 
-        if (!data) {
-          return {
-            errors: [
-              {
-                code: "INVALID_INPUT",
-                message: "uploadFile requires 'data' input",
-              },
-            ],
-          };
-        }
-        const { description } = data;
+      if (readonly) {
+        return readonlyErrorReturn;
+      }
 
-        const file = isFileData(data) ? data.file : null;
-        const url = isFileAtUrlData(data) ? data.url : null;
-        if (!file && !url?.trim()) {
-          throw new Error("Please provide either a valid URL or file");
-        }
+      if (!data) {
+        return {
+          errors: [
+            {
+              code: "INVALID_INPUT",
+              message: "uploadFile requires 'data' input",
+            },
+          ],
+        };
+      }
+      const { description } = data;
 
-        let filename: string | undefined = data.name;
-        let resolvedUrl: string = "https://unknown-url.example.com";
-        if (url) {
-          if (!filename) {
-            filename = url.split("/").pop() ?? filename;
-          }
-          resolvedUrl = url;
-        } else if (file) {
-          if (!filename) {
-            filename = file.name;
-          }
-          try {
-            const readFileResult = await new Promise<
-              FileReader["result"] | null
-            >((resolve, reject) => {
+      const file = isFileData(data) ? data.file : null;
+      const url = isFileAtUrlData(data) ? data.url : null;
+      if (!file && !url?.trim()) {
+        throw new Error("Please provide either a valid URL or file");
+      }
+
+      let filename: string | undefined = data.name;
+      let resolvedUrl: string = "https://unknown-url.example.com";
+      if (url) {
+        if (!filename) {
+          filename = url.split("/").pop() ?? filename;
+        }
+        resolvedUrl = url;
+      } else if (file) {
+        if (!filename) {
+          filename = file.name;
+        }
+        try {
+          const readFileResult = await new Promise<FileReader["result"] | null>(
+            (resolve, reject) => {
               const reader = new FileReader();
 
               reader.onload = (event) => {
@@ -736,56 +758,56 @@ export const useMockDatastore = (
               };
 
               reader.readAsDataURL(file);
-            });
-            if (!readFileResult) {
-              throw new Error("No result from file reader");
-            }
-            resolvedUrl = readFileResult.toString();
-          } catch (err) {
-            throw new Error("Could not upload file");
+            },
+          );
+          if (!readFileResult) {
+            throw new Error("No result from file reader");
           }
+          resolvedUrl = readFileResult.toString();
+        } catch (err) {
+          throw new Error("Could not upload file");
         }
+      }
 
-        if (!filename) {
-          throw new Error("Could not determine filename and no name provided");
-        }
+      if (!filename) {
+        throw new Error("Could not determine filename and no name provided");
+      }
 
-        const mimeType = mime.getType(filename) || "application/octet-stream";
+      const mimeType = mime.getType(filename) || "application/octet-stream";
 
-        const newEntityProperties: RemoteFileEntityProperties = {
-          "https://blockprotocol.org/@blockprotocol/types/property-type/description/":
-            description,
-          "https://blockprotocol.org/@blockprotocol/types/property-type/file-name/":
-            filename,
-          "https://blockprotocol.org/@blockprotocol/types/property-type/mime-type/":
-            mimeType,
-          "https://blockprotocol.org/@blockprotocol/types/property-type/file-url/":
-            resolvedUrl,
+      const newEntityProperties: RemoteFileEntityProperties = {
+        "https://blockprotocol.org/@blockprotocol/types/property-type/description/":
+          description,
+        "https://blockprotocol.org/@blockprotocol/types/property-type/file-name/":
+          filename,
+        "https://blockprotocol.org/@blockprotocol/types/property-type/mime-type/":
+          mimeType,
+        "https://blockprotocol.org/@blockprotocol/types/property-type/file-url/":
+          resolvedUrl,
+      };
+
+      const { data: newEntity, errors } = await createEntity({
+        data: {
+          entityTypeId:
+            "https://blockprotocol.org/@blockprotocol/types/entity-type/remote-file/v/2",
+          properties: newEntityProperties,
+        },
+      });
+
+      if (errors || !newEntity) {
+        return {
+          errors: errors ?? [
+            {
+              code: "INVALID_INPUT",
+              message: "Could not create File entity ",
+            },
+          ],
         };
-
-        const { data: newEntity, errors } = await createEntity({
-          data: {
-            entityTypeId:
-              "https://blockprotocol.org/@blockprotocol/types/entity-type/remote-file/v/2",
-            properties: newEntityProperties,
-          },
-        });
-
-        if (errors || !newEntity) {
-          return {
-            errors: errors ?? [
-              {
-                code: "INVALID_INPUT",
-                message: "Could not create File entity ",
-              },
-            ],
-          };
-        }
-        return Promise.resolve({ data: newEntity as RemoteFileEntity });
-      },
-      [createEntity, readonly],
-      simulateDatastoreLatency,
-    );
+      }
+      return Promise.resolve({ data: newEntity as RemoteFileEntity });
+    },
+    [createEntity, readonly, waitForLatency],
+  );
 
   return {
     graph,

--- a/libs/mock-block-dock/src/datastore/use-mock-datastore/temporal.ts
+++ b/libs/mock-block-dock/src/datastore/use-mock-datastore/temporal.ts
@@ -17,7 +17,6 @@ import {
 } from "@blockprotocol/graph/temporal";
 import { getEntityRevision } from "@blockprotocol/graph/temporal/stdlib";
 import mime from "mime/lite";
-import { useCallback } from "react";
 import { v4 as uuid } from "uuid";
 
 import { useDefaultState } from "../../use-default-state";
@@ -28,6 +27,7 @@ import { getEntity as getEntityImpl } from "../hook-implementations/entity/get-e
 import { queryEntities as queryEntitiesImpl } from "../hook-implementations/entity/query-entities";
 import { MockData } from "../mock-data";
 import { useMockDataToSubgraph } from "../use-mock-data-to-subgraph";
+import { useCallbackWithLatency } from "./shared";
 
 export type MockDatastore = {
   graph: Subgraph;
@@ -57,6 +57,7 @@ const readonlyErrorReturn: {
 export const useMockDatastore = (
   initialData: MockData<true>,
   readonly?: boolean,
+  simulateLatency?: { min: number; max: number },
 ): MockDatastore => {
   const mockDataSubgraph = useMockDataToSubgraph(initialData);
   const [graph, setGraph] = useDefaultState(mockDataSubgraph);
@@ -66,7 +67,7 @@ export const useMockDatastore = (
   // >(initialData.linkedQueryDefinitions);
 
   const queryEntities: GraphEmbedderMessageCallbacks["queryEntities"] =
-    useCallback(
+    useCallbackWithLatency(
       async ({ data }) => {
         if (!data) {
           return {
@@ -99,10 +100,11 @@ export const useMockDatastore = (
         };
       },
       [graph],
+      simulateLatency,
     );
 
   const createEntity: GraphEmbedderMessageCallbacks["createEntity"] =
-    useCallback(
+    useCallbackWithLatency(
       async ({ data }) => {
         if (readonly) {
           return readonlyErrorReturn;
@@ -167,52 +169,55 @@ export const useMockDatastore = (
         });
       },
       [readonly, setGraph],
+      simulateLatency,
     );
 
-  const getEntity: GraphEmbedderMessageCallbacks["getEntity"] = useCallback(
-    async ({ data }) => {
-      if (!data) {
-        return {
-          errors: [
-            {
-              code: "INVALID_INPUT",
-              message: "getEntity requires 'data' input",
-            },
-          ],
-        };
-      }
+  const getEntity: GraphEmbedderMessageCallbacks["getEntity"] =
+    useCallbackWithLatency(
+      async ({ data }) => {
+        if (!data) {
+          return {
+            errors: [
+              {
+                code: "INVALID_INPUT",
+                message: "getEntity requires 'data' input",
+              },
+            ],
+          };
+        }
 
-      if ((data as GetEntityDataTemporal).temporalAxes === undefined) {
-        return {
-          data: getEntityImpl<true>(
-            {
-              ...data,
-              temporalAxes: getDefaultTemporalAxes(),
-            },
-            graph,
-          ),
-        };
-      }
+        if ((data as GetEntityDataTemporal).temporalAxes === undefined) {
+          return {
+            data: getEntityImpl<true>(
+              {
+                ...data,
+                temporalAxes: getDefaultTemporalAxes(),
+              },
+              graph,
+            ),
+          };
+        }
 
-      const entitySubgraph = getEntityImpl<true>(data, graph);
+        const entitySubgraph = getEntityImpl<true>(data, graph);
 
-      if (!entitySubgraph) {
-        return {
-          errors: [
-            {
-              code: "NOT_FOUND",
-              message: `Could not find entity with entityId '${data.entityId}'`,
-            },
-          ],
-        };
-      }
-      return { data: entitySubgraph };
-    },
-    [graph],
-  );
+        if (!entitySubgraph) {
+          return {
+            errors: [
+              {
+                code: "NOT_FOUND",
+                message: `Could not find entity with entityId '${data.entityId}'`,
+              },
+            ],
+          };
+        }
+        return { data: entitySubgraph };
+      },
+      [graph],
+      simulateLatency,
+    );
 
   const updateEntity: GraphEmbedderMessageCallbacks["updateEntity"] =
-    useCallback(
+    useCallbackWithLatency(
       async ({ data }) => {
         if (readonly) {
           return readonlyErrorReturn;
@@ -362,10 +367,11 @@ export const useMockDatastore = (
         });
       },
       [readonly, setGraph],
+      simulateLatency,
     );
 
   const deleteEntity: GraphEmbedderMessageCallbacks["deleteEntity"] =
-    useCallback(
+    useCallbackWithLatency(
       async ({ data }) => {
         return {
           errors: [
@@ -400,99 +406,122 @@ export const useMockDatastore = (
         });
       },
       [setGraph, readonly],
+      simulateLatency,
     );
 
   const queryEntityTypes: GraphEmbedderMessageCallbacks["queryEntityTypes"] =
-    useCallback(async ({ data: _ }) => {
-      return {
-        errors: [
-          {
-            code: "NOT_IMPLEMENTED",
-            message: `queryEntityTypes is not currently supported`,
-          },
-        ],
-      };
-    }, []);
-
-  const getEntityType: GraphEmbedderMessageCallbacks["getEntityType"] =
-    useCallback(async ({ data }) => {
-      return {
-        errors: [
-          {
-            code: "NOT_IMPLEMENTED",
-            message: `Retrieving Entity Types is not currently supported`,
-          },
-        ],
-      };
-
-      /** @todo - interim solution: retrieve entity type from URL */
-      /** @todo - implement entity type resolution */
-      // eslint-disable-next-line no-unreachable -- currently unimplemented
-      if (!data) {
+    useCallbackWithLatency(
+      async ({ data: _ }) => {
         return {
           errors: [
             {
-              code: "INVALID_INPUT",
-              message: "getEntityType requires 'data' input",
+              code: "NOT_IMPLEMENTED",
+              message: `queryEntityTypes is not currently supported`,
             },
           ],
         };
-      }
-    }, []);
+      },
+      [],
+      simulateLatency,
+    );
+
+  const getEntityType: GraphEmbedderMessageCallbacks["getEntityType"] =
+    useCallbackWithLatency(
+      async ({ data }) => {
+        return {
+          errors: [
+            {
+              code: "NOT_IMPLEMENTED",
+              message: `Retrieving Entity Types is not currently supported`,
+            },
+          ],
+        };
+
+        /** @todo - interim solution: retrieve entity type from URL */
+        /** @todo - implement entity type resolution */
+        // eslint-disable-next-line no-unreachable -- currently unimplemented
+        if (!data) {
+          return {
+            errors: [
+              {
+                code: "INVALID_INPUT",
+                message: "getEntityType requires 'data' input",
+              },
+            ],
+          };
+        }
+      },
+      [],
+      simulateLatency,
+    );
 
   const getPropertyType: GraphEmbedderMessageCallbacks["getPropertyType"] =
-    useCallback(async ({ data: _ }) => {
-      return {
-        errors: [
-          {
-            code: "NOT_IMPLEMENTED",
-            message: `getPropertyType is not currently supported`,
-          },
-        ],
-      };
-    }, []);
+    useCallbackWithLatency(
+      async ({ data: _ }) => {
+        return {
+          errors: [
+            {
+              code: "NOT_IMPLEMENTED",
+              message: `getPropertyType is not currently supported`,
+            },
+          ],
+        };
+      },
+      [],
+      simulateLatency,
+    );
 
   const queryPropertyTypes: GraphEmbedderMessageCallbacks["queryPropertyTypes"] =
-    useCallback(async ({ data: _ }) => {
-      return {
-        errors: [
-          {
-            code: "NOT_IMPLEMENTED",
-            message: `queryPropertyTypes is not currently supported`,
-          },
-        ],
-      };
-    }, []);
+    useCallbackWithLatency(
+      async ({ data: _ }) => {
+        return {
+          errors: [
+            {
+              code: "NOT_IMPLEMENTED",
+              message: `queryPropertyTypes is not currently supported`,
+            },
+          ],
+        };
+      },
+      [],
+      simulateLatency,
+    );
 
-  const getDataType: GraphEmbedderMessageCallbacks["getDataType"] = useCallback(
-    async ({ data: _ }) => {
-      return {
-        errors: [
-          {
-            code: "NOT_IMPLEMENTED",
-            message: `getDataType is not currently supported`,
-          },
-        ],
-      };
-    },
-    [],
-  );
+  const getDataType: GraphEmbedderMessageCallbacks["getDataType"] =
+    useCallbackWithLatency(
+      async ({ data: _ }) => {
+        return {
+          errors: [
+            {
+              code: "NOT_IMPLEMENTED",
+              message: `getDataType is not currently supported`,
+            },
+          ],
+        };
+      },
+      [],
+      simulateLatency,
+    );
 
   const queryDataTypes: GraphEmbedderMessageCallbacks["queryDataTypes"] =
-    useCallback(async ({ data: _ }) => {
-      return {
-        errors: [
-          {
-            code: "NOT_IMPLEMENTED",
-            message: `queryDataTypes is not currently supported`,
-          },
-        ],
-      };
-    }, []);
+    useCallbackWithLatency(
+      async ({ data: _ }) => {
+        return {
+          errors: [
+            {
+              code: "NOT_IMPLEMENTED",
+              message: `queryDataTypes is not currently supported`,
+            },
+          ],
+        };
+      },
+      [],
+      simulateLatency,
+    );
 
   /** @todo - Reimplement linkedQueries */
   // const createLinkedQuery: GraphEmbedderMessageCallbacks["createLinkedQuery"] =
-  //   useCallback(
+  //   useCallbackWithLatency(
   //     async ({ data }) => {
   //       if (readonly) {
   //         return readonlyErrorReturn;
@@ -522,7 +551,7 @@ export const useMockDatastore = (
   //   );
   //
   // const getLinkedQuery: GraphEmbedderMessageCallbacks["getLinkedQuery"] =
-  //   useCallback(
+  //   useCallbackWithLatency(
   //     async ({ data }) => {
   //       if (!data) {
   //         return {
@@ -559,7 +588,7 @@ export const useMockDatastore = (
   //   );
   //
   // const updateLinkedQuery: GraphEmbedderMessageCallbacks["updateLinkedQuery"] =
-  //   useCallback(
+  //   useCallbackWithLatency(
   //     async ({ data }) => {
   //       if (readonly) {
   //         return readonlyErrorReturn;
@@ -610,7 +639,7 @@ export const useMockDatastore = (
   //   );
   //
   // const deleteLinkedQuery: GraphEmbedderMessageCallbacks["deleteLinkedQuery"] =
-  //   useCallback(
+  //   useCallbackWithLatency(
   //     async ({ data }) => {
   //       if (readonly) {
   //         return readonlyErrorReturn;
@@ -656,44 +685,46 @@ export const useMockDatastore = (
   //     [setLinkedQueries, readonly],
   //   );
 
-  const uploadFile: GraphEmbedderMessageCallbacks["uploadFile"] = useCallback(
-    async ({ data }) => {
-      if (readonly) {
-        return readonlyErrorReturn;
-      }
-
-      if (!data) {
-        return {
-          errors: [
-            {
-              code: "INVALID_INPUT",
-              message: "uploadFile requires 'data' input",
-            },
-          ],
-        };
-      }
-      const { description } = data;
-
-      const file = isFileData(data) ? data.file : null;
-      const url = isFileAtUrlData(data) ? data.url : null;
-      if (!file && !url?.trim()) {
-        throw new Error("Please provide either a valid URL or file");
-      }
-
-      let filename: string | undefined = data.name;
-      let resolvedUrl: string = "https://unknown-url.example.com";
-      if (url) {
-        if (!filename) {
-          filename = url.split("/").pop() ?? filename;
+  const uploadFile: GraphEmbedderMessageCallbacks["uploadFile"] =
+    useCallbackWithLatency(
+      async ({ data }) => {
+        if (readonly) {
+          return readonlyErrorReturn;
         }
-        resolvedUrl = url;
-      } else if (file) {
-        if (!filename) {
-          filename = file.name;
+
+        if (!data) {
+          return {
+            errors: [
+              {
+                code: "INVALID_INPUT",
+                message: "uploadFile requires 'data' input",
+              },
+            ],
+          };
         }
-        try {
-          const readFileResult = await new Promise<FileReader["result"] | null>(
-            (resolve, reject) => {
+        const { description } = data;
+
+        const file = isFileData(data) ? data.file : null;
+        const url = isFileAtUrlData(data) ? data.url : null;
+        if (!file && !url?.trim()) {
+          throw new Error("Please provide either a valid URL or file");
+        }
+
+        let filename: string | undefined = data.name;
+        let resolvedUrl: string = "https://unknown-url.example.com";
+        if (url) {
+          if (!filename) {
+            filename = url.split("/").pop() ?? filename;
+          }
+          resolvedUrl = url;
+        } else if (file) {
+          if (!filename) {
+            filename = file.name;
+          }
+          try {
+            const readFileResult = await new Promise<
+              FileReader["result"] | null
+            >((resolve, reject) => {
               const reader = new FileReader();
 
               reader.onload = (event) => {
@@ -705,56 +736,56 @@ export const useMockDatastore = (
               };
 
               reader.readAsDataURL(file);
-            },
-          );
-          if (!readFileResult) {
-            throw new Error("No result from file reader");
+            });
+            if (!readFileResult) {
+              throw new Error("No result from file reader");
+            }
+            resolvedUrl = readFileResult.toString();
+          } catch (err) {
+            throw new Error("Could not upload file");
           }
-          resolvedUrl = readFileResult.toString();
-        } catch (err) {
-          throw new Error("Could not upload file");
         }
-      }
 
-      if (!filename) {
-        throw new Error("Could not determine filename and no name provided");
-      }
+        if (!filename) {
+          throw new Error("Could not determine filename and no name provided");
+        }
 
-      const mimeType = mime.getType(filename) || "application/octet-stream";
+        const mimeType = mime.getType(filename) || "application/octet-stream";
 
-      const newEntityProperties: RemoteFileEntityProperties = {
-        "https://blockprotocol.org/@blockprotocol/types/property-type/description/":
-          description,
-        "https://blockprotocol.org/@blockprotocol/types/property-type/file-name/":
-          filename,
-        "https://blockprotocol.org/@blockprotocol/types/property-type/mime-type/":
-          mimeType,
-        "https://blockprotocol.org/@blockprotocol/types/property-type/file-url/":
-          resolvedUrl,
-      };
-
-      const { data: newEntity, errors } = await createEntity({
-        data: {
-          entityTypeId:
-            "https://blockprotocol.org/@blockprotocol/types/entity-type/remote-file/v/2",
-          properties: newEntityProperties,
-        },
-      });
-
-      if (errors || !newEntity) {
-        return {
-          errors: errors ?? [
-            {
-              code: "INVALID_INPUT",
-              message: "Could not create File entity ",
-            },
-          ],
+        const newEntityProperties: RemoteFileEntityProperties = {
+          "https://blockprotocol.org/@blockprotocol/types/property-type/description/":
+            description,
+          "https://blockprotocol.org/@blockprotocol/types/property-type/file-name/":
+            filename,
+          "https://blockprotocol.org/@blockprotocol/types/property-type/mime-type/":
+            mimeType,
+          "https://blockprotocol.org/@blockprotocol/types/property-type/file-url/":
+            resolvedUrl,
         };
-      }
-      return Promise.resolve({ data: newEntity as RemoteFileEntity });
-    },
-    [createEntity, readonly],
-  );
+
+        const { data: newEntity, errors } = await createEntity({
+          data: {
+            entityTypeId:
+              "https://blockprotocol.org/@blockprotocol/types/entity-type/remote-file/v/2",
+            properties: newEntityProperties,
+          },
+        });
+
+        if (errors || !newEntity) {
+          return {
+            errors: errors ?? [
+              {
+                code: "INVALID_INPUT",
+                message: "Could not create File entity ",
+              },
+            ],
+          };
+        }
+        return Promise.resolve({ data: newEntity as RemoteFileEntity });
+      },
+      [createEntity, readonly],
+      simulateLatency,
+    );
 
   return {
     graph,

--- a/libs/mock-block-dock/src/mock-block-dock.tsx
+++ b/libs/mock-block-dock/src/mock-block-dock.tsx
@@ -70,7 +70,7 @@ type MockBlockDockProps<Temporal extends boolean> = {
     name: string;
     protocol: string;
   };
-  simulateLatency?: { min: number; max: number };
+  simulateDatastoreLatency?: { min: number; max: number };
 };
 
 const MockBlockDockNonTemporal: FunctionComponent<
@@ -86,7 +86,7 @@ const MockBlockDockNonTemporal: FunctionComponent<
   initialData,
   readonly: initialReadonly = false,
   serviceModuleCallbacks: serviceModuleCallbacksFromProps,
-  simulateLatency,
+  simulateDatastoreLatency,
 }: Omit<MockBlockDockProps<false>, "temporal">) => {
   const {
     blockEntityRecordId,
@@ -99,7 +99,7 @@ const MockBlockDockNonTemporal: FunctionComponent<
     blockEntityRecordId: initialBlockEntityRecordId,
     initialData: initialData as InitialData<false>,
     readonly: !!initialReadonly,
-    simulateLatency,
+    simulateDatastoreLatency,
   });
 
   const [debugMode, setDebugMode] = useDefaultState<boolean>(initialDebug);
@@ -338,7 +338,7 @@ const MockBlockDockTemporal: FunctionComponent<
   initialData,
   readonly: initialReadonly = false,
   serviceModuleCallbacks: serviceModuleCallbacksFromProps,
-  simulateLatency,
+  simulateDatastoreLatency,
 }: Omit<MockBlockDockProps<true>, "temporal">) => {
   const {
     blockEntityRecordId,
@@ -351,7 +351,7 @@ const MockBlockDockTemporal: FunctionComponent<
     blockEntityRecordId: initialBlockEntityRecordId,
     initialData: initialData as InitialData<true>,
     readonly: !!initialReadonly,
-    simulateLatency,
+    simulateDatastoreLatency,
   });
 
   const [debugMode, setDebugMode] = useDefaultState<boolean>(initialDebug);
@@ -595,7 +595,7 @@ const MockBlockDockTemporal: FunctionComponent<
  * @param [props.initialData.initialLinkedQueries] - The linkedQuery DEFINITIONS to include in the data store (results will be resolved automatically)
  * @param [props.readonly=false] whether the block should display in readonly mode or not
  * @param [props.serviceModuleCallbacks] overrides the default service module callbacks
- * @param {{min: number, max: number}} [props.simulateLatency] simulate latency in responses where each delay is randomly chosen from the supplied range
+ * @param {{min: number, max: number}} [props.simulateDatastoreLatency] simulate latency in responses where each delay is randomly chosen from the supplied range
  */
 export const MockBlockDock: FunctionComponent<MockBlockDockProps<boolean>> = <
   Temporal extends boolean,
@@ -611,7 +611,7 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps<boolean>> = <
   initialData,
   readonly: initialReadonly = false,
   serviceModuleCallbacks,
-  simulateLatency,
+  simulateDatastoreLatency,
 }: MockBlockDockProps<Temporal>) => {
   return temporal ? (
     <MockBlockDockTemporal
@@ -625,7 +625,7 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps<boolean>> = <
       initialData={initialData as InitialData<true>}
       readonly={initialReadonly}
       serviceModuleCallbacks={serviceModuleCallbacks}
-      simulateLatency={simulateLatency}
+      simulateDatastoreLatency={simulateDatastoreLatency}
     />
   ) : (
     <MockBlockDockNonTemporal
@@ -639,7 +639,7 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps<boolean>> = <
       initialData={initialData}
       readonly={initialReadonly}
       serviceModuleCallbacks={serviceModuleCallbacks}
-      simulateLatency={simulateLatency}
+      simulateDatastoreLatency={simulateDatastoreLatency}
     />
   );
 };

--- a/libs/mock-block-dock/src/mock-block-dock.tsx
+++ b/libs/mock-block-dock/src/mock-block-dock.tsx
@@ -70,6 +70,7 @@ type MockBlockDockProps<Temporal extends boolean> = {
     name: string;
     protocol: string;
   };
+  simulateLatency?: { min: number; max: number };
 };
 
 const MockBlockDockNonTemporal: FunctionComponent<
@@ -85,6 +86,7 @@ const MockBlockDockNonTemporal: FunctionComponent<
   initialData,
   readonly: initialReadonly = false,
   serviceModuleCallbacks: serviceModuleCallbacksFromProps,
+  simulateLatency,
 }: Omit<MockBlockDockProps<false>, "temporal">) => {
   const {
     blockEntityRecordId,
@@ -97,6 +99,7 @@ const MockBlockDockNonTemporal: FunctionComponent<
     blockEntityRecordId: initialBlockEntityRecordId,
     initialData: initialData as InitialData<false>,
     readonly: !!initialReadonly,
+    simulateLatency,
   });
 
   const [debugMode, setDebugMode] = useDefaultState<boolean>(initialDebug);
@@ -335,6 +338,7 @@ const MockBlockDockTemporal: FunctionComponent<
   initialData,
   readonly: initialReadonly = false,
   serviceModuleCallbacks: serviceModuleCallbacksFromProps,
+  simulateLatency,
 }: Omit<MockBlockDockProps<true>, "temporal">) => {
   const {
     blockEntityRecordId,
@@ -347,6 +351,7 @@ const MockBlockDockTemporal: FunctionComponent<
     blockEntityRecordId: initialBlockEntityRecordId,
     initialData: initialData as InitialData<true>,
     readonly: !!initialReadonly,
+    simulateLatency,
   });
 
   const [debugMode, setDebugMode] = useDefaultState<boolean>(initialDebug);
@@ -590,6 +595,7 @@ const MockBlockDockTemporal: FunctionComponent<
  * @param [props.initialData.initialLinkedQueries] - The linkedQuery DEFINITIONS to include in the data store (results will be resolved automatically)
  * @param [props.readonly=false] whether the block should display in readonly mode or not
  * @param [props.serviceModuleCallbacks] overrides the default service module callbacks
+ * @param {{min: number, max: number}} [props.simulateLatency] simulate latency in responses where each delay is randomly chosen from the supplied range
  */
 export const MockBlockDock: FunctionComponent<MockBlockDockProps<boolean>> = <
   Temporal extends boolean,
@@ -605,6 +611,7 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps<boolean>> = <
   initialData,
   readonly: initialReadonly = false,
   serviceModuleCallbacks,
+  simulateLatency,
 }: MockBlockDockProps<Temporal>) => {
   return temporal ? (
     <MockBlockDockTemporal
@@ -618,6 +625,7 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps<boolean>> = <
       initialData={initialData as InitialData<true>}
       readonly={initialReadonly}
       serviceModuleCallbacks={serviceModuleCallbacks}
+      simulateLatency={simulateLatency}
     />
   ) : (
     <MockBlockDockNonTemporal
@@ -631,6 +639,7 @@ export const MockBlockDock: FunctionComponent<MockBlockDockProps<boolean>> = <
       initialData={initialData}
       readonly={initialReadonly}
       serviceModuleCallbacks={serviceModuleCallbacks}
+      simulateLatency={simulateLatency}
     />
   );
 };

--- a/libs/mock-block-dock/src/mock-block-dock.tsx
+++ b/libs/mock-block-dock/src/mock-block-dock.tsx
@@ -595,7 +595,7 @@ const MockBlockDockTemporal: FunctionComponent<
  * @param [props.initialData.initialLinkedQueries] - The linkedQuery DEFINITIONS to include in the data store (results will be resolved automatically)
  * @param [props.readonly=false] whether the block should display in readonly mode or not
  * @param [props.serviceModuleCallbacks] overrides the default service module callbacks
- * @param {{min: number, max: number}} [props.simulateDatastoreLatency] simulate latency in responses where each delay is randomly chosen from the supplied range
+ * @param {{min: number, max: number}} [props.simulateDatastoreLatency] simulate latency in responses to datastore-related requests, where each delay is randomly chosen from the supplied range
  */
 export const MockBlockDock: FunctionComponent<MockBlockDockProps<boolean>> = <
   Temporal extends boolean,

--- a/libs/mock-block-dock/src/use-mock-block-props.ts
+++ b/libs/mock-block-dock/src/use-mock-block-props.ts
@@ -68,7 +68,7 @@ const defaultMockData = initialMockData<false>(undefined);
  * @param [args.initialData.initialEntities] - The entities to include in the data store (NOT the block entity, which is always provided)
  * @param [args.initialData.initialTemporalAxes] - The temporal axes that were used in creating the initial entities
  * @param [args.initialData.initialLinkedQueries] - The linkedQuery DEFINITIONS to include in the data store (results will be resolved automatically)
- * @param {{min: number, max: number}} [args.simulateDatastoreLatency] simulate latency in responses where each delay is randomly chosen from the supplied range
+ * @param {{min: number, max: number}} [args.simulateDatastoreLatency] simulate latency in responses to datastore-related requests, where each delay is randomly chosen from the supplied range
  */
 export const useMockBlockPropsNonTemporal = (
   args: MockBlockHookArgs<false>,
@@ -137,7 +137,7 @@ const defaultTemporalMockData = initialMockData<true>(
  * @param [args.initialData.initialEntities] - The entities to include in the data store (NOT the block entity, which is always provided)
  * @param [args.initialData.initialTemporalAxes] - The temporal axes that were used in creating the initial entities
  * @param [args.initialData.initialLinkedQueries] - The linkedQuery DEFINITIONS to include in the data store (results will be resolved automatically)
- * @param {{min: number, max: number}} [args.simulateDatastoreLatency] simulate latency in responses where each delay is randomly chosen from the supplied range
+ * @param {{min: number, max: number}} [args.simulateDatastoreLatency] simulate latency in responses to datastore-related requests, where each delay is randomly chosen from the supplied range
  */
 export const useMockBlockPropsTemporal = (
   args: MockBlockHookArgs<true>,

--- a/libs/mock-block-dock/src/use-mock-block-props.ts
+++ b/libs/mock-block-dock/src/use-mock-block-props.ts
@@ -36,6 +36,7 @@ export type MockBlockHookArgs<Temporal extends boolean> = {
     : EntityRecordIdNonTemporal;
   initialData?: InitialData<Temporal>;
   readonly: boolean;
+  simulateLatency?: { min: number; max: number };
 };
 
 export type MockBlockHookResult<Temporal extends boolean> = {
@@ -67,6 +68,7 @@ const defaultMockData = initialMockData<false>(undefined);
  * @param [args.initialData.initialEntities] - The entities to include in the data store (NOT the block entity, which is always provided)
  * @param [args.initialData.initialTemporalAxes] - The temporal axes that were used in creating the initial entities
  * @param [args.initialData.initialLinkedQueries] - The linkedQuery DEFINITIONS to include in the data store (results will be resolved automatically)
+ * @param {{min: number, max: number}} [args.simulateLatency] simulate latency in responses where each delay is randomly chosen from the supplied range
  */
 export const useMockBlockPropsNonTemporal = (
   args: MockBlockHookArgs<false>,
@@ -104,7 +106,11 @@ export const useMockBlockPropsNonTemporal = (
 
   const [readonly, setReadonly] = useDefaultState<boolean>(args.readonly);
 
-  const mockDatastore = useMockDatastoreNonTemporal(mockData, readonly);
+  const mockDatastore = useMockDatastoreNonTemporal(
+    mockData,
+    readonly,
+    args.simulateLatency,
+  );
 
   return {
     blockEntityRecordId: entityRecordIdOfEntityForBlock,
@@ -131,6 +137,7 @@ const defaultTemporalMockData = initialMockData<true>(
  * @param [args.initialData.initialEntities] - The entities to include in the data store (NOT the block entity, which is always provided)
  * @param [args.initialData.initialTemporalAxes] - The temporal axes that were used in creating the initial entities
  * @param [args.initialData.initialLinkedQueries] - The linkedQuery DEFINITIONS to include in the data store (results will be resolved automatically)
+ * @param {{min: number, max: number}} [args.simulateLatency] simulate latency in responses where each delay is randomly chosen from the supplied range
  */
 export const useMockBlockPropsTemporal = (
   args: MockBlockHookArgs<true>,
@@ -178,7 +185,11 @@ export const useMockBlockPropsTemporal = (
 
   const [readonly, setReadonly] = useDefaultState<boolean>(args.readonly);
 
-  const mockDatastore = useMockDatastoreTemporal(mockData, readonly);
+  const mockDatastore = useMockDatastoreTemporal(
+    mockData,
+    readonly,
+    args.simulateLatency,
+  );
 
   return {
     blockEntityRecordId: entityRecordIdOfEntityForBlock,

--- a/libs/mock-block-dock/src/use-mock-block-props.ts
+++ b/libs/mock-block-dock/src/use-mock-block-props.ts
@@ -36,7 +36,7 @@ export type MockBlockHookArgs<Temporal extends boolean> = {
     : EntityRecordIdNonTemporal;
   initialData?: InitialData<Temporal>;
   readonly: boolean;
-  simulateLatency?: { min: number; max: number };
+  simulateDatastoreLatency?: { min: number; max: number };
 };
 
 export type MockBlockHookResult<Temporal extends boolean> = {
@@ -68,7 +68,7 @@ const defaultMockData = initialMockData<false>(undefined);
  * @param [args.initialData.initialEntities] - The entities to include in the data store (NOT the block entity, which is always provided)
  * @param [args.initialData.initialTemporalAxes] - The temporal axes that were used in creating the initial entities
  * @param [args.initialData.initialLinkedQueries] - The linkedQuery DEFINITIONS to include in the data store (results will be resolved automatically)
- * @param {{min: number, max: number}} [args.simulateLatency] simulate latency in responses where each delay is randomly chosen from the supplied range
+ * @param {{min: number, max: number}} [args.simulateDatastoreLatency] simulate latency in responses where each delay is randomly chosen from the supplied range
  */
 export const useMockBlockPropsNonTemporal = (
   args: MockBlockHookArgs<false>,
@@ -109,7 +109,7 @@ export const useMockBlockPropsNonTemporal = (
   const mockDatastore = useMockDatastoreNonTemporal(
     mockData,
     readonly,
-    args.simulateLatency,
+    args.simulateDatastoreLatency,
   );
 
   return {
@@ -137,7 +137,7 @@ const defaultTemporalMockData = initialMockData<true>(
  * @param [args.initialData.initialEntities] - The entities to include in the data store (NOT the block entity, which is always provided)
  * @param [args.initialData.initialTemporalAxes] - The temporal axes that were used in creating the initial entities
  * @param [args.initialData.initialLinkedQueries] - The linkedQuery DEFINITIONS to include in the data store (results will be resolved automatically)
- * @param {{min: number, max: number}} [args.simulateLatency] simulate latency in responses where each delay is randomly chosen from the supplied range
+ * @param {{min: number, max: number}} [args.simulateDatastoreLatency] simulate latency in responses where each delay is randomly chosen from the supplied range
  */
 export const useMockBlockPropsTemporal = (
   args: MockBlockHookArgs<true>,
@@ -188,7 +188,7 @@ export const useMockBlockPropsTemporal = (
   const mockDatastore = useMockDatastoreTemporal(
     mockData,
     readonly,
-    args.simulateLatency,
+    args.simulateDatastoreLatency,
   );
 
   return {

--- a/libs/mock-block-dock/src/util.ts
+++ b/libs/mock-block-dock/src/util.ts
@@ -31,6 +31,10 @@ export const mustBeDefined = <T>(x: T | undefined, message?: string): T => {
   return x;
 };
 
+export const randomNumberFromRange = (min: number, max: number) => {
+  return Math.random() * (max - min) + min;
+};
+
 // @todo deduplicate this and libs/@blockprotocol/graph/src/internal/mutate-subgraph/is-equal.ts
 // https://gist.github.com/jsjain/a2ba5d40f20e19f734a53c0aad937fbb
 export const isEqual = (first: any, second: any): boolean => {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Delays in responses to methods from an EA can **very easily** result in strange errors in components. Such errors were very difficult to identify during block development because MockBlockDock responded very quickly to requests.

This PR introduces a new prop which allows the user to configure a latency range whereby responses from the Graph Module will delay for a random time in ms from within that range.

## 🔗 Related links

- [Asana task](https://app.asana.com/0/1203179076056186/1204144427699229/f) _(internal)_

## 🚫 Blocked by

N/A

## 🔍 What does this change?

- Introduces a `simulateLatency` prop in MBD
- Adjusts the Graph module callbacks to wait for a random time within the given latency range
- Updates the templates to provide the parameter

## 📜 Does this require a change to the docs?

- I'm unsure if there is documentation about MBD props, I have updated the templates and given an accompanying message

## ⚠️ Known issues

- A lot of our demo blocks called an `update` on every key-press. This was already known as being problematic (as it would absolutely spam the EA with updates, and should be batched), but the latency issues with re-renders causing the input to reset is unfortunate and luckily highlights the need for this PR.

## 🐾 Next steps

- Update existing blocks (including templates) to account for the issues uncovered by this

## 🛡 What tests cover this?

- `tsc`
- `eslint`
- Manually running the templates

## ❓ How to test this?

1. Try running MBD or the templates
2. Adjust the latency parameter (and remove it) and see the differences

## 📹 Demo


https://user-images.githubusercontent.com/25749103/224759478-f60bfe37-63f3-44bc-9a8d-adf9f91438e6.mov
