### PR TITLE
Remove stray `$`

### DIFF
--- a/libs/wordpress-plugin/plugin/trunk/server/block-api-endpoints.php
+++ b/libs/wordpress-plugin/plugin/trunk/server/block-api-endpoints.php
@@ -361,7 +361,7 @@ function create_block_protocol_entity(WP_REST_Request $request)
     return $results;
   }
 
-  $block_metadata = isset($params['$block_metadata']) ? $params['block_metadata'] : null;
+  $block_metadata = isset($params['block_metadata']) ? $params['block_metadata'] : null;
 
   if ($block_metadata) {
     block_protocol_page_data('new_block', [


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?
This PR removed a stray `$` that caused the `if` statement to never pass. Perhaps `?:` or `??` would be best here, but this should be fine (tested locally)