### PR TITLE
Silence .env warnings, remove blockEntityType from metadata

### DIFF
--- a/.changeset/thick-kiwis-joke.md
+++ b/.changeset/thick-kiwis-joke.md
@@ -1,0 +1,5 @@
+---
+"block-scripts": patch
+---
+
+silence warning if no .env file present. don't include blockEntityType in block-metadata.json

--- a/libs/block-scripts/shared/generate-dist-block-metadata.js
+++ b/libs/block-scripts/shared/generate-dist-block-metadata.js
@@ -27,6 +27,9 @@ export const generateDistBlockMetadata = async (extra) => {
     ? await fs.readJson(variantsJsonPath)
     : undefined;
 
+  const schema = blockprotocol.blockEntityType;
+  delete blockprotocol.blockEntityType;
+
   const blockMetadata = {
     name,
     version,
@@ -36,9 +39,9 @@ export const generateDistBlockMetadata = async (extra) => {
     license,
     externals: peerDependencies,
     variants,
+    schema,
     ...blockprotocol,
     ...extra,
-    schema: blockprotocol.blockEntityType,
   };
 
   return writeFormattedJson(

--- a/libs/block-scripts/shared/webpack-config.js
+++ b/libs/block-scripts/shared/webpack-config.js
@@ -146,7 +146,7 @@ export const generateDevWebpackConfig = async () => {
     plugins: [
       ...(baseWebpackConfig.plugins ?? []),
       new BlockAssetsPlugin(),
-      new Dotenv(),
+      new Dotenv({ silent: true }),
       new HtmlWebpackPlugin({
         filename: "index.html",
         template: path.resolve(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A couple of tweaks to the output of `block-scripts`:
1. Silence warning if no `.env` file is present – otherwise users see `Failed to load ./.env` every time they run `yarn dev` if they aren't using a `.env` file, which might seem like a problem 
2. Don't include the `blockEntityType` property from `package.json[blockprotocol]` in `block-metadata.json` – its value should be taken for `schema` in that file, rather than appearing twice under different keys