### PR TITLE
Fix repeated submissions of verification codes from magic links

### DIFF
--- a/apps/site/src/components/screens/verification-code-screen.tsx
+++ b/apps/site/src/components/screens/verification-code-screen.tsx
@@ -69,6 +69,8 @@ export const VerificationCodeScreen: FunctionComponent<
 }) => {
   const verificationCodeInputRef = useRef<HTMLInputElement>(null);
 
+  const submittedInitialVerificationCode = useRef<string | null>(null);
+
   useEffect(() => {
     if (verificationCodeInputRef.current) {
       verificationCodeInputRef.current.select();
@@ -120,6 +122,10 @@ export const VerificationCodeScreen: FunctionComponent<
 
   const handleSubmit = useCallback(
     async (code: string) => {
+      if (submitting) {
+        return;
+      }
+
       setTouchedVerificationCodeInput(true);
       setApiSubmittedErrorMessage(undefined);
 
@@ -140,13 +146,17 @@ export const VerificationCodeScreen: FunctionComponent<
         }
       }
     },
-    [onSubmit, submit, userId, verificationCodeId],
+    [onSubmit, submit, submitting, userId, verificationCodeId],
   );
 
   useEffect(() => {
-    if (initialVerificationCode) {
+    if (
+      initialVerificationCode &&
+      initialVerificationCode !== submittedInitialVerificationCode.current
+    ) {
       setTouchedVerificationCodeInput(true);
       setVerificationCode(initialVerificationCode);
+      submittedInitialVerificationCode.current = initialVerificationCode;
       void handleSubmit(initialVerificationCode);
     }
   }, [initialVerificationCode, setVerificationCode, handleSubmit]);

--- a/apps/site/src/pages/signup.page.tsx
+++ b/apps/site/src/pages/signup.page.tsx
@@ -2,7 +2,7 @@ import { faArrowLeft, faUser } from "@fortawesome/free-solid-svg-icons";
 import { Box, Container, Fade, Paper, Typography } from "@mui/material";
 import { NextPage } from "next";
 import { useRouter } from "next/router";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Button } from "../components/button";
 import {
@@ -129,15 +129,15 @@ const SignupPage: NextPage = () => {
     setCurrentScreen("VerificationCode");
   };
 
-  const handleVerificationCodeSubmitted = (
-    loggedInUser: SerializedUser,
-    nextRedirectPath?: string,
-  ) => {
-    if (nextRedirectPath) {
-      setRedirectPath(nextRedirectPath);
-    }
-    setUser(loggedInUser);
-  };
+  const handleVerificationCodeSubmitted = useCallback(
+    (loggedInUser: SerializedUser, nextRedirectPath?: string) => {
+      if (nextRedirectPath) {
+        setRedirectPath(nextRedirectPath);
+      }
+      setUser(loggedInUser);
+    },
+    [setUser],
+  );
 
   return (
     <Box


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR fixes an issuse in the signup screen where a verification code passed in the URL from a magic link is submitted multiple times. This caused signup to fail sometimes, because concurrent requests were each given their own session id in response (i.e. given a new cookie value for `blockprotocol-session-id`), and unless the successful request was the last processed by the browser the user would be left with an unauthenticated session.

While the possibility of submitting the verification code multiple times looks to have been present for a good while, it's possible that this issue has only become an issue recently due to:
1. Recent changes to state / rendering of the signup page and verification code screen causing the 'submit code from url' effect to run more times than it was previously – e.g. https://github.com/blockprotocol/blockprotocol/pull/1246
2. Upgrade to passport `0.0.6` causing the session to be regenerated in circumstances where it wasn't previously (although I'm less sure about this because it looks like it's only supposed to happen on explicit calls to login / logout) – https://github.com/blockprotocol/blockprotocol/pull/996

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

## 🔍 What does this change?

- Tracks the verification code submitted from a url in a ref and prevents it being submitted more than once

And for good measure
- Bails out of the `onSubmit` function if the `submitting` state is `true` (this is insufficient to fix the issue because it doesn't guarantee the same code isn't submitted twice)
- Memoizes a function in the parent component which is used as a dependency of effects (I think the only practical impact of this is to avoid reconstructing `handleSubmit` in `VerificationCodeScreen` unnecessarily, i.e. not much impact)

## 🚀 Has this modified a publishable library?

<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Try creating an account via a magic link a few times and check it works (versus locally where it should fail at least once in a few attempts)

