### PR TITLE
Edit bar improvements in entity type editor 

### DIFF
--- a/apps/site/src/components/navbar.tsx
+++ b/apps/site/src/components/navbar.tsx
@@ -250,10 +250,11 @@ const Navbar: FunctionComponent<
 
   const isHomePage = generatePathWithoutParams(hydrationFriendlyAsPath) === "/";
   const isDocs = hydrationFriendlyAsPath.startsWith("/docs");
+  const isTypeEditor = hydrationFriendlyAsPath.includes("/types/entity-type/");
   const [mobileNavVisible, setMobileNavVisible] = useMobileNavVisible();
 
   const { scrolledPast, isNavbarHidden } = useScrollingNavbar(
-    isDocs,
+    isDocs || isTypeEditor,
     isHomePage ? HOME_PAGE_HEADER_HEIGHT : null,
     mobileNavVisible,
   );

--- a/apps/site/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
+++ b/apps/site/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
@@ -151,8 +151,6 @@ const EntityTypePage: NextPage = () => {
         entityType: responseData.entityType,
         latestVersion: responseData.entityType,
       });
-
-      void router.replace(responseData.entityType.schema.$id);
     } else {
       const { data: responseData, error: responseError } =
         await apiClient.updateEntityType({

--- a/apps/site/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
+++ b/apps/site/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page.tsx
@@ -105,7 +105,10 @@ const EntityTypePage: NextPage = () => {
     (stateToSet: EntityTypeState) => {
       setEntityTypeState(stateToSet);
       reset(getFormDataFromSchema(stateToSet.entityType.schema));
-      void router.push(stateToSet.entityType.schema.$id);
+
+      void router.replace(stateToSet.entityType.schema.$id, undefined, {
+        scroll: false,
+      });
     },
     [reset, router, setEntityTypeState],
   );

--- a/apps/site/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/entity-type-edit-bar.tsx
+++ b/apps/site/src/pages/[shortname]/types/entity-type/[...slug-maybe-version].page/entity-type-edit-bar.tsx
@@ -4,6 +4,7 @@ import {
   useEntityTypeFormState,
 } from "@hashintel/type-editor";
 import { Box, Stack, Typography } from "@mui/material";
+import { Container } from "@mui/system";
 import { useRouter } from "next/router";
 import { useState } from "react";
 
@@ -46,50 +47,61 @@ export const EntityTypeEditBar = ({
 
   return (
     <Box
-      sx={({ palette }) => ({
+      sx={({ palette, zIndex, shadows }) => ({
         backgroundColor: palette.purple[60],
         color: "white",
-        display: "flex",
-        alignItems: "center",
-        padding: "18px 30px",
+        position: "sticky",
+        top: "var(--navbar-height)",
+        zIndex: zIndex.appBar - 1,
+        boxShadow: shadows[1],
       })}
     >
-      {isDraft ? (
-        <FontAwesomeIcon icon={faSmile} sx={{ fontSize: 14 }} />
-      ) : (
-        <PencilSimpleLineIcon />
-      )}
-      <Typography sx={{ ml: 1, color: "white" }}>
-        <Box component="span" sx={{ fontWeight: "bold", mr: 1 }}>
-          Currently editing
-        </Box>{" "}
-        {isDraft ? (
-          <>- this type has not yet been created</>
-        ) : (
-          `Version ${frozenVersion} -> ${frozenVersion + 1}`
-        )}
-      </Typography>
-      <Stack spacing={1.25} sx={{ marginLeft: "auto" }} direction="row">
-        <Button
-          disabled={frozenSubmitting}
-          type="button"
-          variant="secondary"
-          size="small"
-          {...(isDraft
-            ? { href: `/${router.query.shortname}/all-types` }
-            : { onClick: () => reset() })}
+      <Container>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            py: "18px",
+          }}
         >
-          Discard changes
-        </Button>
-        <Button
-          disabled={frozenSubmitting}
-          variant="primary"
-          size="small"
-          type="submit"
-        >
-          {isDraft ? <>Create</> : <>Publish update</>}
-        </Button>
-      </Stack>
+          {isDraft ? (
+            <FontAwesomeIcon icon={faSmile} sx={{ fontSize: 14 }} />
+          ) : (
+            <PencilSimpleLineIcon />
+          )}
+          <Typography sx={{ ml: 1, color: "white" }}>
+            <Box component="span" sx={{ fontWeight: "bold", mr: 1 }}>
+              Currently editing
+            </Box>{" "}
+            {isDraft ? (
+              <>- this type has not yet been created</>
+            ) : (
+              `Version ${frozenVersion} -> ${frozenVersion + 1}`
+            )}
+          </Typography>
+          <Stack spacing={1.25} sx={{ marginLeft: "auto" }} direction="row">
+            <Button
+              disabled={frozenSubmitting}
+              type="button"
+              variant="secondary"
+              size="small"
+              {...(isDraft
+                ? { href: `/${router.query.shortname}/all-types` }
+                : { onClick: () => reset() })}
+            >
+              Discard changes
+            </Button>
+            <Button
+              disabled={frozenSubmitting}
+              variant="primary"
+              size="small"
+              type="submit"
+            >
+              {isDraft ? <>Create</> : <>Publish update</>}
+            </Button>
+          </Stack>
+        </Box>
+      </Container>
     </Box>
   );
 };


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

The Edit Bar, which displays when you have pending changes to an entity type, can appear out of view. This PR makes it sticky, so it scrolls with the viewport. It also ensures the header doesn't hide when on the entity type editor, to make it easier to know where to position the edit bar, and associated visual changes.

**Importantly, it also changes the URL management for entity types from a push to a replace**, and removes the scroll up. This is to prevent the scroll up when publishing new versions, which wasn't evident before as you had to be scrolled up to access the edit bar anyway. This also prevents history being polluted with previous versions, and matches the behaviour in HASH. There is a minor chance replace may be used instead of push when that isn't desirable – i.e, if you've changed to a whole new entity type instead of just a new version, but that isn't possible in the current UI. 

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203358502199087/1203979552136012/f) _(internal)_

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

N/A

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- The header now always displays on the type editor
- URL is now updated using replace instead of push, with scroll disabled. The reasons for this are explained above.
- Removed a redundant call to router.replace when publishing the initial version of entity types. 
- Edit bar is now sticky below the header, and its contents are centered to match the header

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

No

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

N/A

## 🐾 Next steps

<!-- Are there are planned/suggested follow-ups which are related but won't be done in this PR? -->

We may want to make the edit bar animate in, as in HASH. 

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

Visual approval

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204203279487398