### PR TITLE
Bump WordPress plugin version to 0.0.6

### DIFF
--- a/libs/mock-block-dock/src/version.ts
+++ b/libs/mock-block-dock/src/version.ts
@@ -1,1 +1,1 @@
-export const MOCK_BLOCK_DOCK_VERSION = "0.1.3";
+export const MOCK_BLOCK_DOCK_VERSION = "0.1.4";

--- a/libs/wordpress-plugin/package.json
+++ b/libs/wordpress-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wordpress-plugin",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "description": "Repository for developing the Block Protocol WordPress plugin",
   "homepage": "https://blockprotocol.org/wordpress",

--- a/libs/wordpress-plugin/plugin/trunk/block-protocol.php
+++ b/libs/wordpress-plugin/plugin/trunk/block-protocol.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package blockprotocol
- * @version 0.0.5
+ * @version 0.0.6
  */
 /*
 Plugin Name: Block Protocol
@@ -9,14 +9,14 @@ Plugin URI: https://blockprotocol.org/wordpress
 Description: Access an open, growing ecosystem of high-quality and powerful blocks via the Block Protocol.
 Author: Block Protocol
 Author URI: https://blockprotocol.org/?utm_medium=organic&utm_source=wordpress_plugin-directory_blockprotocol-plugin_author-name
-Version: 0.0.5
+Version: 0.0.6
 Requires at least: 5.6.0
 Tested up to: 6.1.1
 License: AGPL-3.0
 License URI: https://www.gnu.org/licenses/agpl-3.0.en.html
 */
 
-const BLOCK_PROTOCOL_PLUGIN_VERSION = "0.0.5";
+const BLOCK_PROTOCOL_PLUGIN_VERSION = "0.0.6";
 
 if (is_readable(__DIR__ . '/vendor/autoload.php')) {
 	require __DIR__ . '/vendor/autoload.php';

--- a/libs/wordpress-plugin/plugin/trunk/changelog.txt
+++ b/libs/wordpress-plugin/plugin/trunk/changelog.txt
@@ -1,6 +1,6 @@
 == Changelog ==
 
-= Unreleased =
+= 0.0.6 =
 * Support older versions of MySQL (Minimum version is now 5.7.8 down from 8.0)
 
 = 0.0.5 =

--- a/libs/wordpress-plugin/plugin/trunk/readme.txt
+++ b/libs/wordpress-plugin/plugin/trunk/readme.txt
@@ -5,7 +5,7 @@ Tags: block protocol, blocks, gutenberg, gutenberg blocks, block, schema, countd
 Requires at least: 5.6.0
 Tested up to: 6.1.1
 Requires PHP: 7.4
-Stable tag: 0.0.5
+Stable tag: 0.0.6
 License: AGPL-3.0
 License URI: https://www.gnu.org/licenses/agpl-3.0.en.html
 
@@ -84,12 +84,12 @@ Please [contact us](https://blockprotocol.org/contact) or say 'hi!' on our [Disc
 
 <!-- Only the latest release's entry should appear here – the full log should be in changelog.txt -->
 
-= 0.0.5 =
-* Handle blocks being inside an iFrame in editor view (fixes incompatibility with Gutenberg plugin)
+= 0.0.6 =
+* Support older versions of MySQL (Minimum version is now 5.7.8 down from 8.0)
 
 == Upgrade Notice ==
 
 <!-- Upgrade notices describe the reason a user should upgrade. No more than 300 characters. -->
 
-= 0.0.5 =
-Upgrade for compatibility with the Gutenberg plugin
+= 0.0.6 =
+Upgrade for support for older versions of MySQL (new minimum 5.7.8)


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Version number and changelog amendments in order to release the WordPress plugin at version `0.0.6`.