### PR TITLE
Add retry logic to `fetchTypeAsJson`

### DIFF
--- a/.changeset/lemon-peas-shout.md
+++ b/.changeset/lemon-peas-shout.md
@@ -1,0 +1,5 @@
+---
+"@blockprotocol/graph": patch
+---
+
+Add retry logic around type fetching in codegen

--- a/libs/@blockprotocol/graph/src/codegen/initialize/traverse/fetch.ts
+++ b/libs/@blockprotocol/graph/src/codegen/initialize/traverse/fetch.ts
@@ -1,8 +1,33 @@
 import fetch from "node-fetch";
 
-export const fetchTypeAsJson = (versionedUrl: string) =>
-  fetch(versionedUrl, {
-    headers: {
-      accept: "application/json",
-    },
-  }).then((resp) => resp.json());
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 100;
+
+export const fetchTypeAsJson = async (versionedUrl: string) => {
+  for (let retry = 0; retry < MAX_RETRIES; retry++) {
+    const delay = RETRY_DELAY_MS * retry;
+
+    // This will be 0 for the first iteration, a bit superfluous but keeps the code logic simple
+    await new Promise((resolve) => {
+      setTimeout(resolve, delay);
+    });
+
+    try {
+      const response = await fetch(versionedUrl, {
+        headers: {
+          accept: "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        continue;
+      }
+
+      return await response.json();
+    } catch (err) {
+      if (retry === MAX_RETRIES - 1) {
+        throw err;
+      }
+    }
+  }
+};


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In some circumstances codegen would fail when trying to fetch a type, these failures were intermittent and introduced flakiness. This adds some simple retry logic around `fetchTypeAsJson` to mitigate ones that are spurious.

## 🔗 Related links

N/A

## 🚫 Blocked by

N/A

## 🔍 What does this change?

- Adds retry logic

## 🚀 Has this modified a publishable library?

<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] modifies a **block** that will need publishing
- [ ] does not modify any publishable blocks or libraries
- [ ] I am unsure / need advice

## 📜 Does this require a change to the docs?

No

## ⚠️ Known issues

N/A

## 🐾 Next steps

N/A

## 🛡 What tests cover this?

- `codegen` in the templates should fail if this breaks things

## ❓ How to test this?

Try regenerating some types

## 📹 Demo

CI
