### PR TITLE
Fix import path for mock block dock in sandbox

### DIFF
--- a/apps/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
+++ b/apps/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
@@ -121,7 +121,7 @@ const handler: NextApiHandler = async (req, res) => {
       import React from "https://esm.sh/react@${reactVersion}?target=es2021"
       import ReactDOM from "https://esm.sh/react-dom@${reactVersion}?target=es2021"
       import { jsx as _jsx } from "https://esm.sh/react@${reactVersion}/jsx-runtime.js?target=es2021";
-      import { MockBlockDock } from "https://esm.sh/mock-block-dock@${mockBlockDockVersion}/dist/esm/index.js?target=es2021&deps=react@${reactVersion}";
+      import { MockBlockDock } from "https://esm.sh/mock-block-dock@${mockBlockDockVersion}/dist/index.js?target=es2021&deps=react@${reactVersion}";
 
       const requireLookup = {
         "react-dom": ReactDOM,

--- a/libs/mock-block-dock/src/version.ts
+++ b/libs/mock-block-dock/src/version.ts
@@ -1,1 +1,1 @@
-export const MOCK_BLOCK_DOCK_VERSION = "0.1.2";
+export const MOCK_BLOCK_DOCK_VERSION = "0.1.3";


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
We have an import path for Mock Block Dock in the sandbox iFrame that needs fixing following #1162 