### PR TITLE
Add support for .env files in block templates

### DIFF
--- a/.changeset/plenty-files-sneeze.md
+++ b/.changeset/plenty-files-sneeze.md
@@ -1,0 +1,7 @@
+---
+"block-template-custom-element": patch
+"block-template-react": patch
+"block-scripts": patch
+---
+
+add .env file support to block templates

--- a/libs/block-scripts/package.json
+++ b/libs/block-scripts/package.json
@@ -40,6 +40,7 @@
     "copy-webpack-plugin": "10.2.4",
     "core-js": "^3.26.1",
     "css-loader": "^6.7.1",
+    "dotenv-webpack": "^8.0.1",
     "fs-extra": "^10.1.0",
     "html-webpack-plugin": "^5.5.0",
     "sass": "^1.52.3",
@@ -57,6 +58,7 @@
   "devDependencies": {
     "@local/eslint-config": "0.0.0-private",
     "@local/tsconfig": "0.0.0-private",
+    "@types/dotenv-webpack": "^7.0.3",
     "@types/serve-handler": "^6.1.1",
     "@types/webpack-assets-manifest": "^5.1.0",
     "@types/webpack-bundle-analyzer": "^4.6.0",

--- a/libs/block-scripts/shared/webpack-config.js
+++ b/libs/block-scripts/shared/webpack-config.js
@@ -2,6 +2,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import CopyPlugin from "copy-webpack-plugin";
+import Dotenv from "dotenv-webpack";
 import fs from "fs-extra";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import webpack from "webpack";
@@ -145,6 +146,7 @@ export const generateDevWebpackConfig = async () => {
     plugins: [
       ...(baseWebpackConfig.plugins ?? []),
       new BlockAssetsPlugin(),
+      new Dotenv(),
       new HtmlWebpackPlugin({
         filename: "index.html",
         template: path.resolve(

--- a/libs/block-template-custom-element/.gitignore.dist
+++ b/libs/block-template-custom-element/.gitignore.dist
@@ -1,3 +1,4 @@
 dist
 node_modules
 .blockprotocolrc
+.env

--- a/libs/block-template-custom-element/README.md
+++ b/libs/block-template-custom-element/README.md
@@ -67,6 +67,22 @@ for a fuller explanation of querying, creating and updating entity data from you
 
 You can format your code using `yarn format` (or `npm run format`).
 
+If you want to use environment variables in development, add a `.env` file in this directory, and then you can access variables defined in it via `process.env.VARIABLE_NAME`. This is useful for providing a `blockProtocolApiKey` to `MockBlockDock` in `dev.tsx`.
+
+e.g. your `.env` file might look like this:
+
+```text
+BLOCK_PROTOCOL_API_KEY=super-secret
+```
+
+and `dev.tsx` like this:
+
+```typescript
+  return (
+    <MockBlockDock
+      blockProtocolApiKey={process.env.BLOCK_PROTOCOL_API_KEY}
+```
+
 ## Step five: publish your block
 
 Head over to [blockprotocol.org](https://blockprotocol.org/docs/developing-blocks#publish) to read instructions on publishing your block.

--- a/libs/block-template-react/.gitignore.dist
+++ b/libs/block-template-react/.gitignore.dist
@@ -1,3 +1,4 @@
 dist
 node_modules
 .blockprotocolrc
+.env

--- a/libs/block-template-react/README.md
+++ b/libs/block-template-react/README.md
@@ -64,6 +64,22 @@ Please see [the React docs](https://reactjs.org/docs/getting-started.html) for g
 
 You can format your code using `yarn format` (or `npm run format`).
 
+If you want to use environment variables in development, add a `.env` file in this directory, and then you can access variables defined in it via `process.env.VARIABLE_NAME`. This is useful for providing a `blockProtocolApiKey` to `MockBlockDock` in `dev.tsx`.
+
+e.g. your `.env` file might look like this:
+
+```text
+BLOCK_PROTOCOL_API_KEY=super-secret
+```
+
+and `dev.tsx` like this:
+
+```typescript
+  return (
+    <MockBlockDock
+      blockProtocolApiKey={process.env.BLOCK_PROTOCOL_API_KEY}
+```
+
 ## Step five: publish your block
 
 Head over to [blockprotocol.org](https://blockprotocol.org/docs/developing-blocks#publish) to read instructions on publishing your block.


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds support for using `.env` files in blocks in development. Helpful now that we accept a `blockProtocolApiKey` in `MockBlockDock` to be able to set this from `process.env`.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203623179643290/1204089119834164/f) _(internal)_


## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

- README has been updated.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Add a `.env` file to one of the block templates, put something in it
2. Try logging out `process.env.VARIABLE_NAME` in the block
