### PR TITLE
Add better compatibility for older MySQL versions

### DIFF
--- a/libs/wordpress-plugin/README.md
+++ b/libs/wordpress-plugin/README.md
@@ -108,7 +108,7 @@ Within `trunk` there are:
 
 - **WordPress:** you must be running at least WordPress 5.6 (due to Composer autoload)
 - **PHP 7.4 or later:** your server must be running at least PHP 7.4. PHP 8.0 and 8.1 are also supported.
-- **MySQL 5.7.8+ _or_ MariaDB 10.2.7+:** your database must be using at least MySQL 5.7.8. Be aware, the previous version of MySQL (5.6 and 5.7) respectively reach(ed) end of life in February 2021 and October 2023. You should upgrade to MySQL 8 now to continue to receive security updates, as well as to use the Block Protocol within WordPress. As for MariaDB, although the plugin would work with an old version, we strongly recommend using the newest version available to you.
+- **MySQL 5.7.8+ _or_ MariaDB 10.2.7+:** your database must be using at least MySQL 5.7.8. Be aware, the previous version of MySQL (5.6 and 5.7) respectively reach(ed) end of life in February 2021 and October 2023. You should upgrade to MySQL 8 now to continue to receive security updates, as well as to get the best Block Protocol experience within WordPress. As for MariaDB, although the plugin would work with an older version, we strongly recommend using the newest version available to you.
 - **HTTPS:** your webhost must support HTTPS in order for the Block Protocol to properly function.
 
 To check what your WordPress instance supports, please navigate to `Admin -> Tools -> Site Health -> Info` and then click into either `Server` (for PHP) or `Database` (for MySQL/MariaDB).

--- a/libs/wordpress-plugin/README.md
+++ b/libs/wordpress-plugin/README.md
@@ -108,7 +108,7 @@ Within `trunk` there are:
 
 - **WordPress:** you must be running at least WordPress 5.6 (due to Composer autoload)
 - **PHP 7.4 or later:** your server must be running at least PHP 7.4. PHP 8.0 and 8.1 are also supported.
-- **MySQL 8 _or_ MariaDB 10.2.7+:** your database must be using at least MySQL 8 (due to use of recursive CTE queries). Be aware, the previous version of MySQL (5.6 and 5.7) respectively reach(ed) end of life in February 2021 and October 2023. You should upgrade to MySQL 8 now to continue to receive security updates, as well as to use the Block Protocol within WordPress. As for MariaDB, although the plugin would work with an old version, we strongly recommend using the newest version available to you.
+- **MySQL 5.7.8+ _or_ MariaDB 10.2.7+:** your database must be using at least MySQL 5.7.8. Be aware, the previous version of MySQL (5.6 and 5.7) respectively reach(ed) end of life in February 2021 and October 2023. You should upgrade to MySQL 8 now to continue to receive security updates, as well as to use the Block Protocol within WordPress. As for MariaDB, although the plugin would work with an old version, we strongly recommend using the newest version available to you.
 - **HTTPS:** your webhost must support HTTPS in order for the Block Protocol to properly function.
 
 To check what your WordPress instance supports, please navigate to `Admin -> Tools -> Site Health -> Info` and then click into either `Server` (for PHP) or `Database` (for MySQL/MariaDB).

--- a/libs/wordpress-plugin/README.md
+++ b/libs/wordpress-plugin/README.md
@@ -108,7 +108,7 @@ Within `trunk` there are:
 
 - **WordPress:** you must be running at least WordPress 5.6 (due to Composer autoload)
 - **PHP 7.4 or later:** your server must be running at least PHP 7.4. PHP 8.0 and 8.1 are also supported.
