### PR TITLE
Remove Changeset linting for the existence of a changeset file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      
+      - uses: ./.github/actions/warm-up-repo
 
       - name: Run yarn lint:dependency-version-consistency
         if: ${{ success() || failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      
+
       - uses: ./.github/actions/warm-up-repo
 
       - name: Run yarn lint:dependency-version-consistency

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,28 +21,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 ## Needed for Changesets to find `main` branch
-
-        ## https://github.com/changesets/changesets/issues/517
-      - name: Create git reference to main branch (for Changesets)
-        if: ${{ github.event.pull_request.title != 'Version Packages' }}
-        run: git pull --ff-only --force --no-tags origin main:main
-
-      - uses: ./.github/actions/warm-up-repo
-
-      - name: Run yarn lint:changeset
-        if: ${{ (success() || failure()) && github.event.pull_request.title != 'Version Packages' }}
-        run: |
-          if ! yarn lint:changeset; then
-            echo ''
-            echo ''
-            echo 'ℹ️ ℹ️ ℹ️'
-            echo 'Please fix the above errors locally for the check to pass.'
-            echo 'If you don’t see them, try merging target branch into yours.'
-            echo 'ℹ️ ℹ️ ℹ️'
-            exit 1
-          fi
 
       - name: Run yarn lint:dependency-version-consistency
         if: ${{ success() || failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         ## https://github.com/changesets/changesets/issues/517
       - name: Create git reference to main branch (for Changesets)
         if: ${{ github.event.pull_request.title != 'Version Packages' }}
-        run: git pull --force --no-tags origin main:main
+        run: git pull --ff-only --force --no-tags origin main:main
 
       - uses: ./.github/actions/warm-up-repo
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "fix:prettier": "prettier --cache --write --ignore-unknown .",
     "fix:yarn-deduplicate": "yarn install && yarn-deduplicate --strategy=fewer && yarn install",
     "lint": "npm-run-all --continue-on-error \"lint:*\"",
-    "lint:changeset": "changeset status",
     "lint:dependency-version-consistency": "check-dependency-version-consistency .",
     "lint:eslint": "turbo run --continue lint:eslint",
     "lint:knip": "knip --no-exit-code",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have a linting step which checks if there are any changes to packages without a changeset being present. The precursor to this step, which pulls `main` of the repo so that the [Changesets CLI](https://github.com/changesets/changesets/blob/main/packages/cli) has access to it, causes occasional errors, which were the initial motivation for investigating it:

![Screenshot 2023-03-14 at 17 31 56](https://user-images.githubusercontent.com/37743469/225106408-089020e9-bcd8-4f29-98ea-45f3630ac7de.png)

We could attempt to fix this (e.g. by specifying a reconciliation strategy), but the linting step seems of questionable value anyway – it only errors if there are changes any packages but no changeset file exists _at all_ in the repo. It does not verify that a changeset file exists for the package that has been changed in a PR, let alone whether it was created as part of the commits in the PR. The presence of any changeset file whatsoever satisfies the step. So it does not remove the need for considering changesets manually as part of a PR, and it seems easier to just remove the linting step.

Alternatives:
1. `changeset status --since [commit]` [[docs](https://github.com/changesets/changesets/blob/main/packages/cli/README.md#status)] would at least check whether a changeset has been created as part of the commits a PR is introducing, which might be worth investigating if handling manually proves to be error prone
2. There is a Changesets [bot](https://github.com/changesets/bot) but it warns if no changeset is present for _every_ PR that is missing one, regardless of whether the PR affects a file inside a publishable package, which would be very annoying.

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203623179643290/1204116970062018/f) _(internal)_

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Removes the 'do changesets exist' linting step


## 🐾 Next steps

- Apply the same removal to https://github.com/hashintel/hash, subject to any feedback on this PR.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Check that linting runs successfully without the step 

