### PR TITLE
Update GitHub labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,8 +5,8 @@
   - "apps/**"
   - "!apps/site/src/_pages/**"
 
-"area: copy":
-  - "apps/site/src/_pages/**"
+"area: blocks":
+  - "blocks/**"
 
 "area: dependencies":
   - "**/patches/**"
@@ -22,15 +22,27 @@
 "area: libs":
   - "libs/**"
 
-"area: rfcs":
+"area: user success":
+  - "apps/site/src/_pages/docs/**"
+  - "apps/site/src/_pages/spec/**"
+  - "apps/site/src/_pages/roadmap/**"
+  - "rfcs"
+
+"content: docs":
+  - "apps/site/src/_pages/docs/**"
+
+"content: rfcs":
   - "rfcs/**"
 
-"area: spec":
+"content: spec":
   - "apps/site/src/_pages/spec/**"
 
 "lib: @Þ/core":
   - "libs/@blockprotocol/core/**"
 
+"lib: @Þ/design-system":
+  - "libs/@blockprotocol/design-system/**"
+  
 "lib: @Þ/graph":
   - "libs/@blockprotocol/graph/**"
 
@@ -67,3 +79,7 @@
 
 "lib: wordpress-plugin":
   - "libs/wordpress-plugin/**"
+  
+"type: writing":
+  - "apps/site/src/_pages/**"
+

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -47,7 +47,7 @@
 
 "area: libs > @Þ/design-system":
   - "libs/@blockprotocol/design-system/**"
-  
+
 "area: libs > @Þ/graph":
   - "libs/@blockprotocol/graph/**"
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,17 +2,14 @@
   - "apps/site/**"
 
 "area: apps":
-  - "apps/**"
+  - ["apps/**", "!apps/site/src/_pages/**"]
+
+"area: copy":
+  - "apps/site/src/_pages/**"
 
 "area: dependencies":
   - "**/patches/**"
   - "**/yarn.lock"
-
-"area: docs":
-  - "apps/site/src/_pages/docs/**"
-
-"area: hub":
-  - "hub/**"
 
 "area: infra":
   - ".changeset/config.json"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -23,6 +23,10 @@
 "area: libs":
   - "libs/**"
 
+"area: tests":
+  - "**/*.test.ts"
+  - "**/tests/**"
+
 "area: user success":
   - "apps/site/src/_pages/docs/**"
   - "apps/site/src/_pages/spec/**"
@@ -38,49 +42,51 @@
 "area: user success > spec":
   - "apps/site/src/_pages/spec/**"
 
-"lib: @Þ/core":
+"area: libs > @Þ/core":
   - "libs/@blockprotocol/core/**"
 
-"lib: @Þ/design-system":
+"area: libs > @Þ/design-system":
   - "libs/@blockprotocol/design-system/**"
   
-"lib: @Þ/graph":
+"area: libs > @Þ/graph":
   - "libs/@blockprotocol/graph/**"
 
-"lib: @Þ/hook":
+"area: libs > @Þ/hook":
   - "libs/@blockprotocol/hook/**"
 
-"lib: @Þ/type-system":
+"area: libs > @Þ/type-system":
   - "libs/@blockprotocol/type-system-node/**"
   - "libs/@blockprotocol/type-system-web/**"
 
-"lib: @local/*":
+"area: libs > @local/*":
   - "libs/@local/**"
 
-"lib: block-scripts":
+"area: libs > block-scripts":
   - "libs/block-scripts/**"
 
-"lib: block-template-custom-element":
+"area: libs > block-template-custom-element":
   - "libs/block-template-custom-element/**"
 
-"lib: block-template-html":
+"area: libs > block-template-html":
   - "libs/block-template-html/**"
 
-"lib: block-template-react":
+"area: libs > block-template-react":
   - "libs/block-template-react/**"
 
-"lib: blockprotocol":
+"area: libs > blockprotocol":
   - "libs/blockprotocol/**"
 
-"lib: create-block-app":
+"area: libs > create-block-app":
   - "libs/create-block-app/**"
 
-"lib: mock-block-dock":
+"area: libs > mock-block-dock":
   - "libs/mock-block-dock/**"
 
-"lib: wordpress-plugin":
+"area: libs > wordpress-plugin":
   - "libs/wordpress-plugin/**"
-  
+
+"type: frontend":
+  - "libs/@blockprotocol/design-system/**"
+
 "type: writing":
   - "apps/site/src/_pages/**"
-

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,9 +1,9 @@
-"app: site":
-  - "apps/site/**"
-
 "area: apps":
   - "apps/**"
   - "!apps/site/src/_pages/**"
+
+"area: apps > site":
+  - "apps/site/**"
 
 "area: blocks":
   - "blocks/**"
@@ -14,6 +14,7 @@
 
 "area: infra":
   - ".changeset/config.json"
+  - ".config/**"
   - ".github/**"
   - ".husky/**"
   - "infra/**"
@@ -28,13 +29,13 @@
   - "apps/site/src/_pages/roadmap/**"
   - "rfcs"
 
-"content: docs":
+"area: user success > docs":
   - "apps/site/src/_pages/docs/**"
 
-"content: rfcs":
+"area: user success > rfcs":
   - "rfcs/**"
 
-"content: spec":
+"area: user success > spec":
   - "apps/site/src/_pages/spec/**"
 
 "lib: @Þ/core":

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,7 +2,8 @@
   - "apps/site/**"
 
 "area: apps":
-  - ["apps/**", "!apps/site/src/_pages/**"]
+  - "apps/**"
+  - "!apps/site/src/_pages/**"
 
 "area: copy":
   - "apps/site/src/_pages/**"


### PR DESCRIPTION
## Changes

- Removes deprecated label (`area: hub`)
- Renames `area: docs` to `area: copy` and updates matching rules around this
- Implements various new rules including automatic tagging of testing-related changes as `area: testing`