### PR TITLE
Add missing padding to BP icon

### DIFF
--- a/apps/site/src/components/pages/wordpress/why-install.tsx
+++ b/apps/site/src/components/pages/wordpress/why-install.tsx
@@ -145,8 +145,9 @@ export const WhyInstall = () => {
             textAlign: "center",
           }}
         >
-          Download the free <BlockProtocolIcon gradient sx={{ mb: 0.5 }} />
-          WordPress plugin
+          {"Download the free "}
+          <BlockProtocolIcon gradient sx={{ mb: 0.5 }} />
+          {" WordPress plugin"}
         </Typography>
 
         <Box sx={{ maxWidth: 500, width: 1, mt: 5 }}>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds missing padding to BP icon on `/wordpress` page.
## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204000740778938/1204203279487405/f) _(internal)_

## 📹 Demo
![Screenshot 2023-03-22 at 12 06 47](https://user-images.githubusercontent.com/39553853/226853873-e03986fc-8958-4f39-a75f-a443690260ca.png)


