### PR TITLE
GEN-101: Set `poweredByHeader` to `false`

### DIFF
--- a/apps/site/next.config.js
+++ b/apps/site/next.config.js
@@ -13,6 +13,7 @@ const nextConfig = {
     isrMemoryCacheSize: 0,
   },
   pageExtensions: ["page.ts", "page.tsx", "api.ts"],
+  poweredByHeader: false,
   productionBrowserSourceMaps: true,
   swcMinify: true,
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Sets `poweredByHeader` to false in the Block Protocol website's `next.config.js` file.

## 🔗 Related links

- [poweredByHeader](https://nextjs.org/docs/app/api-reference/next-config-js/poweredByHeader) in the `Next.js` docs