### PR TITLE
Remove debug logs, fix type RegExp check

### DIFF
--- a/apps/site/src/middleware.page.ts
+++ b/apps/site/src/middleware.page.ts
@@ -31,14 +31,10 @@ export async function middleware(request: NextRequest) {
     );
 
     if (url.host === productionFrontendHost && openingBlockSandboxPage) {
-      // eslint-disable-next-line no-console
-      console.log("redirecting to sandbox", url.host, url.pathname);
       return changeHostAndRedirect(productionSandboxHost);
     }
 
     if (url.host === productionSandboxHost && !openingBlockSandboxPage) {
-      // eslint-disable-next-line no-console
-      console.log("redirecting to production", url.host, url.pathname);
       return changeHostAndRedirect(productionFrontendHost);
     }
   }

--- a/apps/site/src/middleware.page.ts
+++ b/apps/site/src/middleware.page.ts
@@ -5,8 +5,8 @@ import { NextResponse } from "next/server";
 
 import { hardcodedTypes } from "./middleware.page/hardcoded-types";
 import {
+  isValidBlockProtocolVersionedUrl,
   returnTypeAsJson,
-  versionedTypeUrlRegExp,
 } from "./middleware.page/return-types-as-json";
 
 const productionFrontendHost = process.env.NEXT_PUBLIC_FRONTEND_URL
@@ -40,7 +40,7 @@ export async function middleware(request: NextRequest) {
   }
 
   // if this is a /types/* page, serve JSON unless we're asked for HTML (unless it's a hardcoded type – no HTML available)
-  const openingTypePage = Boolean(url.pathname.match(versionedTypeUrlRegExp));
+  const openingTypePage = isValidBlockProtocolVersionedUrl(url.href);
   const htmlRequested = request.headers.get("accept")?.includes("text/html");
   const isHardedCodedType =
     url.href.replace(url.origin, "https://blockprotocol.org") in hardcodedTypes;

--- a/apps/site/src/middleware.page/return-types-as-json.ts
+++ b/apps/site/src/middleware.page/return-types-as-json.ts
@@ -31,8 +31,9 @@ const generateJsonResponse = (object: DataType | EntityType | PropertyType) =>
 export const versionedTypeUrlRegExp =
   /^\/@.+\/types\/(entity-type|data-type|property-type)\/.+\/v\/\d+$/;
 
-const validateVersionedUrl = (url: string): url is VersionedUrl =>
-  !!url.match(versionedTypeUrlRegExp);
+export const isValidBlockProtocolVersionedUrl = (
+  url: string,
+): url is VersionedUrl => !!new URL(url).pathname.match(versionedTypeUrlRegExp);
 
 const getTypeByVersionedUrl = (
   versionedUrl: VersionedUrl,
@@ -52,7 +53,7 @@ const getTypeByVersionedUrl = (
 export const returnTypeAsJson = async (request: NextRequest) => {
   const { url } = request;
 
-  const isUrlValid = validateVersionedUrl(url);
+  const isUrlValid = isValidBlockProtocolVersionedUrl(url);
 
   if (!isUrlValid) {
     return generateErrorResponse(


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Remove debug logs added in #1329 – the issue was a redirect on the domain rather than anything in the application logic. Block pages are working again.

Also fixes a RegExp check which was updated in the same PR to avoid false positives on NextJS 'JSON for page' fetches, but missed a check.
