### PR TITLE
Bulk-upgrade GitHub actions to `x.x.x` versions

### DIFF
--- a/.github/workflows/algolia-upload-index.yml
+++ b/.github/workflows/algolia-upload-index.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.6.0
 
       - uses: ./.github/actions/warm-up-repo
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

In advance of dependency pinning.
