### PR TITLE
Add example of block requirements proposal

### DIFF
--- a/libs/block-template-react/package.json
+++ b/libs/block-template-react/package.json
@@ -66,6 +66,22 @@
     "image": "public/block-preview.png",
     "name": "block-template-react",
     "protocol": "0.3",
+    "requirements": {
+      "graph": {
+        "version": "0.3",
+        "messages": {
+          "updateEntity": {
+            "data": {
+              "entityTypeId": [
+                {
+                  "blockEntity": true
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
     "blockEntityType": "https://blockprotocol.org/@blockprotocol/types/entity-type/thing/v/2",
     "codegen": {
       "outputFolder": "src/types/generated",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We want a way of blocks expressing which parts of the protocol they require (or can use), in order that:
1. blocks can be filtered by which features they use, for the purpose of finding blocks of interest
2. an embedding application can determine whether it supports a particular block or not
3. users can give a block permission to use certain modules / features

This PR adds a basic version of the draft proposal to the React block template, and will be expanded with more complex examples and rejection of requests from blocks that they do not specify a requirement for.
<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203179076056186/1202636018097183/f) _(internal)_

## 🚫 Blocked by

- [ ] RFC to detail the proposal
- [ ] Further examples
- [ ] Handle block requirement declaration in Mock Block Dock

## 📜 Does this require a change to the docs?

- The proposal will require amendments to the 'developing a block' docs.

## 🐾 Next steps

- Add requirement declarations to our existing blocks.
