### PR TITLE
Allow "free" users to update payment method

### DIFF
--- a/apps/site/src/pages/settings/billing-settings-panel/billing-overview.tsx
+++ b/apps/site/src/pages/settings/billing-settings-panel/billing-overview.tsx
@@ -74,6 +74,10 @@ export const BillingOverviewPanelPage: FunctionComponent = () => {
     [user],
   );
 
+  const subscriptionStatusIsActiveOrPastDue =
+    stripeSubscriptionStatus === "active" ||
+    stripeSubscriptionStatus === "past_due";
+
   const currentSubscriptionTierIsPaid = isPaidSubscriptionTier(
     currentSubscriptionTier,
   );
@@ -122,12 +126,12 @@ export const BillingOverviewPanelPage: FunctionComponent = () => {
         <Grid item md={6} sm={12} sx={{ position: "relative" }}>
           <Link
             href={
-              currentSubscriptionTierIsPaid
+              subscriptionStatusIsActiveOrPastDue
                 ? paymentMethodsPanelPageAsPath
                 : "#"
             }
             onClick={(event) => {
-              if (!currentSubscriptionTierIsPaid) {
+              if (!subscriptionStatusIsActiveOrPastDue) {
                 event.preventDefault();
                 /**
                  * @todo: figure out why calling `scrollIntoView` directly results
@@ -170,7 +174,7 @@ export const BillingOverviewPanelPage: FunctionComponent = () => {
               <Box display="flex" alignItems="center">
                 <Typography variant="bpBodyCopy">
                   <strong>
-                    {currentSubscriptionTierIsPaid
+                    {subscriptionStatusIsActiveOrPastDue
                       ? "Change payment method"
                       : "Upgrade to get more"}
                   </strong>
@@ -184,8 +188,7 @@ export const BillingOverviewPanelPage: FunctionComponent = () => {
                   }}
                 />
               </Box>
-              {/* @todo: implement "change payment" settings panel @see https://app.asana.com/0/0/1203781148500075/f */}
-              {currentSubscriptionTierIsPaid ? (
+              {subscriptionStatusIsActiveOrPastDue ? (
                 defaultSubscriptionPaymentMethod ? (
                   <PaymentMethod
                     paymentMethod={defaultSubscriptionPaymentMethod}

--- a/apps/site/src/pages/settings/billing-settings-panel/payment-history-section.tsx
+++ b/apps/site/src/pages/settings/billing-settings-panel/payment-history-section.tsx
@@ -83,7 +83,9 @@ export const PaymentHistorySection: FunctionComponent<{
   const fetchInvoices = useCallback(async () => {
     const {
       data: { invoices: fetchedInvoices },
-    } = await internalApi.getInvoices();
+    } = await internalApi
+      .getInvoices()
+      .catch(() => ({ data: { invoices: [] } }));
 
     setPastInvoices(fetchedInvoices.sort((a, b) => b.created - a.created));
   }, [setPastInvoices]);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR enables anyone with an active stripe subscription (including those with a "free" subscription tier) to edit their payment method.

It also fixes an issue where a runtime error is thrown for users with an inactive stripe subscription in the `PaymentHistorySection` component.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Update BP site to let user change payment method when they have a "free" account](https://app.asana.com/0/1204000740778935/1204188703131678/f) _(internal)_
- [Catch errors when a user without a subscription loads billing page](https://app.asana.com/0/1204000740778938/1204173853214856/f) _(internal)_

## ⚠️ Known issues

- when a user has an active stripe subscription on the "free" tier, they are not able to use the existing upgrade subscription flow ([asana task](https://app.asana.com/0/0/1204188703131699/f))

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

Manual testing.

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1. Checkout the branch and go to the billing page as new user with an inactive stripe subscription
2. Ensure no runtime error is thrown on the billing page
3. Upgrade the user to the "hobby" or "pro" tier using test stripe card details
4. Go to the stripe dashboard, and update the user's subscription manually to a "free" tier by removing the "hobby" tier subscription item and adding the "free" tier subscription item to the stripe subscription (you can watch me do this in the demo video of [this PR](https://github.com/hashintel/internal-api/pull/86))
5. Go back to the billing page, and observe that the user is on the "free" tier and is able to update their payment information

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

<img width="1214" alt="image" src="https://user-images.githubusercontent.com/42802102/225866601-8ac6046d-2858-4c0d-a701-9a940a0f77ce.png">

