### PR TITLE
Make @blockprotocol/design-system private temporarily

### DIFF
--- a/libs/@blockprotocol/design-system/package.json
+++ b/libs/@blockprotocol/design-system/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blockprotocol/design-system",
-  "private": true,
   "version": "0.0.1",
+  "private": true,
   "description": "Implementation of the Block Protocol Design System",
   "keywords": [
     "blockprotocol",

--- a/libs/@blockprotocol/design-system/package.json
+++ b/libs/@blockprotocol/design-system/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@blockprotocol/design-system",
+  "private": true,
   "version": "0.0.1",
   "description": "Implementation of the Block Protocol Design System",
   "keywords": [


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have a CI check which publishes packages to a local registry to check that they publish successfully – this is currently [failing](https://github.com/blockprotocol/blockprotocol/actions/runs/4510198147/jobs/7940865428) on a new package, `@blockprotocol/design-system`. 

It's not clear why, but making this package `private: true` until we actually need to publish it to NPM will allow us to defer figuring it out.