### PR TITLE
Conditionally enable Sentry error reporting in the WordPress plugin

### DIFF
--- a/libs/wordpress-plugin/plugin/trunk/server/data.php
+++ b/libs/wordpress-plugin/plugin/trunk/server/data.php
@@ -174,14 +174,11 @@ function block_protocol_sentry_has_other_config()
   // Check if sentry is already instantiated
   $client = \Sentry\SentrySdk::getCurrentHub()->getClient();
 
-  $different_dsn_set = $client->getOptions()->getDsn() != BLOCK_PROTOCOL_SENTRY_DSN ?: false;
+  $different_dsn_set = 
+    $client != null 
+    ? $client->getOptions()->getDsn() != BLOCK_PROTOCOL_SENTRY_DSN ?: false
+    : false;
 
-  if($client == null) {
-    // The get call creates a new hub for some reason, 
-    // we need to remove it if there is no client
-    \Sentry\SentrySdk::setCurrentHub(null);
-  } 
-  
   return $different_dsn_set;
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This PR adjusts our Sentry usage so we don't overwrite existing sentry configurations (that are using the Sentry SDK). 
We still catch and report manually instrumented errors (such as DB errors and API errors) because of our `block_protocol_maybe_capture_error` function.
The diff may be a little annoying functions in the file were moved around.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203358502199087/1204147504869254/f) _(internal)_

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Adds conditional sentry setup (checks if existing config exists with another DSN we don't know about)
- As a fallback we manually/explicitly catch any errors that we instrument with `block_protocol_maybe_capture_error`.
- Add anonymous user identifier as a sentry tag

## ❓ How to test this?
Testing this is a little convoluted and requires another sentry project to test against

- Set up WP installation on branch
- Install `WordPress Sentry` WP plugin 
    - Setting this up requires editing the `wp-settings.php` file in the WP docker container
    - Add the following lines with your "test" DSN to the `wp-settings.php` from `docker exec -it wordpress-wordpress-1 bash`
```php
define('WP_SENTRY_PHP_DSN', "YOUR DSN");
define('WP_SENTRY_ENV', 'development');
```
- Go to the test page for the WP sentry plugin at http://localhost:8000/wp-admin/tools.php?page=wp-sentry try sending a test event. This should go through and add an event to your Sentry test project 
- Observe no event in the BP sentry for the WP plugin
- trigger an exception in the BP code (for example changing the URL of the `wp_remote_get` in `plugin/trunk/block-protocol.php:103` to be `/api/foo`)
- Go to BP settings page, undo change above, observe BP sentry page, should now report the error without reporting it to the test sentry instance

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->
Successfully reporting event through the WP Sentry plugin
![image](https://user-images.githubusercontent.com/6988668/225319347-db92e29b-aeb5-4ca9-b9a1-d6890e3e7187.png)
The above event in Sentry
![image](https://user-images.githubusercontent.com/6988668/225319793-407996fc-1734-4186-8db6-c8b24f266c56.png)


An unrelated event triggered by causing an exception in the BP code. It shows up in the BP sentry
![image](https://user-images.githubusercontent.com/6988668/225319389-80327d82-fe54-4676-82a7-99b990a90fa0.png)
