### PR TITLE
Add missing `default` attributes

### DIFF
--- a/libs/@blockprotocol/type-system/crate/src/ontology/data_type/repr.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/data_type/repr.rs
@@ -35,7 +35,7 @@ pub struct DataType {
     id: String,
     title: String,
     #[cfg_attr(target_arch = "wasm32", tsify(optional))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     #[serde(rename = "type")]
     json_type: String,

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/repr.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/repr.rs
@@ -36,7 +36,7 @@ pub struct EntityType {
     id: String,
     title: String,
     #[cfg_attr(target_arch = "wasm32", tsify(optional))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     #[serde(flatten)]
     all_of: repr::AllOf<EntityTypeReference>,

--- a/libs/@blockprotocol/type-system/crate/src/ontology/property_type/repr.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/property_type/repr.rs
@@ -37,7 +37,7 @@ pub struct PropertyType {
     id: String,
     title: String,
     #[cfg_attr(target_arch = "wasm32", tsify(optional))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     #[serde(flatten)]
     one_of: repr::OneOf<PropertyValues>,

--- a/libs/@blockprotocol/type-system/crate/src/ontology/shared/all_of/repr.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/shared/all_of/repr.rs
@@ -9,11 +9,7 @@ use crate::{repr, EntityTypeReference, ParseAllOfError};
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AllOf<T> {
     #[cfg_attr(target_arch = "wasm32", tsify(optional, type = "T[]"))]
-    #[serde(
-        rename = "allOf",
-        default = "Vec::new",
-        skip_serializing_if = "Vec::is_empty"
-    )]
+    #[serde(rename = "allOf", default, skip_serializing_if = "Vec::is_empty")]
     pub elements: Vec<T>,
 }
 

--- a/libs/@blockprotocol/type-system/crate/src/ontology/shared/all_of/repr.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/shared/all_of/repr.rs
@@ -9,7 +9,11 @@ use crate::{repr, EntityTypeReference, ParseAllOfError};
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct AllOf<T> {
     #[cfg_attr(target_arch = "wasm32", tsify(optional, type = "T[]"))]
-    #[serde(rename = "allOf", default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        rename = "allOf",
+        default = "Vec::new",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub elements: Vec<T>,
 }
 

--- a/libs/@blockprotocol/type-system/crate/src/ontology/shared/array/repr.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/shared/array/repr.rs
@@ -24,10 +24,10 @@ pub struct Array<T> {
     r#type: ArrayTypeTag,
     items: T,
     #[cfg_attr(target_arch = "wasm32", tsify(optional))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     min_items: Option<usize>,
     #[cfg_attr(target_arch = "wasm32", tsify(optional))]
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     max_items: Option<usize>,
 }
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Some structs, which derive `Deserialize`, don't properly deserialize if the field is missing. `serde_json` and `serde_yaml` default to this behavior on `Option`, but other crates may/do not.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord, Asana) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- [Discussion](https://www.notion.so/Using-WebAssembly-for-a-Portable-Single-Source-of-Truth-1dffefa1565c4c0e87e1f83786eff398?d=707d1e562630451fa5df041058e6247f&pvs=4#1ceaf8d05d75468a8f428e0f8ce82f56) _(internal)_


## 🚀 Has this modified a publishable library?

<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [ ] modifies an **npm**-publishable library and **I have added a changeset file(s)**
- [ ] modifies a **Cargo**-publishable library and **I have amended the version**
- [ ] modifies a **Cargo**-publishable library, but **it is not yet ready to publish**
- [ ] modifies a **block** that will need publishing
- [x] does not modify any publishable blocks or libraries
- [ ] I am unsure / need advice