### PR TITLE
[BP-22] Ensure correct header scroll position on spec, docs, roadmap, etc pages

### DIFF
--- a/apps/site/src/components/page-sidebar.tsx
+++ b/apps/site/src/components/page-sidebar.tsx
@@ -236,7 +236,10 @@ const SidebarPage: FunctionComponent<SidebarPageProps> = ({
               setSelectedAnchorElement(ref);
             }
           }}
-          scroll={!asPath?.startsWith("/docs") && !asPath?.startsWith("/spec")}
+          scroll={
+            (!asPath?.startsWith("/docs") && !asPath?.startsWith("/spec")) ||
+            !asPath?.startsWith("/roadmap")
+          }
           href={href}
           sx={(theme) => ({
             alignSelf: "flex-start",


### PR DESCRIPTION
🌟 What is the purpose of this PR?
---
Correct header scroll position on spec, docs, roadmap, etc pages
---
🔗  Related links
---
- [Client Issue Link](https://github.com/blockprotocol/blockprotocol/issues/1276)
- Here is the GitStart Ticket for this pull request: [BP-OSS-1276](https://developers.gitstart.com/client/blockprotocol-oss/ticket/BP-OSS-1276)

❓How to test this?
---
https://www.loom.com/share/044308e8737041c497afba7318452db6
---
This code was written and reviewed by GitStart Community. Growing future engineers, one PR at a time.
