### PR TITLE
Add missing Babel plugin dependencies

### DIFF
--- a/.changeset/tasty-kids-enjoy.md
+++ b/.changeset/tasty-kids-enjoy.md
@@ -3,4 +3,4 @@
 "block-scripts": patch
 ---
 
-add @babel/plugin-proposal-private-methods dependency
+add missing babel plugin dependencies

--- a/.changeset/tasty-kids-enjoy.md
+++ b/.changeset/tasty-kids-enjoy.md
@@ -1,0 +1,6 @@
+---
+"mock-block-dock": patch
+"block-scripts": patch
+---
+
+add @babel/plugin-proposal-private-methods dependency

--- a/libs/block-scripts/package.json
+++ b/libs/block-scripts/package.json
@@ -28,6 +28,7 @@
     "@babel/core": "^7.21.0",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.21.0",
+    "@babel/plugin-proposal-private-methods": "7.18.6",
     "@babel/plugin-transform-runtime": "^7.21.0",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.18.6",

--- a/libs/block-scripts/package.json
+++ b/libs/block-scripts/package.json
@@ -29,6 +29,7 @@
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-decorators": "^7.21.0",
     "@babel/plugin-proposal-private-methods": "7.18.6",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.0",
     "@babel/plugin-transform-runtime": "^7.21.0",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.18.6",

--- a/libs/mock-block-dock/package.json
+++ b/libs/mock-block-dock/package.json
@@ -58,6 +58,7 @@
   "devDependencies": {
     "@babel/core": "^7.21.0",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
+    "@babel/plugin-proposal-private-methods": "7.18.6",
     "@babel/plugin-transform-runtime": "^7.21.0",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.18.6",

--- a/libs/mock-block-dock/package.json
+++ b/libs/mock-block-dock/package.json
@@ -59,6 +59,7 @@
     "@babel/core": "^7.21.0",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-private-methods": "7.18.6",
+    "@babel/plugin-proposal-private-property-in-object": "7.21.0",
     "@babel/plugin-transform-runtime": "^7.21.0",
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.18.6",

--- a/libs/mock-block-dock/src/version.ts
+++ b/libs/mock-block-dock/src/version.ts
@@ -1,1 +1,1 @@
-export const MOCK_BLOCK_DOCK_VERSION = "0.1.4";
+export const MOCK_BLOCK_DOCK_VERSION = "0.1.5";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1438,7 +1438,7 @@
     "@babel/helper-skip-transparent-expression-wrappers" "^7.20.0"
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
 
-"@babel/plugin-proposal-private-methods@^7.18.6":
+"@babel/plugin-proposal-private-methods@7.18.6", "@babel/plugin-proposal-private-methods@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.18.6.tgz#5209de7d213457548a98436fa2882f52f4be6bea"
   integrity sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1446,6 +1446,16 @@
     "@babel/helper-create-class-features-plugin" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
 
+"@babel/plugin-proposal-private-property-in-object@7.21.0":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0.tgz#19496bd9883dd83c23c7d7fc45dcd9ad02dfa1dc"
+  integrity sha512-ha4zfehbJjc5MmXBlHec1igel5TJXXLDDRbuJ4+XT2TJcyD9/V1919BA8gMvsdHcNMBy4WBUBiRb3nw/EQUtBw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-create-class-features-plugin" "^7.21.0"
+    "@babel/helper-plugin-utils" "^7.20.2"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
+
 "@babel/plugin-proposal-private-property-in-object@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.18.6.tgz#a64137b232f0aca3733a67eb1a144c192389c503"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1446,7 +1446,7 @@
     "@babel/helper-create-class-features-plugin" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-proposal-private-property-in-object@7.21.0":
+"@babel/plugin-proposal-private-property-in-object@7.21.0", "@babel/plugin-proposal-private-property-in-object@^7.18.6":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0.tgz#19496bd9883dd83c23c7d7fc45dcd9ad02dfa1dc"
   integrity sha512-ha4zfehbJjc5MmXBlHec1igel5TJXXLDDRbuJ4+XT2TJcyD9/V1919BA8gMvsdHcNMBy4WBUBiRb3nw/EQUtBw==
@@ -1454,16 +1454,6 @@
     "@babel/helper-annotate-as-pure" "^7.18.6"
     "@babel/helper-create-class-features-plugin" "^7.21.0"
     "@babel/helper-plugin-utils" "^7.20.2"
-    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
-
-"@babel/plugin-proposal-private-property-in-object@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.18.6.tgz#a64137b232f0aca3733a67eb1a144c192389c503"
-  integrity sha512-9Rysx7FOctvT5ouj5JODjAFAkgGoudQuLPamZb0v1TGLpapdNaftzifU8NTWQm0IRjqoYypdrSmyWgkocDQ8Dw==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.18.6"
-    "@babel/helper-create-class-features-plugin" "^7.18.6"
-    "@babel/helper-plugin-utils" "^7.18.6"
     "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
 
 "@babel/plugin-proposal-unicode-property-regex@^7.18.6", "@babel/plugin-proposal-unicode-property-regex@^7.4.4":


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The recent `7.22` release of Babel removed some plugin dependencies that we were relying on, which broke new block installs and thus CI in this repo, because the block templates don't come with a `yarn.lock` file and were getting the latest release (this isn't a problem running blocks inside the repo because Babel is locked to `7.21`).

This PR adds the missing dependencies.

## 🔗 Related links

- [Example failed CI run](https://github.com/blockprotocol/blockprotocol/actions/runs/5111441235/jobs/9188404775?pr=1255) 

## 🚀 Has this modified a publishable library?

<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x modifies an **npm**-publishable library and **I have added a changeset file(s)**

## 🐾 Next steps

- Merge the Version Packages PR once it is created

## 🛡 What tests cover this?

- CI: NPM Packages