### PR TITLE
Improve performance on API keys page

### DIFF
--- a/apps/site/src/pages/account/api-keys-panel.tsx
+++ b/apps/site/src/pages/account/api-keys-panel.tsx
@@ -19,16 +19,11 @@ import { ApiKeysContext } from "./api-keys-panel/api-keys-context";
 import { ApiKeysEmptyState } from "./api-keys-panel/api-keys-empty-state";
 import { ApiKeysList } from "./api-keys-panel/api-keys-list";
 import { ApiKeysLoading } from "./api-keys-panel/api-keys-loading";
-import {
-  ApiKeyProps,
-  ApiKeysContextValue,
-  KeyActionStatus,
-} from "./api-keys-panel/types";
+import { ApiKeyProps, ApiKeysContextValue } from "./api-keys-panel/types";
 
 export const ApiKeysPanel: FunctionComponent = () => {
   const [apiKeys, setApiKeys] = useState<ApiKeyProps[]>([]);
   const [apiKeysLoading, setApiKeysLoading] = useState(true);
-  const [keyActionStatus, setKeyActionStatus] = useState<KeyActionStatus>();
   const [isCreatingNewKey, setIsCreatingNewKey] = useState(false);
   const [newlyCreatedKeyIds, setNewlyCreatedKeyIds] = useState<string[]>([]);
 
@@ -51,23 +46,15 @@ export const ApiKeysPanel: FunctionComponent = () => {
     () => ({
       apiKeys,
       setApiKeys,
-      isCreatingNewKey,
-      setIsCreatingNewKey,
       newlyCreatedKeyIds,
       setNewlyCreatedKeyIds,
-      keyActionStatus,
-      setKeyActionStatus,
       fetchAndSetApiKeys,
     }),
     [
       apiKeys,
       setApiKeys,
-      isCreatingNewKey,
-      setIsCreatingNewKey,
       newlyCreatedKeyIds,
       setNewlyCreatedKeyIds,
-      keyActionStatus,
-      setKeyActionStatus,
       fetchAndSetApiKeys,
     ],
   );
@@ -100,7 +87,10 @@ export const ApiKeysPanel: FunctionComponent = () => {
           ) : shouldRenderEmptyState ? (
             <ApiKeysEmptyState />
           ) : (
-            <ApiKeysList />
+            <ApiKeysList
+              isCreatingNewKey={isCreatingNewKey}
+              onCreatingNewKeyChange={setIsCreatingNewKey}
+            />
           )}
 
           {!isCreatingNewKey && !apiKeysLoading && (

--- a/apps/site/src/pages/account/api-keys-panel/api-keys-list/api-keys-memo-list.tsx
+++ b/apps/site/src/pages/account/api-keys-panel/api-keys-list/api-keys-memo-list.tsx
@@ -1,0 +1,60 @@
+import { Box } from "@mui/material";
+import { Fragment, memo } from "react";
+
+import { ApiKeyProps } from "../types";
+import { ApiKeyTableRow } from "./api-keys-memo-list/api-key-table-row";
+import { MobileApiKeyItem } from "./api-keys-memo-list/mobile-api-key-item";
+
+const ApiKeysMemoList = ({
+  apiKeys,
+  mobile = false,
+  onRevoke,
+  onRename,
+}: {
+  apiKeys: ApiKeyProps[];
+  mobile?: boolean;
+  onRevoke: (publicId: string) => Promise<void>;
+  onRename: (publicId: string, displayName: string) => Promise<void>;
+}) => {
+  if (mobile) {
+    return (
+      <>
+        {apiKeys.map((data, index) => (
+          <Fragment key={data.publicId}>
+            <MobileApiKeyItem
+              apiKey={data}
+              onRevoke={onRevoke}
+              onRename={onRename}
+            />
+            <Box
+              key={`${data.publicId}-divider`}
+              sx={{
+                mt: 3,
+                mb: index < apiKeys.length - 1 ? 3 : 0,
+                borderTop: "1px solid",
+                borderColor: ({ palette }) => palette.gray[30],
+              }}
+            />
+          </Fragment>
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {apiKeys.map((data) => (
+        <ApiKeyTableRow
+          key={data.publicId}
+          apiKey={data}
+          onRevoke={onRevoke}
+          onRename={onRename}
+        />
+      ))}
+    </>
+  );
+};
+
+const ApiKeysMemoListOuter = memo(ApiKeysMemoList);
+
+export { ApiKeysMemoListOuter as ApiKeysMemoList };

--- a/apps/site/src/pages/account/api-keys-panel/api-keys-list/api-keys-memo-list/api-key-table-row/row-actions.tsx
+++ b/apps/site/src/pages/account/api-keys-panel/api-keys-list/api-keys-memo-list/api-key-table-row/row-actions.tsx
@@ -6,7 +6,7 @@ import {
   usePopupState,
 } from "material-ui-popup-state/hooks";
 
-import { FontAwesomeIcon } from "../../../../../components/icons";
+import { FontAwesomeIcon } from "../../../../../../components/icons";
 
 interface RowActionsProps {
   id: string;

--- a/apps/site/src/pages/account/api-keys-panel/shared/key-action-status.tsx
+++ b/apps/site/src/pages/account/api-keys-panel/shared/key-action-status.tsx
@@ -1,0 +1,31 @@
+import { useTheme } from "@mui/material";
+import { useEffect, useRef, useState } from "react";
+
+import { KeyActionStatus } from "../types";
+
+export const useKeyActionStatus = () => {
+  const [keyActionStatus, setKeyActionStatus] = useState<KeyActionStatus>();
+  const theme = useTheme();
+  const query = theme.breakpoints.up("md").replace("@media ", "");
+  const didMatch = useRef<boolean | undefined>();
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(query);
+
+    const onChange = ({ matches }: MediaQueryListEvent | MediaQueryList) => {
+      if (didMatch.current !== matches) {
+        didMatch.current = matches;
+        setKeyActionStatus(undefined);
+      }
+    };
+
+    mediaQuery.addEventListener("change", onChange);
+    onChange(mediaQuery);
+
+    return () => {
+      mediaQuery.removeEventListener("change", onChange);
+    };
+  }, [query]);
+
+  return [keyActionStatus, setKeyActionStatus] as const;
+};

--- a/apps/site/src/pages/account/api-keys-panel/types.ts
+++ b/apps/site/src/pages/account/api-keys-panel/types.ts
@@ -14,21 +14,18 @@ export type KeyActionStatus =
   | undefined;
 
 export interface ApiKeyItemProps {
-  renameApiKeyCard: ReactElement;
-  revokeApiKeyCard: ReactElement;
-  fullKeyValue?: string;
   apiKey: ApiKeyProps;
-  keyAction?: KeyAction;
+  // @todo move into context
+  onRevoke: (publicId: string) => Promise<void>;
+  onRename: (publicId: string, displayName: string) => Promise<void>;
 }
 
 export interface ApiKeysContextValue {
+  // @todo remove from context
   apiKeys: ApiKeyProps[];
   setApiKeys: Dispatch<SetStateAction<ApiKeyProps[]>>;
-  isCreatingNewKey: boolean;
-  setIsCreatingNewKey: Dispatch<SetStateAction<boolean>>;
+  // @todo remove – move into ApiKeyProps
   newlyCreatedKeyIds: string[];
   setNewlyCreatedKeyIds: Dispatch<SetStateAction<string[]>>;
-  keyActionStatus: KeyActionStatus;
-  setKeyActionStatus: Dispatch<SetStateAction<KeyActionStatus>>;
   fetchAndSetApiKeys: () => Promise<void>;
 }


### PR DESCRIPTION
There's still lots to do here (which I've tried to leave comments for), but this indicates sort of what you need to do – storing everything in a single context means every component (and all its children) need to re-render whenever you do any interaction. On my computer, where I have lots of API keys, that's regularly taking 100ms-200ms to do. 