### PR TITLE
Specify @types/react-is version in block templates

### DIFF
--- a/.changeset/heavy-pears-speak.md
+++ b/.changeset/heavy-pears-speak.md
@@ -1,0 +1,6 @@
+---
+"block-template-custom-element": patch
+"block-template-react": patch
+---
+
+specify @types/react-is version

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -133,7 +133,7 @@
     "@types/passport": "^1.0.11",
     "@types/prismjs": "^1.26.0",
     "@types/react": "^18.0.25",
-    "@types/react-dom": "^18.0.9",
+    "@types/react-dom": "18.0.9",
     "@types/react-gtm-module": "^2.0.1",
     "@types/react-html-parser": "^2.0.2",
     "@types/react-slick": "^0.23.10",

--- a/blocks/feature-showcase/package.json
+++ b/blocks/feature-showcase/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@local/eslint-config": "0.0.0-private",
     "@local/tsconfig": "0.0.0-private",
-    "@types/react-dom": "^18.0.9",
+    "@types/react-dom": "18.0.9",
     "block-scripts": "0.2.3",
     "eslint": "8.33.0",
     "mock-block-dock": "0.1.4",

--- a/libs/block-template-custom-element/package.json
+++ b/libs/block-template-custom-element/package.json
@@ -38,7 +38,8 @@
   },
   "devDependencies": {
     "@local/eslint-config": "0.0.0-private",
-    "@types/react-dom": "^18.0.9",
+    "@types/react-dom": "18.0.9",
+    "@types/react-is": "18.2.0",
     "block-scripts": "0.2.3",
     "eslint": "8.33.0",
     "mock-block-dock": "0.1.4",

--- a/libs/block-template-react/package.json
+++ b/libs/block-template-react/package.json
@@ -37,7 +37,8 @@
   },
   "devDependencies": {
     "@local/eslint-config": "0.0.0-private",
-    "@types/react-dom": "^18.0.9",
+    "@types/react-dom": "18.0.9",
+    "@types/react-is": "17.0.3",
     "block-scripts": "0.2.3",
     "eslint": "8.33.0",
     "mock-block-dock": "0.1.4",

--- a/libs/block-template-react/package.json
+++ b/libs/block-template-react/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@local/eslint-config": "0.0.0-private",
     "@types/react-dom": "18.0.9",
-    "@types/react-is": "17.0.3",
+    "@types/react-is": "18.2.0",
     "block-scripts": "0.2.3",
     "eslint": "8.33.0",
     "mock-block-dock": "0.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5478,7 +5478,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@18.0.9", "@types/react-dom@^18.0.9":
+"@types/react-dom@18.0.9":
   version "18.0.9"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.9.tgz#ffee5e4bfc2a2f8774b15496474f8e7fe8d0b504"
   integrity sha512-qnVvHxASt/H7i+XG1U1xMiY5t+IHcPGUK7TDMDzom08xa7e86eCeKOiLZezwCKVxJn6NEiiy2ekgX8aQssjIKg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5478,7 +5478,7 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@^18.0.9":
+"@types/react-dom@18.0.9", "@types/react-dom@^18.0.9":
   version "18.0.9"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.9.tgz#ffee5e4bfc2a2f8774b15496474f8e7fe8d0b504"
   integrity sha512-qnVvHxASt/H7i+XG1U1xMiY5t+IHcPGUK7TDMDzom08xa7e86eCeKOiLZezwCKVxJn6NEiiy2ekgX8aQssjIKg==
@@ -5498,10 +5498,17 @@
     "@types/htmlparser2" "*"
     "@types/react" "*"
 
-"@types/react-is@^16.7.1 || ^17.0.0":
+"@types/react-is@17.0.3", "@types/react-is@^16.7.1 || ^17.0.0":
   version "17.0.3"
   resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-17.0.3.tgz#2d855ba575f2fc8d17ef9861f084acc4b90a137a"
   integrity sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-is@18.2.0":
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-18.2.0.tgz#2f5137853a46017b3d56447940fb3eb92bbf24a5"
+  integrity sha512-1vz2yObaQkLL7YFe/pme2cpvDsCwI1WXIfL+5eLz0MI9gFG24Re16RzUsI8t9XZn9ZWvgLNDrJBmrqXJO7GNQQ==
   dependencies:
     "@types/react" "*"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5498,17 +5498,17 @@
     "@types/htmlparser2" "*"
     "@types/react" "*"
 
-"@types/react-is@17.0.3", "@types/react-is@^16.7.1 || ^17.0.0":
-  version "17.0.3"
-  resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-17.0.3.tgz#2d855ba575f2fc8d17ef9861f084acc4b90a137a"
-  integrity sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==
-  dependencies:
-    "@types/react" "*"
-
 "@types/react-is@18.2.0":
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-18.2.0.tgz#2f5137853a46017b3d56447940fb3eb92bbf24a5"
   integrity sha512-1vz2yObaQkLL7YFe/pme2cpvDsCwI1WXIfL+5eLz0MI9gFG24Re16RzUsI8t9XZn9ZWvgLNDrJBmrqXJO7GNQQ==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-is@^16.7.1 || ^17.0.0":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-17.0.3.tgz#2d855ba575f2fc8d17ef9861f084acc4b90a137a"
+  integrity sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

A new patch version for `@types/react-is` `17.0.4` was released 2 days ago that causes compilation issues in the block templates – see e.g. [this action run](https://github.com/blockprotocol/blockprotocol/actions/runs/4828042358/jobs/8601409864). Probably because it removed `next.d.ts` for some reason, as part of releasing a new `18.2.0` version.

Because the templates don't come with a lock file, they pick up this latest patch version (the first in 2 years) and `tsc` fails in them. This is true of any blocks created now, and means that all CI runs are failing. This was not picked up in CI because it is related to a broken patch version of a dependency being released (or at least one that breaks when used in this context).

This PR fixes the issue by specifying the version of `@types/react-is` to use rather than leaving it up to `yarn` to resolve. I've gone for the latest since it doesn't have compilation issues. 

I've also taken the opportunity to pin the only non-exact dependency in the templates (`@types/react-dom`).

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->


## 🚀 Has this modified a publishable library?

<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**


## 🐾 Next steps

- Release the new versions of the templates via the Version Packages PR.

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

- Action: CI -> NPM Packages

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Check that the action passes

