### PR TITLE
Manually install `wasm-pack`

### DIFF
--- a/.github/actions/warm-up-repo/action.yml
+++ b/.github/actions/warm-up-repo/action.yml
@@ -15,6 +15,11 @@ runs:
       with:
         node-version: 16 ## aligned with Node version on Vercel
 
+    - name: Install Rust tools
+      uses: taiki-e/install-action@v2
+      with:
+        tool: wasm-pack@0.10.3
+
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
       with:

--- a/libs/@blockprotocol/type-system/crate/.justfile
+++ b/libs/@blockprotocol/type-system/crate/.justfile
@@ -11,6 +11,10 @@ cargo-profile := env_var_or_default('PROFILE', "dev")
   just --list --unsorted
   echo "For further information, run 'just --help'"
 
+
+install-tool tool version:
+  `{{tool}} --version | grep -q "{{version}}" || cargo install "{{tool}}" --version "{{version}}" --locked --force`
+
 [private]
 cargo command *arguments:
   cargo {{command}} --workspace --all-features {{arguments}}
@@ -32,7 +36,7 @@ build-host *arguments:
 
 # Builds the wasm targets of the workspace
 [private]
-build-wasm *arguments:
+build-wasm *arguments: (install-tool "wasm-pack" "0.10.3")
   # TODO: add profile
   # TODO: consider moving away from wasm-pack and using wasm-bindgen directly so we can use weak-refs
   #       https://github.com/iotaledger/identity.rs/pull/694

--- a/libs/@blockprotocol/type-system/package.json
+++ b/libs/@blockprotocol/type-system/package.json
@@ -68,7 +68,6 @@
     "rollup": "3.5.1",
     "ts-jest": "29.0.5",
     "tslib": "2.4.1",
-    "typescript": "4.9.4",
-    "wasm-pack": "0.10.3"
+    "typescript": "4.9.4"
   }
 }

--- a/libs/@blockprotocol/type-system/scripts/build-wasm.ts
+++ b/libs/@blockprotocol/type-system/scripts/build-wasm.ts
@@ -35,6 +35,10 @@ const runWasmPack = () => {
     "-Zbuild-std-features=panic_immediate_abort",
   ]);
 
+  if (result.error) {
+    throw new Error(`Running wasm-pack failed: ${result.error}`);
+  }
+
   if (result.status !== 0) {
     console.log(result.stdout.toString());
     console.log(result.stderr.toString());

--- a/yarn.lock
+++ b/yarn.lock
@@ -5155,13 +5155,6 @@ axios@0.26.1, axios@^0.26.0:
   dependencies:
     follow-redirects "^1.14.8"
 
-axios@^0.21.1:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
-  dependencies:
-    follow-redirects "^1.14.0"
-
 axios@^0.25.0:
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.25.0.tgz#349cfbb31331a9b4453190791760a8d35b093e0a"
@@ -5340,15 +5333,6 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
-
-binary-install@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/binary-install/-/binary-install-0.1.1.tgz#c1b22f174581764e5c52cd16664cf1d287e38bd4"
-  integrity sha512-DqED0D/6LrS+BHDkKn34vhRqOGjy5gTMgvYZsGK2TpNbdPuz4h+MRlNgGv5QBRd7pWq/jylM4eKNCizgAq3kNQ==
-  dependencies:
-    axios "^0.21.1"
-    rimraf "^3.0.2"
-    tar "^6.1.0"
 
 bl@^4.0.3, bl@^4.1.0:
   version "4.1.0"
@@ -7887,7 +7871,7 @@ flux@^4.0.1:
     fbemitter "^3.0.0"
     fbjs "^3.0.1"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.0, follow-redirects@^1.14.7, follow-redirects@^1.14.8, follow-redirects@^1.15.0:
+follow-redirects@^1.0.0, follow-redirects@^1.14.7, follow-redirects@^1.14.8, follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -15164,13 +15148,6 @@ walker@^1.0.8:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
-
-wasm-pack@0.10.3:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/wasm-pack/-/wasm-pack-0.10.3.tgz#2d7dd78ba539c34b3817e2249c3f30c646c84b69"
-  integrity sha512-dg1PPyp+QwWrhfHsgG12K/y5xzwfaAoK1yuVC/DUAuQsDy5JywWDuA7Y/ionGwQz+JBZVw8jknaKBnaxaJfwTA==
-  dependencies:
-    binary-install "^0.1.0"
 
 watchpack@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We encountered quite a few issues with installing `wasm-pack` through `yarn`.

## 🔗 Related links

- [Slack thread](https://hashintel.slack.com/archives/C04SP1PGKC1/p1679054824550009) _(internal)_

## 🔍 What does this change?

- Add `install-tool` recipe to `.justfile`
- Install `wasm-pack` if not already installed or installed with wrong version
- Drive-by: Add check for error before trying to print stdout