### PR TITLE
Remove Mock Block Dock CommonJS build output

### DIFF
--- a/.changeset/thirty-coats-smell.md
+++ b/.changeset/thirty-coats-smell.md
@@ -1,0 +1,5 @@
+---
+"mock-block-dock": patch
+---
+
+remove (broken) commonjs build output

--- a/libs/mock-block-dock/package.json
+++ b/libs/mock-block-dock/package.json
@@ -17,17 +17,14 @@
     "name": "HASH",
     "url": "https://hash.ai"
   },
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
-  "types": "./dist/esm/index.d.ts",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "yarn clean && yarn build:cjs && yarn build:esm",
-    "build:cjs": "tsc --skipLibCheck --project tsconfig.build.cjs.json",
+    "build": "yarn clean && tsc --skipLibCheck",
     "build:dev": "yarn clean && cross-env NODE_ENV=development webpack --mode development --config=dev/webpack.config.js",
-    "build:esm": "tsc --skipLibCheck --project tsconfig.build.esm.json",
     "clean": "rimraf ./dist/",
     "codegen": "node -p \"'export const MOCK_BLOCK_DOCK_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
     "dev": "concurrently -n webpack,webpack-dev-server -c green,cyan \"yarn build:dev --watch\" \"yarn run-dev-server\"",

--- a/libs/mock-block-dock/tsconfig.build.cjs.json
+++ b/libs/mock-block-dock/tsconfig.build.cjs.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "outDir": "dist/cjs"
-  },
-  "include": ["src"]
-}

--- a/libs/mock-block-dock/tsconfig.build.esm.json
+++ b/libs/mock-block-dock/tsconfig.build.esm.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "outDir": "dist/esm"
-  },
-  "include": ["src"]
-}

--- a/libs/mock-block-dock/tsconfig.json
+++ b/libs/mock-block-dock/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "@local/tsconfig/dom+jsx.json",
-  "include": ["assets.d.ts", "src", "dev"]
+  "include": ["src"],
+  "compilerOptions": {
+    "outDir": "dist"
+  }
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We were building `mock-block-dock` for both CommonJS and ESM output, but the CommonJS output doesn't work because it has an ESM dependency ,`@lit-labs/react`.

We could fix this by using some other bundler, but since MBD is intended as a local development tool rather than being bundled up in other apps, it doesn't seem worth it, and just outputting ESM simplifies things.

This PR is a byproduct of trying to figure out why the Block Hub doesn't work in incognito, which seems to be something to do with esm.sh (since just importing MBD directly into the Hub works – it's only when it's loaded via esm.sh that it fails).