### PR TITLE
Add suffix to name of auto-generated data types

### DIFF
--- a/.changeset/soft-years-help.md
+++ b/.changeset/soft-years-help.md
@@ -1,0 +1,7 @@
+---
+"block-template-custom-element": patch
+"@blockprotocol/graph": patch
+"block-template-react": patch
+---
+
+add suffix to auto-generated data types, to avoid name clashes

--- a/blocks/feature-showcase/src/types/generated/block-entity.ts
+++ b/blocks/feature-showcase/src/types/generated/block-entity.ts
@@ -4,9 +4,9 @@
 
 import { Entity } from "@blockprotocol/graph";
 
-import { NamePropertyValue, Text } from "./shared";
+import { NamePropertyValue, TextDataType } from "./shared";
 
-export type { NamePropertyValue, Text };
+export type { NamePropertyValue, TextDataType };
 
 export type BlockEntity = Thing;
 

--- a/blocks/feature-showcase/src/types/generated/company.ts
+++ b/blocks/feature-showcase/src/types/generated/company.ts
@@ -27,7 +27,7 @@ import {
   PersonOutgoingLinkAndTarget,
   PersonOutgoingLinksByLinkEntityTypeId,
   PersonProperties,
-  Text,
+  TextDataType,
 } from "./shared";
 
 export type {
@@ -55,5 +55,5 @@ export type {
   PersonOutgoingLinkAndTarget,
   PersonOutgoingLinksByLinkEntityTypeId,
   PersonProperties,
-  Text,
+  TextDataType,
 };

--- a/blocks/feature-showcase/src/types/generated/person.ts
+++ b/blocks/feature-showcase/src/types/generated/person.ts
@@ -27,7 +27,7 @@ import {
   PersonOutgoingLinkAndTarget,
   PersonOutgoingLinksByLinkEntityTypeId,
   PersonProperties,
-  Text,
+  TextDataType,
 } from "./shared";
 
 export type {
@@ -55,5 +55,5 @@ export type {
   PersonOutgoingLinkAndTarget,
   PersonOutgoingLinksByLinkEntityTypeId,
   PersonProperties,
-  Text,
+  TextDataType,
 };

--- a/blocks/feature-showcase/src/types/generated/shared.ts
+++ b/blocks/feature-showcase/src/types/generated/shared.ts
@@ -27,7 +27,7 @@ export type CompanyProperties = {
 /**
  * An e-mail address.
  */
-export type EMailPropertyValue = Text;
+export type EMailPropertyValue = TextDataType;
 
 export type EmployedBy = Entity<EmployedByProperties> & { linkData: LinkData };
 
@@ -69,7 +69,7 @@ export type LinkProperties = {};
 /**
  * A word or set of words by which something is known, addressed, or referred to.
  */
-export type NamePropertyValue = Text;
+export type NamePropertyValue = TextDataType;
 
 export type Person = Entity<PersonProperties>;
 
@@ -95,4 +95,4 @@ export type PersonProperties = {
 /**
  * An ordered sequence of characters
  */
-export type Text = string;
+export type TextDataType = string;

--- a/libs/@blockprotocol/graph/src/codegen/shared.ts
+++ b/libs/@blockprotocol/graph/src/codegen/shared.ts
@@ -8,7 +8,7 @@ export const primitiveLinkEntityTypeId =
 
 /** The suffix to append to generated types for each class of ontology type */
 export const generatedTypeSuffix = {
-  dataType: "",
+  dataType: "DataType",
   propertyType: "PropertyValue",
   entityType: "Properties",
 };

--- a/libs/block-template-custom-element/src/types/generated/block-entity.ts
+++ b/libs/block-template-custom-element/src/types/generated/block-entity.ts
@@ -11,12 +11,12 @@ export type BlockEntityOutgoingLinkAndTarget = ThingOutgoingLinkAndTarget;
 /**
  * A word or set of words by which something is known, addressed, or referred to.
  */
-export type NamePropertyValue = Text;
+export type NamePropertyValue = TextDataType;
 
 /**
  * An ordered sequence of characters
  */
-export type Text = string;
+export type TextDataType = string;
 
 export type Thing = Entity<ThingProperties>;
 

--- a/libs/block-template-react/src/types/generated/block-entity.ts
+++ b/libs/block-template-react/src/types/generated/block-entity.ts
@@ -11,12 +11,12 @@ export type BlockEntityOutgoingLinkAndTarget = ThingOutgoingLinkAndTarget;
 /**
  * A word or set of words by which something is known, addressed, or referred to.
  */
-export type NamePropertyValue = Text;
+export type NamePropertyValue = TextDataType;
 
 /**
  * An ordered sequence of characters
  */
-export type Text = string;
+export type TextDataType = string;
 
 export type Thing = Entity<ThingProperties>;
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

When generating TypeScript types from ontology type schemas, we want to avoid giving identical names to different types.

Because an entity type and a data type did not have any suffix on their name in the existing code, entity types and data types with identical titles (e.g. `Text`) could end up with identical type names.

This PR fixes that by giving a `DataType` suffix to data types, e.g. `TextDataType`.

## 🚀 Has this modified a publishable library?

<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