-- **MySQL 5.7.8+ _or_ MariaDB 10.2.7+:** your database must be using at least MySQL 5.7.8. Be aware, the previous version of MySQL (5.6 and 5.7) respectively reach(ed) end of life in February 2021 and October 2023. You should upgrade to MySQL 8 now to continue to receive security updates, as well as to get the best Block Protocol experience within WordPress. As for MariaDB, although the plugin would work with an older version, we strongly recommend using the newest version available to you.
+- **MySQL 5.7.8+ _or_ MariaDB 10.2.7+:** your database must be using at least MySQL 5.7.8. Be aware, MySQL 5.6 and 5.7 respectively reach(ed) end of life in February 2021 and October 2023. You should upgrade to MySQL 8 now to continue to receive security updates, as well as to get the best Block Protocol experience within WordPress. As for MariaDB, although the plugin would work with an older version, we strongly recommend using the newest version available to you.
 - **HTTPS:** your webhost must support HTTPS in order for the Block Protocol to properly function.
 
 To check what your WordPress instance supports, please navigate to `Admin -> Tools -> Site Health -> Info` and then click into either `Server` (for PHP) or `Database` (for MySQL/MariaDB).

--- a/libs/wordpress-plugin/plugin/trunk/changelog.txt
+++ b/libs/wordpress-plugin/plugin/trunk/changelog.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= Unreleased =
+* Support older versions of MySQL (Minimum version is now 5.7.8 down from 8.0)
+
 = 0.0.5 =
 * Handle blocks being inside an iFrame in editor view (fixes incompatibility with Gutenberg plugin)
 

--- a/libs/wordpress-plugin/plugin/trunk/readme.txt
+++ b/libs/wordpress-plugin/plugin/trunk/readme.txt
@@ -36,9 +36,9 @@ You can also build your own block for the Block Protocol without any PHP, and pu
 
 **5.** If you want to add your own block to the plugin, visit https://blockprotocol.org/docs/developing-blocks
 
-Note that you must be using at least MySQL 8. To check please navigate to `Admin -> Tools -> Site Health -> Info -> Database`.
-The previous versions of MySQL (5.6 and 5.7) respectively reach(ed) end of life in February 2021 and October 2023. 
-You should upgrade to MySQL 8 now to continue to receive security updates, as well as to use the Block Protocol within WordPress.
+Note that you must be using at least MySQL 5.7.8. To check please navigate to `Admin -> Tools -> Site Health -> Info -> Database`.
+MySQL 5.6 and 5.7 respectively reach(ed) end of life in February 2021 and October 2023. 
+You should upgrade to MySQL 8 now to continue to receive security updates, as well as to get the best Block Protocol experience within WordPress.
 
 When you install or use the _Block Protocol for WordPress_ plugin, we don’t send any data to any third-party analytics services. 
 However, we do collect the domain name of the website that the plugin has been activated on, and limited aggregate information 

--- a/libs/wordpress-plugin/plugin/trunk/server/block-api-endpoints.php
+++ b/libs/wordpress-plugin/plugin/trunk/server/block-api-endpoints.php
@@ -184,7 +184,7 @@ function block_protocol_native_subgraph_query(
       $next_nodes = array_merge($next_nodes, $wpdb->get_results($sql, ARRAY_A));
     }
 
