### PR TITLE
H-1345: Refactor non-temporal BP methods to always have non-temporal returns

### DIFF
--- a/.changeset/hungry-pears-cough.md
+++ b/.changeset/hungry-pears-cough.md
@@ -2,4 +2,4 @@
 "@blockprotocol/graph": patch
 ---
 
-Ensure non-temporal BP methods have a non-temporal return, even when passed a temporal subgraph. Add `rewriteTypeId` parameter to the codegen script. Gracefully handle non-intersecting edges in `getIncomingLinksForEntity` and `getOutgoingLinksForEntity`.
+Ensure non-temporal BP methods have a non-temporal return, even when passed a temporal subgraph. Add `getFetchUrlFromTypeId` parameter to the codegen script. Gracefully handle non-intersecting edges in `getIncomingLinksForEntity` and `getOutgoingLinksForEntity`.

--- a/.changeset/hungry-pears-cough.md
+++ b/.changeset/hungry-pears-cough.md
@@ -1,0 +1,5 @@
+---
+"@blockprotocol/graph": minor
+---
+
+Ensure non-temporal BP methods have a non-temporal return, even when passed a temporal subgraph. Add `rewriteTypeId` parameter to the codegen script. Gracefully handle non-intersecting edges in `getIncomingLinksForEntity` and `getOutgoingLinksForEntity`.

--- a/.changeset/hungry-pears-cough.md
+++ b/.changeset/hungry-pears-cough.md
@@ -1,5 +1,5 @@
 ---
-"@blockprotocol/graph": minor
+"@blockprotocol/graph": patch
 ---
 
 Ensure non-temporal BP methods have a non-temporal return, even when passed a temporal subgraph. Add `rewriteTypeId` parameter to the codegen script. Gracefully handle non-intersecting edges in `getIncomingLinksForEntity` and `getOutgoingLinksForEntity`.

