### PR TITLE
Handle blocks with schemas and missing example

### DIFF
--- a/apps/site/src/components/pages/hub/block-data-container.tsx
+++ b/apps/site/src/components/pages/hub/block-data-container.tsx
@@ -120,11 +120,9 @@ export const BlockDataContainer: FunctionComponent<BlockDataContainerProps> = ({
         }
       }
 
-      if (entityProperties) {
-        exampleEntity.properties = entityProperties;
-        setEntity(exampleEntity);
-        return;
-      }
+      exampleEntity.properties = entityProperties ?? {};
+      setEntity(exampleEntity);
+      return;
     }
 
     if (exampleGraph) {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Fixes a bug in the Block Hub whereby if a block has an empty `examples` array (e.g. FAQ, Address), we would throw an error:

```
        `Unable to create a new entity for block ${metadata.name} from its \`examples\` or \`variants\` as it doesn't have an associated schema`,
```

This is because there was an assumption that if the examples array was present, it would contain an example object. This PR handles empty examples array and defaults to an empty properties object.

## 🔗 Related links

- [Slack report ](https://hashintel.slack.com/archives/C02LG39FJAU/p1681809011296369)(internal)

## 🚀 Has this modified a publishable library?

This PR:

- [x] does not modify any publishable blocks or libraries

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  View the FAQ and Address block on the staging deployment