### PR TITLE
Increase WordPress plugin version to 0.0.8, fix MariaDB version checking

### DIFF
--- a/libs/wordpress-plugin/package.json
+++ b/libs/wordpress-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wordpress-plugin",
-  "version": "0.0.6",
+  "version": "0.0.8",
   "private": true,
   "description": "Repository for developing the Block Protocol WordPress plugin",
   "homepage": "https://blockprotocol.org/wordpress",

--- a/libs/wordpress-plugin/plugin/trunk/block-protocol.php
+++ b/libs/wordpress-plugin/plugin/trunk/block-protocol.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package blockprotocol
- * @version 0.0.7
+ * @version 0.0.8
  */
 /*
 Plugin Name: Block Protocol
@@ -9,14 +9,14 @@ Plugin URI: https://blockprotocol.org/wordpress
 Description: Access an open, growing ecosystem of high-quality and powerful blocks via the Block Protocol.
 Author: Block Protocol
 Author URI: https://blockprotocol.org/?utm_medium=organic&utm_source=wordpress_plugin-directory_blockprotocol-plugin_author-name
-Version: 0.0.7
+Version: 0.0.8
 Requires at least: 5.6.0
 Tested up to: 6.2
 License: AGPL-3.0
 License URI: https://www.gnu.org/licenses/agpl-3.0.en.html
 */
 
-const BLOCK_PROTOCOL_PLUGIN_VERSION = "0.0.7";
+const BLOCK_PROTOCOL_PLUGIN_VERSION = "0.0.8";
 
 if (is_readable(__DIR__ . '/vendor/autoload.php')) {
 	require __DIR__ . '/vendor/autoload.php';

--- a/libs/wordpress-plugin/plugin/trunk/changelog.txt
+++ b/libs/wordpress-plugin/plugin/trunk/changelog.txt
@@ -1,7 +1,11 @@
 == Changelog ==
 
+= 0.0.8 =
+* Improved onboarding experience
+* Attempt to re-run migrations where they previously failed, for older dbs now supported
+
 = 0.0.7 =
-* Provider better support for querying with MariaDB
+* Provide better support for querying with MariaDB
 
 = 0.0.6 =
 * Support older versions of MySQL (Minimum version is now 5.7.8 down from 8.0)

--- a/libs/wordpress-plugin/plugin/trunk/readme.txt
+++ b/libs/wordpress-plugin/plugin/trunk/readme.txt
@@ -5,7 +5,7 @@ Tags: block protocol, blocks, gutenberg, gutenberg blocks, block, schema, countd
 Requires at least: 5.6.0
 Tested up to: 6.2
 Requires PHP: 7.4
-Stable tag: 0.0.7
+Stable tag: 0.0.8
 License: AGPL-3.0
 License URI: https://www.gnu.org/licenses/agpl-3.0.en.html
 
@@ -84,12 +84,13 @@ Please [contact us](https://blockprotocol.org/contact) or say 'hi!' on our [Disc
 
 <!-- Only the latest release's entry should appear here – the full log should be in changelog.txt -->
 
-= 0.0.7 =
-* Provider better support for querying with MariaDB
+= 0.0.8 =
+* Improved onboarding experience
+* Attempt to re-run migrations where they previously failed, for older dbs now supported
 
 == Upgrade Notice ==
 
 <!-- Upgrade notices describe the reason a user should upgrade. No more than 300 characters. -->
 
-= 0.0.7 =
-Upgrade for better MariaDB support
+= 0.0.8 =
+Upgrade for older database support and improved onboarding experience

--- a/libs/wordpress-plugin/plugin/trunk/server/block-db-table.php
+++ b/libs/wordpress-plugin/plugin/trunk/server/block-db-table.php
@@ -10,8 +10,9 @@ function block_protocol_database_at_version(string $mysql_version, string $maria
 {
 
   global $wpdb;
-  
-  $db_version = $wpdb->db_version();
+
+  // $wpdb->db_version() can be broken for MariaDB - @see https://core.trac.wordpress.org/ticket/47738
+  $db_version = $wpdb->get_var( 'SELECT VERSION()' );
   $db_server_info = $wpdb->db_server_info();
 
   if (strpos($db_server_info, 'MariaDB') != false) {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Bumps the WordPress plugin version to `0.0.8`, to introduce the new onboarding experience, and re-running migrations for users with older dbs that installed the plugin prior to older db support being introduced.

It also fixes an issue in checking MariaDB version number – MariaDB prefixes its version number with `5.5.5-` as a hack (apparently for [Oracle support](https://www.php.net/manual/en/mysqli.begin-transaction.php#122775)). This is stripped by clients but apparently not in all circumstances – try e.g. a instawp.xyz site, which will report an incompatible MariaDB version number for the plugin despite being compatible, because it appears as 5.5.5-10etc.

This PR therefore updates the check to query the db for its version, which is the approach used by WordPress – see https://core.trac.wordpress.org/ticket/47738

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Run the server and plugin locally per the instructions in `libs/wordpress-plugin/README.md`, or
2. Add this zip to a WP instance
[block-protocol.zip](https://github.com/blockprotocol/blockprotocol/files/11253522/block-protocol.zip)


