### PR TITLE
Remove `const` field in `allOf` in entity type meta schema

### DIFF
--- a/apps/site/public/types/modules/graph/0.3/schema/entity-type.json
+++ b/apps/site/public/types/modules/graph/0.3/schema/entity-type.json
@@ -31,8 +31,8 @@
         "type": "object",
         "properties": {
           "$ref": {
-            "type": "string",
-            "const": "https://blockprotocol.org/@blockprotocol/types/entity-type/link/v/1"
+            "$comment": "The versioned URL of a entity type (the $id of the entity type's schema)",
+            "type": "string"
           }
         },
         "required": ["$ref"],


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

To allow more than just the predefined `link` type the constraint on `allOf` needs to be removed.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Asana task](https://app.asana.com/0/1204274556967336/1204588404823943/f) _(internal)_

## 🚀 Has this modified a publishable library?

<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] modifies a **block** that will need publishing
- [ ] does not modify any publishable blocks or libraries
- [x] I am unsure / need advice