### PR TITLE
Add `openaiCompleteChat` method to sandbox callbacks

### DIFF
--- a/apps/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
+++ b/apps/site/src/pages/api/rewrites/sandboxed-block-demo.api.ts
@@ -196,6 +196,11 @@ const handler: NextApiHandler = async (req, res) => {
           methodName: "completeText",
           payload,
         }),
+        openaiCompleteChat: ({ data: payload }) => handleServiceMessage({
+          providerName: "OpenAI",
+          methodName: "completeChat",
+          payload,
+        }),
         mapboxForwardGeocoding: ({ data: payload }) => handleServiceMessage({
           providerName: "Mapbox",
           methodName: "forwardGeocoding",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR adds the `openaiCompleteChat` method to the sandbox block demo callbacks.

## ❓ How to test this?

Go to the deployment, and try to use the AI Chat block at https://blockprotocol-jjalmoq9x.stage.hash.ai/@hash/blocks/ai-chat

<img width="1709" alt="image" src="https://user-images.githubusercontent.com/42802102/228612678-51d740ed-fa28-4d6d-9f00-20e184074dbb.png">
