### PR TITLE
Fix Property Type metaschema

### DIFF
--- a/apps/site/public/types/modules/graph/0.3/schema/property-type.json
+++ b/apps/site/public/types/modules/graph/0.3/schema/property-type.json
@@ -32,7 +32,6 @@
   "additionalProperties": false,
   "$defs": {
     "propertyValues": {
-      "$id": "propertyValues",
       "title": "propertyValues",
       "description": "The definition of potential property values, either references to data types, objects made up of more property types, or an array where the items are defined from a set of other property values definitions.",
       "oneOf": [
@@ -48,9 +47,9 @@
             },
             "properties": {
               "$ref": "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type-object"
-            },
-            "minimumProperties": 1
+            }
           },
+          "minProperties": 1,
           "required": ["type", "properties"]
         },
         {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The constraint for the minimum number of properties inside a property type object was in the incorrect place, it also was using the incorrect keyword (`minimumProperties` as opposed to `minProperties`). This fixes this mistake, and removes an `$id` in a sub-schema which seems to cause problems for local `$ref` resolution. The type has been checked with `ajv` and it seems to pass validation now.

Despite this being a breaking change to the schema, we are not treating these sorts of changes as breaking changes to the specification, as its omission was a bug and schemas made which do not satisfy these changes would be considered invalid as opposed to outdated. Importantly, the type-system crate (which is currently treated as the source of truth in usage) had these constraints appropriately applied.