### PR TITLE
BP-54: Pin GitHub Action SHAs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,7 @@
   "npm": { "minimumReleaseAge": "3 days" },
   "postUpdateOptions": ["yarnDedupeFewer"],
   "rangeStrategy": "bump",
-  "rebaseWhen": "conflicted"
+  "rebaseWhen": "conflicted",
   "semanticCommits": "disabled",
 
   "packageRules": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
   "branchPrefix": "deps/",
   "dependencyDashboard": true,
   "dependencyDashboardApproval": true,
+  "dependencyDashboardOSVVulnerabilitySummary": "none",
   "dependencyDashboardTitle": "🚀 Dependency Updates",
   "npm": { "minimumReleaseAge": "3 days" },
   "postUpdateOptions": ["yarnDedupeFewer"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -42,4 +42,5 @@
       "commitMessageTopic": "Docker tag `{{depName}}`",
       "additionalBranchPrefix": "docker/"
     }
+  ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,5 +41,5 @@
       "matchManagers": ["docker-compose", "dockerfile"],
       "commitMessageTopic": "Docker tag `{{depName}}`",
       "additionalBranchPrefix": "docker/"
-    },
+    }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
   "branchPrefix": "deps/",
   "dependencyDashboard": true,
   "dependencyDashboardApproval": true,
+  "dependencyDashboardTitle": "🚀 Dependency Updates",
   "npm": { "minimumReleaseAge": "3 days" },
   "postUpdateOptions": ["yarnDedupeFewer"],
   "rangeStrategy": "bump",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,44 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
+
   "automerge": true,
+  "branchPrefix": "deps/",
   "dependencyDashboard": true,
   "dependencyDashboardApproval": true,
+  "npm": { "minimumReleaseAge": "3 days" },
   "postUpdateOptions": ["yarnDedupeFewer"],
   "rangeStrategy": "bump",
   "rebaseWhen": "conflicted"
+  "semanticCommits": "disabled",
+
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "commitMessageTopic": "npm package `{{depName}}`",
+      "additionalBranchPrefix": "js/"
+    },
+    {
+      "matchManagers": ["poetry"],
+      "commitMessageTopic": "Python package `{{depName}}`",
+      "additionalBranchPrefix": "py/",
+      "reviewers": ["team:Python"]
+    },
+    {
+      "matchManagers": ["cargo"],
+      "additionalBranchPrefix": "rs/",
+      "reviewers": ["team:Rust"],
+      "commitMessageTopic": "Rust crate `{{depName}}`"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "commitMessageTopic": "GitHub Action `{{depName}}`",
+      "additionalBranchPrefix": "gha/",
+      "pinDigests": true
+    },
+    {
+      "matchManagers": ["docker-compose", "dockerfile"],
+      "commitMessageTopic": "Docker tag `{{depName}}`",
+      "additionalBranchPrefix": "docker/"
+    },
 }


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Following https://github.com/hashintel/hash/pull/2993, superseded by changes in https://github.com/hashintel/hash/pull/2997/files#diff-f82f7d36a61d22f640c25bdb8b0435bf9cb38679d99d5f460753fa668ee7cdb3, we now pin GitHub Actions to their SHAs. For security reasons we want to do the same here in the Þ repo.

Makes minor other updates for consistency with the Renovate config in the HASH repo.

## 🔗 Related links

- Will help address [CWE-1357](https://cwe.mitre.org/data/definitions/1357.html) when corresponding GitHub Actions are then updated.