--- a/libs/@blockprotocol/graph/src/codegen/initialize/traverse-and-collate-schemas.ts
+++ b/libs/@blockprotocol/graph/src/codegen/initialize/traverse-and-collate-schemas.ts
@@ -124,8 +124,14 @@ export const traverseAndCollateSchemas = async (
 
     initialContext.logDebug(`Fetching ${typeId}...`);
 
+    // Rewrite the type ID before attempting to fetch it if a
+    // `rewriteTypeId` function was provided in the parameters
+    const rewrittenTypeId = initialContext.parameters.rewriteTypeId
+      ? initialContext.parameters.rewriteTypeId(typeId)
+      : typeId;
+
     addFetchPromise(
-      fetchTypeAsJson(typeId).then((type) => {
+      fetchTypeAsJson(rewrittenTypeId).then((type) => {
         if (isDataType(type)) {
           initialContext.addDataType(type);
         } else if (isPropertyType(type)) {

--- a/libs/@blockprotocol/graph/src/codegen/initialize/traverse-and-collate-schemas.ts
+++ b/libs/@blockprotocol/graph/src/codegen/initialize/traverse-and-collate-schemas.ts
@@ -125,9 +125,9 @@ export const traverseAndCollateSchemas = async (
     initialContext.logDebug(`Fetching ${typeId}...`);
 
     // Rewrite the type ID before attempting to fetch it if a
-    // `rewriteTypeId` function was provided in the parameters
-    const rewrittenTypeId = initialContext.parameters.rewriteTypeId
-      ? initialContext.parameters.rewriteTypeId(typeId)
+    // `getFetchUrlFromTypeId` function was provided in the parameters
+    const rewrittenTypeId = initialContext.parameters.getFetchUrlFromTypeId
+      ? initialContext.parameters.getFetchUrlFromTypeId(typeId)
       : typeId;
 
     addFetchPromise(

--- a/libs/@blockprotocol/graph/src/codegen/parameters.ts
+++ b/libs/@blockprotocol/graph/src/codegen/parameters.ts
@@ -23,6 +23,7 @@ export type CodegenParameters = {
   typeNameOverrides?: {
     [sourceTypeId: string]: string;
   };
+  rewriteTypeId?: (typeId: VersionedUrl) => VersionedUrl;
   /** Generate look-up maps with aliases for all type URLs */
   typeIdAliases?:
     | { enabled: false }
@@ -174,8 +175,9 @@ export const validateCodegenParameters = (
 
 export type ProcessedCodegenParameters = Omit<
   Required<CodegenParameters>,
-  "targets"
+  "targets" | "rewriteTypeId"
 > & {
+  rewriteTypeId: CodegenParameters["rewriteTypeId"];
   targets: {
     [fileName: string]: {
       sourceTypeIds: VersionedUrl[];
@@ -226,6 +228,7 @@ export const processCodegenParameters = (
 
   return {
     ...parameters,
+    rewriteTypeId: parameters.rewriteTypeId,
     targets,
     typeIdAliases: parameters.typeIdAliases ?? { enabled: true },
     typeNameOverrides: parameters.typeNameOverrides ?? {},

--- a/libs/@blockprotocol/graph/src/codegen/parameters.ts
+++ b/libs/@blockprotocol/graph/src/codegen/parameters.ts
@@ -23,7 +23,12 @@ export type CodegenParameters = {
   typeNameOverrides?: {
     [sourceTypeId: string]: string;
   };
-  rewriteTypeId?: (typeId: VersionedUrl) => VersionedUrl;
+  /**
+   * Enables fetching the schema from a different URL to the one in its schema.
+   * The return of this function will be used as the URL to fetch the type from,
+   * but does NOT affect the id in the generated schema.
+   */
+  getFetchUrlFromTypeId?: (typeId: VersionedUrl) => VersionedUrl;
   /** Generate look-up maps with aliases for all type URLs */
   typeIdAliases?:
     | { enabled: false }
@@ -175,9 +180,9 @@ export const validateCodegenParameters = (
 
 export type ProcessedCodegenParameters = Omit<
   Required<CodegenParameters>,
-  "targets" | "rewriteTypeId"
+  "targets" | "getFetchUrlFromTypeId"
 > & {
-  rewriteTypeId: CodegenParameters["rewriteTypeId"];
+  getFetchUrlFromTypeId: CodegenParameters["getFetchUrlFromTypeId"];
   targets: {
     [fileName: string]: {
       sourceTypeIds: VersionedUrl[];
@@ -228,7 +233,7 @@ export const processCodegenParameters = (
 
   return {
     ...parameters,
-    rewriteTypeId: parameters.rewriteTypeId,
+    getFetchUrlFromTypeId: parameters.getFetchUrlFromTypeId,
     targets,
     typeIdAliases: parameters.typeIdAliases ?? { enabled: true },
     typeNameOverrides: parameters.typeNameOverrides ?? {},

--- a/libs/@blockprotocol/graph/src/codegen/parameters.ts
+++ b/libs/@blockprotocol/graph/src/codegen/parameters.ts
@@ -26,7 +26,7 @@ export type CodegenParameters = {
   /**
    * Enables fetching the schema from a different URL to the one in its schema.
    * The return of this function will be used as the URL to fetch the type from,
-   * but does NOT affect the id in the generated schema.
+   * but does NOT affect the type id in the generated schema.
    */
   getFetchUrlFromTypeId?: (typeId: VersionedUrl) => VersionedUrl;
   /** Generate look-up maps with aliases for all type URLs */

--- a/libs/@blockprotocol/graph/src/non-temporal/stdlib.ts
+++ b/libs/@blockprotocol/graph/src/non-temporal/stdlib.ts
@@ -119,11 +119,18 @@ export const getDataTypesReferencedByPropertyType =
 export const getIncomingLinksForEntity = (
   subgraph: Subgraph,
   entityId: EntityId,
-) => getIncomingLinksForEntityGeneral<false>(subgraph, entityId);
+) =>
+  getIncomingLinksForEntityGeneral<false>(subgraph, entityId, undefined, true);
 export const getLeftEntityForLinkEntity = (
   subgraph: Subgraph,
   entityId: EntityId,
-) => getLeftEntityForLinkEntityGeneral<false>(subgraph, entityId)?.pop();
+) =>
+  getLeftEntityForLinkEntityGeneral<false>(
+    subgraph,
+    entityId,
+    undefined,
+    true,
+  )?.pop();
 export const getOutgoingLinkAndTargetEntities = <
   LinkAndRightEntities extends LinkEntityAndRightEntity[] = LinkEntityAndRightEntity[],
 >(
@@ -133,15 +140,24 @@ export const getOutgoingLinkAndTargetEntities = <
   getOutgoingLinkAndTargetEntitiesGeneral<false, LinkAndRightEntities>(
     subgraph,
     entityId,
+    undefined,
+    true,
   );
 export const getOutgoingLinksForEntity = (
   subgraph: Subgraph,
   entityId: EntityId,
-) => getOutgoingLinksForEntityGeneral<false>(subgraph, entityId);
+) =>
+  getOutgoingLinksForEntityGeneral<false>(subgraph, entityId, undefined, true);
 export const getRightEntityForLinkEntity = (
   subgraph: Subgraph,
   entityId: EntityId,
-) => getRightEntityForLinkEntityGeneral<false>(subgraph, entityId)?.pop();
+) =>
+  getRightEntityForLinkEntityGeneral<false>(
+    subgraph,
+    entityId,
+    undefined,
+    true,
+  )?.pop();
 export const getDataTypeById = getDataTypeByIdGeneral;
 export const getDataTypeByVertexId = getDataTypeByVertexIdGeneral;
 export const getDataTypes = getDataTypesGeneral;

--- a/libs/@blockprotocol/graph/src/shared/stdlib/subgraph/edge/link-entity.ts
+++ b/libs/@blockprotocol/graph/src/shared/stdlib/subgraph/edge/link-entity.ts
@@ -95,12 +95,7 @@ export const getOutgoingLinksForEntity = <Temporal extends boolean>(
             );
 
             if (intersection === null) {
-              throw new Error(
-                `No entity revision was found which overlapped the given edge, subgraph was likely malformed.\n` +
-                  `EntityId: ${linkEntityId}\n` +
-                  `Search Interval: ${JSON.stringify(searchInterval)}\n` +
-                  `Edge Valid Interval: ${JSON.stringify(edgeInterval)}`,
-              );
+              continue;
             }
 
             for (const entity of getEntityRevisionsByEntityId(
@@ -189,12 +184,7 @@ export const getIncomingLinksForEntity = <Temporal extends boolean>(
             );
 
             if (intersection === null) {
-              throw new Error(
-                `No entity revision was found which overlapped the given edge, subgraph was likely malformed.\n` +
-                  `EntityId: ${linkEntityId}\n` +
-                  `Search Interval: ${JSON.stringify(searchInterval)}\n` +
-                  `Edge Valid Interval: ${JSON.stringify(edgeInterval)}`,
-              );
+              continue;
             }
 
             for (const entity of getEntityRevisionsByEntityId(

--- a/libs/@blockprotocol/graph/src/shared/stdlib/subgraph/edge/link-entity.ts
+++ b/libs/@blockprotocol/graph/src/shared/stdlib/subgraph/edge/link-entity.ts
@@ -56,6 +56,7 @@ export const getOutgoingLinksForEntity = <Temporal extends boolean>(
   subgraph: Subgraph<Temporal>,
   entityId: EntityId,
   interval?: Temporal extends true ? TimeInterval : undefined,
+  forceNonTemporal?: boolean,
 ): Entity<Temporal>[] => {
   const searchInterval =
     interval !== undefined
@@ -81,7 +82,7 @@ export const getOutgoingLinksForEntity = <Temporal extends boolean>(
       )
     ) {
       for (const outwardEdge of outwardEdges) {
-        if (isTemporalSubgraph(subgraph)) {
+        if (!forceNonTemporal && isTemporalSubgraph(subgraph)) {
           const outwardEdgeTemporal = outwardEdge as OutwardEdge<true>;
           if (isOutgoingLinkEdge(outwardEdgeTemporal)) {
             const { entityId: linkEntityId, interval: edgeInterval } =
@@ -150,6 +151,7 @@ export const getIncomingLinksForEntity = <Temporal extends boolean>(
   subgraph: Subgraph<Temporal>,
   entityId: EntityId,
   interval?: Temporal extends true ? TimeInterval : undefined,
+  forceNonTemporal?: boolean,
 ): Entity<Temporal>[] => {
   const searchInterval =
     interval !== undefined
@@ -174,7 +176,7 @@ export const getIncomingLinksForEntity = <Temporal extends boolean>(
       )
     ) {
       for (const outwardEdge of outwardEdges) {
-        if (isTemporalSubgraph(subgraph)) {
+        if (!forceNonTemporal && isTemporalSubgraph(subgraph)) {
           const outwardEdgeTemporal = outwardEdge as OutwardEdge<true>;
           if (isIncomingLinkEdge(outwardEdgeTemporal)) {
             const { entityId: linkEntityId, interval: edgeInterval } =
@@ -243,8 +245,9 @@ export const getLeftEntityForLinkEntity = <Temporal extends boolean>(
   subgraph: Subgraph<Temporal>,
   entityId: EntityId,
   interval?: Temporal extends true ? TimeInterval : undefined,
+  forceNonTemporal?: boolean,
 ): Entity<Temporal>[] | undefined => {
-  if (isTemporalSubgraph(subgraph)) {
+  if (!forceNonTemporal && isTemporalSubgraph(subgraph)) {
     const searchInterval =
       interval !== undefined
         ? interval
@@ -317,8 +320,9 @@ export const getRightEntityForLinkEntity = <Temporal extends boolean>(
   subgraph: Subgraph<Temporal>,
   entityId: EntityId,
   interval?: Temporal extends true ? TimeInterval : undefined,
+  forceNonTemporal?: boolean,
 ): Entity<Temporal>[] | undefined => {
-  if (isTemporalSubgraph(subgraph)) {
+  if (!forceNonTemporal && isTemporalSubgraph(subgraph)) {
     const searchInterval =
       interval !== undefined
         ? interval
@@ -391,11 +395,12 @@ export const getOutgoingLinkAndTargetEntities = <
   subgraph: Subgraph<Temporal>,
   entityId: EntityId,
   interval?: Temporal extends true ? TimeInterval : undefined,
+  forceNonTemporal?: boolean,
 ): LinkAndRightEntities => {
   const searchInterval =
     interval ?? getLatestInstantIntervalForSubgraph(subgraph);
 
-  if (isTemporalSubgraph(subgraph)) {
+  if (!forceNonTemporal && isTemporalSubgraph(subgraph)) {
     const outgoingLinkEntities = getOutgoingLinksForEntity(
       subgraph as Subgraph<true>,
       entityId,


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR refactors several non-temporal BP methods to always have non-temporal return types, even when they are passed temporal subgraphs. This fixes blocks that are using non-temporal methods when they receive temporal subgraph from their EA.

This PR also adds previous HASH app patches to the `@blockprotocol/graph` package.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-1345

## 🔍 What does this change?

<!-- Use a bullet list to explain your changes in more detail, if it would be helpful. -->
<!-- If applicable, link to the specific commit.-->

- adds a `forceNonTemporal` optional parameter to the 5 functions in `link-entity.ts`, and sets these to true in `non-temporal/stdlib.ts`
- adds a `rewriteTypeId` parameter to the codegen script (previously patched in the HASH App)
- handles edges with no temporal intersection gracefully in `getIncomingLinksForEntity`/`getOutgoingLinksForEntity` (previously patched for `getOutgoingLinksForEntity` in the HASH app)

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**=

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## ⚠️ Known issues

<!-- Are there known issues / intentionally omitted functionality? Flag them here to save reviewers doing so -->

## 🐾 Next steps

<!-- Are there are planned/suggested follow ups which are related but won't be done in this PR? -->

## 🛡 What tests cover this?

<!-- What automated tests cover this? Existing ones? New ones? None? -->

None

## ❓ How to test this?

<!-- Tell reviewers how they can test the functionality -->

One way of testing this would be to:
1. Use `yarn workspace @blockprotocol/graph link` to make the package available locally
2. Use `yarn workspace @blocks/address link @blockprotocol/graph` to link the package to the Address block in the HASH app, which requires the changes to work
3. Use the address block and refresh the page, which will pass a temporal subgraph to `useEntitySubgraph` and break if a temporal return type is provided instead instead of the non-temporal return, and should work if the non-temporal return is returned.

## 📹 Demo

<!-- Add a screenshot or video showcasing your work -->

<img width="738" alt="image" src="https://github.com/blockprotocol/blockprotocol/assets/42802102/1b25143b-9555-4d18-bdac-7d29db70dd07">

