### PR TITLE
Revert "Disable Sentry Replay sticky session"

### DIFF
--- a/apps/site/sentry.client.config.ts
+++ b/apps/site/sentry.client.config.ts
@@ -8,7 +8,7 @@ Sentry.init({
   dsn,
   enabled: !!dsn,
   environment: process.env.NEXT_PUBLIC_VERCEL_ENV ?? "unset",
-  integrations: [new Sentry.Replay({ stickySession: false })],
+  integrations: [new Sentry.Replay({ stickySession: true })],
   replaysOnErrorSampleRate: 1,
   replaysSessionSampleRate: parseFloat(
     process.env.NEXT_PUBLIC_SENTRY_REPLAYS_SESSION_SAMPLE_RATE ?? "0",


### PR DESCRIPTION
Reverts blockprotocol/blockprotocol#1139

I'm confident that this is not the cause of the 'hub errors in incognito issue', which I believe is something to do with esm.sh

