### PR TITLE
BP-34: Fix `allOf` not being extended when entity type is merged with parent

### DIFF
--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/repr.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/repr.rs
@@ -85,6 +85,8 @@ impl EntityType {
                 })?,
         );
 
+        self.all_of.elements.extend(other.all_of.elements);
+
         self.property_object
             .properties
             .extend(other.property_object.properties);


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In [#1296](https://github.com/blockprotocol/blockprotocol/pull/1291) `repr::EntityType::merge_parent` was added but an important bit is missing: recursive merging. E.g. if `A` inherits from `B` and `B` inherits from `C` calling `A.merge_parent(B)` should add C to the `allOf` field.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?
<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?
<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?
<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph