### PR TITLE
Remove weekly block download aggregation

### DIFF
--- a/apps/site/src/lib/api/blocks/db.ts
+++ b/apps/site/src/lib/api/blocks/db.ts
@@ -11,7 +11,8 @@ export const getDbBlocks = async (filter: { shortname?: string }) => {
     .collection<ExpandedBlockMetadata>(blocksDbCollectionName)
     .find(filter.shortname ? { author: filter.shortname } : {}, {
       projection: defaultProjection,
-    });
+    })
+    .toArray();
 };
 
 export const getDbBlock = async (

--- a/apps/site/src/lib/api/blocks/db.ts
+++ b/apps/site/src/lib/api/blocks/db.ts
@@ -1,45 +1,17 @@
 import { ExpandedBlockMetadata } from "../../blocks";
 import { connectToDatabase } from "../mongodb";
-import { blockDownloadsCollectionName, blocksDbCollectionName } from "./shared";
+import { blocksDbCollectionName } from "./shared";
 
 const defaultProjection = { _id: 0 };
-
-const weeklyDownloadCountAggregationStage = [
-  {
-    $lookup: {
-      from: blockDownloadsCollectionName,
-      let: { id: "$_id" },
-      pipeline: [
-        {
-          $match: {
-            $expr: { $eq: ["$$id", "$blockId"] },
-            downloadedAt: {
-              $gte: new Date(
-                new Date().valueOf() - 7 * 60 * 60 * 24 * 1000,
-              ).toISOString(),
-            },
-          },
-        },
-      ],
-      as: "weeklyDownloads",
-    },
-  },
-  { $addFields: { downloads: { weekly: { $size: "$weeklyDownloads" } } } },
-  { $project: { weeklyDownloads: 0, ...defaultProjection } },
-];
 
 export const getDbBlocks = async (filter: { shortname?: string }) => {
   const { db } = await connectToDatabase();
 
   return db
-    .collection(blocksDbCollectionName)
-    .aggregate<ExpandedBlockMetadata>([
-      {
-        $match: filter.shortname ? { author: filter.shortname } : {},
-      },
-      ...weeklyDownloadCountAggregationStage,
-    ])
-    .toArray();
+    .collection<ExpandedBlockMetadata>(blocksDbCollectionName)
+    .find(filter.shortname ? { author: filter.shortname } : {}, {
+      projection: defaultProjection,
+    });
 };
 
 export const getDbBlock = async (
@@ -52,15 +24,11 @@ export const getDbBlock = async (
 ) => {
   const { db } = await connectToDatabase();
 
-  const results = await db
-    .collection(blocksDbCollectionName)
-    .aggregate<ExpandedBlockMetadata>([
-      { $match: filter },
-      ...weeklyDownloadCountAggregationStage,
-    ])
-    .toArray();
-
-  return results[0] ?? null;
+  return db
+    .collection<ExpandedBlockMetadata>(blocksDbCollectionName)
+    .findOne(filter, {
+      projection: defaultProjection,
+    });
 };
 
 export const insertDbBlock = async (block: ExpandedBlockMetadata) => {

--- a/apps/site/src/lib/api/blocks/get.ts
+++ b/apps/site/src/lib/api/blocks/get.ts
@@ -13,8 +13,8 @@ export const getFeaturedBlocks = async (): Promise<ExpandedBlockMetadata[]> => {
     getDbBlock({ author: "hash", name: "address" }),
     getDbBlock({ author: "hash", name: "how-to" }),
     getDbBlock({ author: "hash", name: "ai-image" }),
-  ]).then((result) =>
-    result.filter((block): block is ExpandedBlockMetadata => !!block),
+  ]).then(
+    (result) => result.filter((block) => !!block) as ExpandedBlockMetadata[],
   );
 };
 

--- a/apps/site/src/lib/blocks.ts
+++ b/apps/site/src/lib/blocks.ts
@@ -30,12 +30,6 @@ export type ExpandedBlockMetadata = BlockMetadata & {
   // the folder where the block's assets are stored, currently doubling up as a unique identifier for the block
   // @todo this needs rethinking when we introduce versions, as there will be multiple asset folders
   componentId: string;
-
-  downloads?: {
-    // minimum number of downloads of a block's source in the last 7 days (excludes cached results)
-    weekly: number;
-  };
-
   // an absolute URL to example-graph.json, if it exists
   exampleGraph?: string | null;
   lastUpdated?: string | null;


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

We have code that aggregates a weekly download count for blocks when a block is requested (either as part of the list of all blocks, or as a single block). We aren't using this and it's adding unnecessary db work (and therefore slowing down queries). 

We can introduce and optimize it when we want to use it (it needs indices adding).

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1203358502199087/1203922830586244/f) _(internal)_


## 🚀 Has this modified a publishable library?

<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

1.  Check that the block hub and an individual block page work 
