### PR TITLE
Add GitHub workflow to attach Pull Request to Asana task

### DIFF
--- a/.github/workflows/attach-pr-to-asana-task.yml
+++ b/.github/workflows/attach-pr-to-asana-task.yml
@@ -1,0 +1,10 @@
+name: Attach pull request to Asana task
+on: pull_request
+
+jobs:
+  create-asana-attachment-job:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Asana/create-app-attachment-github-action@latest
+        with:
+          asana-secret: ${{ secrets.ASANA_SECRET }}


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds the Asana integration which automatically adds PR links to tasks linked in task descriptions.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204000740778935/1204143704715742/f) _(internal)_

## ⚠️ Known issues

- Asana has been a bit flaky contacting GitHub this week (sometimes PR links cannot be added manually to tasks, sometimes they can).

## ❓ How to test this?

1.  Confirm that the action worked:

<img width="1485" alt="Screenshot 2023-03-15 at 08 22 15" src="https://user-images.githubusercontent.com/37743469/225249483-be6357a7-efd7-473b-8f7c-5a149478935e.png">