-    // Add the next nodes to the queue with updated depth values
+    // Add the next nodes to the queue
     foreach ($next_nodes as $next_node)  {
       $entity_id = $next_node['entity_id'];
 
@@ -361,6 +361,7 @@ function get_block_protocol_subgraph(
   // See https://mariadb.com/kb/en/mariadb-1022-release-notes/#notable-changes
   $mariadb_recursive_cte_version = "10.2.2";
 
+  // Dynamically choose how to execute the query based on the database version
   $action =
     block_protocol_database_at_version(
       $mysql_recursive_cte_version,

--- a/libs/wordpress-plugin/plugin/trunk/server/block-api-endpoints.php
+++ b/libs/wordpress-plugin/plugin/trunk/server/block-api-endpoints.php
@@ -20,19 +20,9 @@ function generate_block_protocol_guidv4()
   return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
 }
 
-function get_block_protocol_subgraph(
-  string $base_where_term,
-  int $has_left_incoming_depth,
-  int $has_right_incoming_depth,
-  int $has_left_outgoing_depth,
-  int $has_right_outgoing_depth
-)
+function block_protocol_entity_selection()
 {
-  global $wpdb;
-
-  $table = get_block_protocol_table_name();
-
-  $selection = "
+  return "
   entity_id,
   entity_type_id,
   left_entity_id,
@@ -44,6 +34,157 @@ function get_block_protocol_subgraph(
   created_at,
   updated_by_id,
   updated_at";
+
+}
+
+/**
+ * Natively traverse a subgraph using a base where term. 
+ * This functions is meant to be as compatible as possible with various MySQL/MariaDB versions
+ */
+function block_protocol_native_subgraph_query(
+  string $base_where_term,
+  int $has_left_incoming_depth,
+  int $has_right_incoming_depth,
+  int $has_left_outgoing_depth,
+  int $has_right_outgoing_depth
+) {
+  global $wpdb;
+
+  $table = get_block_protocol_table_name();
+
+  $subgraph = [];
+  $queue = [];
+
+
+  // Initial query using the base where term
+  $selection = block_protocol_entity_selection();
+  $sql = $wpdb->prepare("
+    SELECT
+        " . $selection . ",
+        0 as has_left_incoming_depth,
+        0 as has_right_incoming_depth,
+        0 as has_left_outgoing_depth,
+        0 as has_right_outgoing_depth
+    FROM {$table}
+    " . $base_where_term);
+
+  // Initialize the queue with the starting nodes
+  $queue = $wpdb->get_results($sql, ARRAY_A);
+
+  $visited = [];
+
+  // Loop while the queue is not empty
+  while (!empty($queue)) {
+      // Dequeue the next node
+      $node = array_shift($queue);
+
+      // Skip nodes that have already been visited
+      if ($visited[$node['entity_id']] ?? false) {
+          continue;
+      }
+
+      $visited[$node['entity_id']] = true;
+
+      // Add the node to the result list
+      $subgraph[] = $node;
+
+      $next_nodes = [];
+
+      // Add nodes connected by incoming has_left links
+      if ($node['has_left_incoming_depth'] < $has_left_incoming_depth) {
+          $sql = $wpdb->prepare("
+              SELECT *
+              FROM {$table}
+              WHERE left_entity_id = %d
+          ", $node['entity_id']);
+
+          $next_nodes = array_merge($next_nodes, $wpdb->get_results($sql, ARRAY_A));
+      }
+
+      // Add nodes connected by incoming has_right links
+      if ($node['has_right_incoming_depth'] < $has_right_incoming_depth) {
+          $sql = $wpdb->prepare("
+              SELECT *
+              FROM {$table}
+              WHERE right_entity_id = %d
+          ", $node['entity_id']);
+
+          $next_nodes = array_merge($next_nodes, $wpdb->get_results($sql, ARRAY_A));
+      }
+
+      // Add nodes connected by outgoing has_left links
+      if ($node['has_left_outgoing_depth'] < $has_left_outgoing_depth) {
+          $sql = $wpdb->prepare("
+              SELECT *
+              FROM {$table}
+              WHERE entity_id = %d
+          ", $node['left_entity_id']);
+
+          $next_nodes = array_merge($next_nodes, $wpdb->get_results($sql, ARRAY_A));
+      }
+
+      // Add nodes connected by outgoing has_right links
+      if ($node['has_right_outgoing_depth'] < $has_right_outgoing_depth) {
+          $sql = $wpdb->prepare("
+              SELECT *
+              FROM {$table}
+              WHERE entity_id = %d
+          ", $node['right_entity_id']);
+
+          $next_nodes = array_merge($next_nodes, $wpdb->get_results($sql, ARRAY_A));
+      }
+
+      // Add the next nodes to the queue with updated depth values
+      foreach ($next_nodes as $next_node)  {
+        $entity_id = $next_node['entity_id'];
+
+        if (!($visited[$entity_id] ?? false)) {
+          $visited[$entity_id] = true;
+          $next_node['has_left_incoming_depth'] = $node['has_left_incoming_depth'];
+          $next_node['has_right_incoming_depth'] = $node['has_right_incoming_depth'];
+          $next_node['has_left_outgoing_depth'] = $node['has_left_outgoing_depth'];
+          $next_node['has_right_outgoing_depth'] = $node['has_right_outgoing_depth'];
+      
+          if ($next_node['left_entity_id'] == $node['entity_id']) {
+            $next_node['has_left_outgoing_depth']++;
+          }
+          if ($next_node['right_entity_id'] == $node['entity_id']) {
+            $next_node['has_right_outgoing_depth']++;
+          }
+          if ($next_node['left_entity_id'] == $node['left_entity_id']) {
+            $next_node['has_left_incoming_depth']++;
+          }
+          if ($next_node['right_entity_id'] == $node['right_entity_id']) {
+            $next_node['has_right_incoming_depth']++;
+          }
+      
+          $queue[] = $next_node;
+          $subgraph[] = $next_node;
+        }
+      }
+  }
+
+  return $subgraph;
+}
+
+
+/**
+ * Traverse a subgraph using Recursive CTEs in the DB.
+ * This functions is likely unsupported by older versions of the DB.
+ */
+function block_protocol_db_subgraph_query(
+  string $base_where_term,
+  int $has_left_incoming_depth,
+  int $has_right_incoming_depth,
+  int $has_left_outgoing_depth,
+  int $has_right_outgoing_depth
+)
+{
+  global $wpdb;
+
+  $table = get_block_protocol_table_name();
+
+  $selection = block_protocol_entity_selection();
 
   $sql = $wpdb->prepare(
     "WITH RECURSIVE linked_entities AS (
@@ -165,6 +306,40 @@ function get_block_protocol_subgraph(
   );
 
   $subgraph = $wpdb->get_results($sql, ARRAY_A);
+
+  return $subgraph;
+}
+
+function get_block_protocol_subgraph(
+  string $base_where_term,
+  int $has_left_incoming_depth,
+  int $has_right_incoming_depth,
+  int $has_left_outgoing_depth,
+  int $has_right_outgoing_depth
+)
+{
+  global $wpdb;
+  $mysql_recursive_cte_version = "8.0";
+  $mariadb_recursive_cte_version = "10.2";
+
+  $subgraph = [];
+  if (block_protocol_database_at_version($mysql_recursive_cte_version, $mariadb_recursive_cte_version)) {
+    $subgraph = block_protocol_db_subgraph_query(
+      $base_where_term,
+      $has_left_incoming_depth,
+      $has_right_incoming_depth,
+      $has_left_outgoing_depth,
+      $has_right_outgoing_depth
+    );
+  } else {
+    $subgraph = block_protocol_native_subgraph_query(
+      $base_where_term,
+      $has_left_incoming_depth,
+      $has_right_incoming_depth,
+      $has_left_outgoing_depth,
+      $has_right_outgoing_depth
+    );
+  }
 
   block_protocol_maybe_capture_error($wpdb->last_error);
   return $subgraph;

--- a/libs/wordpress-plugin/plugin/trunk/server/block-api-endpoints.php
+++ b/libs/wordpress-plugin/plugin/trunk/server/block-api-endpoints.php
@@ -356,8 +356,10 @@ function get_block_protocol_subgraph(
 )
 {
   global $wpdb;
+  // See https://dev.mysql.com/doc/refman/8.0/en/mysql-nutshell.html
   $mysql_recursive_cte_version = "8.0";
-  $mariadb_recursive_cte_version = "10.2";
+  // See https://mariadb.com/kb/en/mariadb-1022-release-notes/#notable-changes
+  $mariadb_recursive_cte_version = "10.2.2";
 
   $action =
     block_protocol_database_at_version(
@@ -368,11 +370,11 @@ function get_block_protocol_subgraph(
     : "block_protocol_native_subgraph_query";
 
   $subgraph = ($action)(
-      $base_where_term,
-      $has_left_incoming_depth,
-      $has_right_incoming_depth,
-      $has_left_outgoing_depth,
-      $has_right_outgoing_depth,
+    $base_where_term,
+    $has_left_incoming_depth,
+    $has_right_incoming_depth,
+    $has_left_outgoing_depth,
+    $has_right_outgoing_depth,
   );
 
   block_protocol_maybe_capture_error($wpdb->last_error);

--- a/libs/wordpress-plugin/plugin/trunk/server/block-db-table.php
+++ b/libs/wordpress-plugin/plugin/trunk/server/block-db-table.php
@@ -1,10 +1,11 @@
 <?php
 
-const BLOCK_PROTOCOL_MINIMUM_MYSQL_VERSION = "8.0.0";
+const BLOCK_PROTOCOL_MINIMUM_MYSQL_VERSION = "5.7.0";
 const BLOCK_PROTOCOL_MINIMUM_MARIADB_VERSION = "10.2.7";
 
-function block_protocol_is_database_supported()
+function block_protocol_database_at_version(string $mysql_version, string $mariadb_version)
 {
+
   global $wpdb;
   
   $db_version = $wpdb->db_version();
@@ -12,11 +13,16 @@ function block_protocol_is_database_supported()
 
   if (strpos($db_server_info, 'MariaDB') != false) {
     // site is using MariaDB
-    return $db_version >= BLOCK_PROTOCOL_MINIMUM_MARIADB_VERSION;
+    return $db_version >= $mariadb_version;
   } else {
     // site is using MySQL
-    return $db_version >= BLOCK_PROTOCOL_MINIMUM_MYSQL_VERSION;
+    return $db_version >= $mysql_version;
   }
+}
+
+function block_protocol_is_database_supported()
+{
+  return block_protocol_database_at_version(BLOCK_PROTOCOL_MINIMUM_MYSQL_VERSION, BLOCK_PROTOCOL_MINIMUM_MARIADB_VERSION);
 }
 
 function block_protocol_migration_1()


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->
This PR adds a "native" PHP-based graph traversal function that can be dynamically used at runtime if the database is at version (MySQL 8+|MariaDB 10.2.2+)

I haven't changes the minimum version of MariaDB in this PR as `10.2.7` introduced JSON, at `10.2.2` we have migration errors which hopefully can be addressed/adjusted in a follow-up.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204000740778938/1204217937089582/f) _(internal)_

## 🚫 Blocked by

<!-- If the pull request is blocked by anything, list the blockers here. -->
<!-- If applicable, link to them. -->

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- Add new manual graph traversal in PHP
- Dynamically decide what method to use at runtime
- Change version checks in the code to allow checking versions ad-hoc per feature

## 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->

- The docs can now specify supporting a lower version of MySQL for general usage of the app (Have adjusted)

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->
- MariaDB version requirements are a little unclear at the moment, ideally we'd be able to use `longtext` instead of `json` there to allow older version support, but we need to see what we can do about that.

## 🐾 Next steps

<!-- Are there are planned/suggested follow-ups which are related but won't be done in this PR? -->

- [Implement queryEntities for MariaDB - Asana task](https://app.asana.com/0/1203179076056186/1204069269252814/f)

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- Manual test, see video demo below

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

I recommend doing a full end-to-end test with this change. This includes:
- Setting the MySQL version to 5.7.9 (notice not 5.7.8 because 5.7.8 cannot be upgraded to version 8.x directly)
- Setting up the WP instance as usual, configuring an API key and creating 3 code blocks
- Manually adding a relationship in the DB that is something like `code block 1 <- code block 2 -> code block 3`
- Validate the response of `GET /blockprotocol/entities/*CODE BLOCK 1 ENTITY ID*` with 1 depths returns this little subgraph
- Upgrade the MySQL version in the docker-compose to `8` and restart the instance
- Validate that the page still loads and that the above response is identical.

You can also test with changing the `has_right_outgoing` depth to be `0` and only return the link entity

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->


https://user-images.githubusercontent.com/6988668/227957971-2c430c50-2623-4a5b-a64b-5401f9e55075.mp4

