### PR TITLE
Move 'can block call services' decision from session storage to component state

### DIFF
--- a/apps/site/src/components/pages/hub/block-data-container.tsx
+++ b/apps/site/src/components/pages/hub/block-data-container.tsx
@@ -285,6 +285,7 @@ export const BlockDataContainer: FunctionComponent<BlockDataContainerProps> = ({
                   </>
                 ) : (
                   <SandboxedBlockDemo
+                    key={metadata.blockSitePath} // reset sandbox state when switching block
                     metadata={metadata}
                     props={props}
                     sandboxBaseUrl={sandboxBaseUrl}

--- a/apps/site/src/components/pages/hub/block-data-container/sandboxed-block-demo.tsx
+++ b/apps/site/src/components/pages/hub/block-data-container/sandboxed-block-demo.tsx
@@ -33,9 +33,8 @@ export const SandboxedBlockDemo: FunctionComponent<SandboxedBlockProps> = ({
   const loadedRef = useRef(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
-  const [serviceUsageIsPermitted, setServiceUsageIsPermitted] = useState<
-    boolean | undefined
-  >(undefined);
+  const [serviceUsageIsPermitted, setServiceUsageIsPermitted] =
+    useState<boolean>();
 
   const [serviceModuleMessage, setServiceModuleMessage] =
     useState<ServiceModuleMessageState | null>(null);

--- a/apps/site/src/components/pages/hub/block-data-container/sandboxed-block-demo.tsx
+++ b/apps/site/src/components/pages/hub/block-data-container/sandboxed-block-demo.tsx
@@ -18,26 +18,6 @@ export interface SandboxedBlockProps {
   sandboxBaseUrl: string;
 }
 
-const generateBlockServicePermissionKey = (blockPath: string) =>
-  `allow-${blockPath}-service-usage`;
-
-const setServiceUsagePermission = (blockPath: string, allowed: boolean) => {
-  sessionStorage.setItem(
-    generateBlockServicePermissionKey(blockPath),
-    allowed.toString(),
-  );
-};
-
-const isServiceUsagePermittedByBlock = (blockPath: string) => {
-  const isAllowed = sessionStorage.getItem(
-    generateBlockServicePermissionKey(blockPath),
-  );
-  if (isAllowed === null) {
-    return undefined;
-  }
-  return isAllowed === "true";
-};
-
 const serviceModuleMessageTypeName = "serviceModule";
 
 type ServiceModuleMessageState = ExternalServiceMethodRequest & {
@@ -52,6 +32,10 @@ export const SandboxedBlockDemo: FunctionComponent<SandboxedBlockProps> = ({
 }) => {
   const loadedRef = useRef(false);
   const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const [serviceUsageIsPermitted, setServiceUsageIsPermitted] = useState<
+    boolean | undefined
+  >(undefined);
 
   const [serviceModuleMessage, setServiceModuleMessage] =
     useState<ServiceModuleMessageState | null>(null);
@@ -94,10 +78,6 @@ export const SandboxedBlockDemo: FunctionComponent<SandboxedBlockProps> = ({
       }
 
       if (message.data.type === serviceModuleMessageTypeName) {
-        const allowed = isServiceUsagePermittedByBlock(
-          metadata.pathWithNamespace,
-        );
-
         const { methodName, payload, providerName, requestId } = message.data;
 
         const process = async () => {
@@ -143,7 +123,7 @@ export const SandboxedBlockDemo: FunctionComponent<SandboxedBlockProps> = ({
           );
         };
 
-        if (allowed === undefined) {
+        if (serviceUsageIsPermitted === undefined) {
           setServiceModuleMessage({
             methodName,
             payload,
@@ -151,7 +131,7 @@ export const SandboxedBlockDemo: FunctionComponent<SandboxedBlockProps> = ({
             providerName,
             reject,
           });
-        } else if (allowed) {
+        } else if (serviceUsageIsPermitted) {
           void process();
         } else {
           reject();
@@ -164,7 +144,12 @@ export const SandboxedBlockDemo: FunctionComponent<SandboxedBlockProps> = ({
     return () => {
       window.removeEventListener("message", listener);
     };
-  }, [metadata.pathWithNamespace, postServiceModuleResponse, sandboxBaseUrl]);
+  }, [
+    metadata.pathWithNamespace,
+    postServiceModuleResponse,
+    sandboxBaseUrl,
+    serviceUsageIsPermitted,
+  ]);
 
   useEffect(() => {
     postBlockProps();
@@ -179,7 +164,7 @@ export const SandboxedBlockDemo: FunctionComponent<SandboxedBlockProps> = ({
     <>
       <ServiceModuleModal
         setServiceUsagePermission={(allowed: boolean) => {
-          setServiceUsagePermission(metadata.pathWithNamespace, allowed);
+          setServiceUsageIsPermitted(allowed);
           if (allowed) {
             void serviceModuleMessage?.process();
           } else {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Implement [this PR suggestion](https://github.com/blockprotocol/blockprotocol/pull/1138#discussion_r1129265623) to not persist a user's decision as to whether a block in the hub can call external services in session storage, as it may confuse users if they revisit the block and it doesn't work – instead, store it in component state that resets every time they revisit the block's page.
<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203623179643290/1204138539312008/f) _(internal)_

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Visit e.g. the AI text block in the preview deployment, use it, see modal, make choice
2. Visit another block, revisit AI text block, see modal again
