### PR TITLE
Fix site middleware

### DIFF
--- a/apps/site/src/middleware.page.ts
+++ b/apps/site/src/middleware.page.ts
@@ -7,6 +7,7 @@ import { hardcodedTypes } from "./middleware.page/hardcoded-types";
 import {
   isValidBlockProtocolVersionedUrl,
   returnTypeAsJson,
+  versionedTypeUrlRegExp,
 } from "./middleware.page/return-types-as-json";
 
 const productionFrontendHost = process.env.NEXT_PUBLIC_FRONTEND_URL
@@ -40,7 +41,7 @@ export async function middleware(request: NextRequest) {
   }
 
   // if this is a /types/* page, serve JSON unless we're asked for HTML (unless it's a hardcoded type – no HTML available)
-  const openingTypePage = isValidBlockProtocolVersionedUrl(url.href);
+  const openingTypePage = !!url.pathname.match(versionedTypeUrlRegExp);
   const htmlRequested = request.headers.get("accept")?.includes("text/html");
   const isHardedCodedType =
     url.href.replace(url.origin, "https://blockprotocol.org") in hardcodedTypes;

--- a/apps/site/src/middleware.page.ts
+++ b/apps/site/src/middleware.page.ts
@@ -5,7 +5,6 @@ import { NextResponse } from "next/server";
 
 import { hardcodedTypes } from "./middleware.page/hardcoded-types";
 import {
-  isValidBlockProtocolVersionedUrl,
   returnTypeAsJson,
   versionedTypeUrlRegExp,
 } from "./middleware.page/return-types-as-json";

--- a/apps/site/src/middleware.page/return-types-as-json.ts
+++ b/apps/site/src/middleware.page/return-types-as-json.ts
@@ -31,9 +31,8 @@ const generateJsonResponse = (object: DataType | EntityType | PropertyType) =>
 export const versionedTypeUrlRegExp =
   /^\/@.+\/types\/(entity-type|data-type|property-type)\/.+\/v\/\d+$/;
 
-export const isValidBlockProtocolVersionedUrl = (
-  url: string,
-): url is VersionedUrl => !!new URL(url).pathname.match(versionedTypeUrlRegExp);
+const isValidBlockProtocolVersionedUrl = (url: string): url is VersionedUrl =>
+  !!new URL(url).pathname.match(versionedTypeUrlRegExp);
 
 const getTypeByVersionedUrl = (
   versionedUrl: VersionedUrl,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

#1330 attempted to share logic with the site's middleware to avoid a bug that crept in previously, but this introduced another bug (and was why the logic wasn't shared originally): the function to share imported a package which includes WASM, which is not allowed in the middleware function.