### PR TITLE
BP-31: Make fields in `entity_type::repr` module public

### DIFF
--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/links/repr.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/links/repr.rs
@@ -21,7 +21,7 @@ pub struct Links {
         )
     )]
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub(crate) links: HashMap<String, MaybeOrderedArray<MaybeOneOfEntityTypeReference>>,
+    pub links: HashMap<String, MaybeOrderedArray<MaybeOneOfEntityTypeReference>>,
 }
 
 impl TryFrom<Links> for super::Links {

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/repr.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/repr.rs
@@ -196,7 +196,7 @@ impl From<super::EntityType> for EntityType {
 pub struct EntityTypeReference {
     #[cfg_attr(target_arch = "wasm32", tsify(type = "VersionedUrl"))]
     #[serde(rename = "$ref")]
-    url: String,
+    pub url: String,
 }
 
 impl TryFrom<EntityTypeReference> for super::EntityTypeReference {

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/repr.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/repr.rs
@@ -37,23 +37,23 @@ pub struct EntityType {
     kind: EntityTypeTag,
     #[cfg_attr(target_arch = "wasm32", tsify(type = "VersionedUrl"))]
     #[serde(rename = "$id")]
-    id: String,
-    title: String,
+    pub id: String,
+    pub title: String,
     #[cfg_attr(target_arch = "wasm32", tsify(optional))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    description: Option<String>,
+    pub description: Option<String>,
     #[serde(flatten)]
-    all_of: repr::AllOf<EntityTypeReference>,
+    pub all_of: repr::AllOf<EntityTypeReference>,
     #[cfg_attr(
         target_arch = "wasm32",
         tsify(optional, type = "Record<BaseUrl, any>[]")
     )]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    examples: Vec<HashMap<String, serde_json::Value>>,
+    pub examples: Vec<HashMap<String, serde_json::Value>>,
     #[serde(flatten)]
-    property_object: repr::Object<repr::ValueOrArray<repr::PropertyTypeReference>>,
+    pub property_object: repr::Object<repr::ValueOrArray<repr::PropertyTypeReference>>,
     #[serde(flatten)]
-    links: repr::Links,
+    pub links: repr::Links,
 }
 
 impl EntityType {

--- a/libs/@blockprotocol/type-system/crate/src/ontology/property_type/repr.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/property_type/repr.rs
@@ -87,7 +87,7 @@ impl From<super::PropertyType> for PropertyType {
 pub struct PropertyTypeReference {
     #[cfg_attr(target_arch = "wasm32", tsify(type = "VersionedUrl"))]
     #[serde(rename = "$ref")]
-    url: String,
+    pub url: String,
 }
 
 impl PropertyTypeReference {

--- a/libs/@blockprotocol/type-system/crate/src/ontology/shared/object/repr.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/shared/object/repr.rs
@@ -22,10 +22,10 @@ pub struct Object<T> {
     #[cfg_attr(target_arch = "wasm32", tsify(type = "'object'"))]
     r#type: ObjectTypeTag,
     #[cfg_attr(target_arch = "wasm32", tsify(type = "Record<BaseUrl, T>"))]
-    pub(crate) properties: HashMap<String, T>,
+    pub properties: HashMap<String, T>,
     #[cfg_attr(target_arch = "wasm32", tsify(optional, type = "BaseUrl[]"))]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub(crate) required: Vec<String>,
+    pub required: Vec<String>,
 }
 
 impl<const MIN: usize> TryFrom<Object<repr::ValueOrArray<repr::PropertyTypeReference>>>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

For implementing entity type inheritance it's required to have access to the underlying structure of the schema.

## 🚀 Has this modified a publishable library?

<!-- AT LEAST ONE box must be checked. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries