### PR TITLE
Manually install `just` instead of using `just-install`

### DIFF
--- a/.github/actions/warm-up-repo/action.yml
+++ b/.github/actions/warm-up-repo/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Install Rust tools
       uses: taiki-e/install-action@v2
       with:
-        tool: wasm-pack@0.11.0
+        tool: just@1.13.0,wasm-pack@0.11.0
 
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "check-dependency-version-consistency": "3.0.3",
     "dotenv-flow": "3.2.0",
     "husky": "8.0.3",
-    "just-install": "^1.0.11",
     "knip": "^1.6.1",
     "lint-staged": "13.1.0",
     "lockfile-lint": "4.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11761,11 +11761,6 @@ jsonschema@^1.4.0:
     array-includes "^3.1.5"
     object.assign "^4.1.3"
 
-just-install@^1.0.11:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/just-install/-/just-install-1.0.11.tgz#157a7f98a3dc8045bcce7669485c9a1c640b1e2f"
-  integrity sha512-3nW53hWK9muHUTXthiTcUqFkd5FXDad7YLoDWJonVhPUZxX8PgCVGvaI8AQ5gqJZ45MBd/hdqg5XPIWPh9Bk/g==
-
 kind-of@^6.0.0, kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

It's likely to be rate-limited in CI when running `just-install`. This manually installs just instead.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204274556967336/1204486732268406/f) _(internal)_

## 🚀 Has this modified a publishable library?

<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] modifies a **block** that will need publishing
- [ ] does not modify any publishable blocks or libraries
- [x] I am unsure / need advice