### PR TITLE
BP-70, BP-59: Implement (de)serialize directly on ontology types

### DIFF
--- a/libs/@blockprotocol/type-system/crate/src/ontology/data_type/mod.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/data_type/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 pub use error::ParseDataTypeError;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     url::{BaseUrl, VersionedUrl},
@@ -12,7 +13,8 @@ pub(in crate::ontology) mod raw;
 #[cfg(target_arch = "wasm32")]
 mod wasm;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "raw::DataType", into = "raw::DataType")]
 pub struct DataType {
     id: VersionedUrl,
     title: String,

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/error.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/error.rs
@@ -32,6 +32,9 @@ pub enum ParseEntityTypeError {
 
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum MergeEntityTypeError {
-    #[error("`{0}` is not contained in the `allOf` property of `{1}`")]
-    NotInAllOf(VersionedUrl, VersionedUrl),
+    #[error("`{parent}` is not contained in the `allOf` property of `{child}`")]
+    DoesNotInheritFrom {
+        child: VersionedUrl,
+        parent: VersionedUrl,
+    },
 }

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/error.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 use tsify::Tsify;
 
 use crate::{
-    url::{ParseBaseUrlError, ParseVersionedUrlError},
+    url::{ParseBaseUrlError, ParseVersionedUrlError, VersionedUrl},
     ParseAllOfError, ParseLinksError, ParsePropertyTypeObjectError,
 };
 
@@ -33,5 +33,5 @@ pub enum ParseEntityTypeError {
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum MergeEntityTypeError {
     #[error("`{0}` is not contained in the `allOf` property of `{1}`")]
-    NotInAllOf(String, String),
+    NotInAllOf(VersionedUrl, VersionedUrl),
 }

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/links/mod.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/links/mod.rs
@@ -13,7 +13,9 @@ use crate::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Links(HashMap<VersionedUrl, MaybeOrderedArray<Option<OneOf<EntityTypeReference>>>>);
+pub struct Links(
+    pub(crate) HashMap<VersionedUrl, MaybeOrderedArray<Option<OneOf<EntityTypeReference>>>>,
+);
 
 impl Links {
     /// Creates a new `Links` object.

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/mod.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/mod.rs
@@ -109,15 +109,16 @@ impl EntityType {
     ///
     /// - [`DoesNotInheritFrom`] if the other entity type is not in the `allOf` field
     ///
-    /// [`DoesNotInheritFrom`]: MergeEntityTypeError::NotInAllOf
+    /// [`DoesNotInheritFrom`]: MergeEntityTypeError::DoesNotInheritFrom
     pub fn merge_parent(&mut self, other: Self) -> Result<(), MergeEntityTypeError> {
         self.inherits_from.elements.remove(
             self.inherits_from
                 .all_of()
                 .iter()
                 .position(|x| x.url == other.id)
-                .ok_or_else(|| {
-                    MergeEntityTypeError::NotInAllOf(other.id.clone(), self.id.clone())
+                .ok_or_else(|| MergeEntityTypeError::DoesNotInheritFrom {
+                    child: self.id.clone(),
+                    parent: other.id.clone(),
                 })?,
         );
 

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/mod.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/mod.rs
@@ -7,20 +7,23 @@ mod wasm;
 use std::collections::{HashMap, HashSet};
 
 pub use error::ParseEntityTypeError;
+use serde::{Deserialize, Serialize};
 
 use crate::{
+    ontology::entity_type::error::MergeEntityTypeError,
     url::{BaseUrl, VersionedUrl},
     AllOf, Links, MaybeOrderedArray, Object, OneOf, PropertyTypeReference, ValidateUrl,
     ValidationError, ValueOrArray,
 };
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "raw::EntityType", into = "raw::EntityType")]
 pub struct EntityType {
     id: VersionedUrl,
     title: String,
     description: Option<String>,
     property_object: Object<ValueOrArray<PropertyTypeReference>>,
-    inherits_from: AllOf<EntityTypeReference>,
+    pub inherits_from: AllOf<EntityTypeReference>,
     links: Links,
     examples: Vec<HashMap<BaseUrl, serde_json::Value>>,
 }
@@ -88,6 +91,56 @@ impl EntityType {
     #[must_use]
     pub const fn examples(&self) -> &Vec<HashMap<BaseUrl, serde_json::Value>> {
         &self.examples
+    }
+
+    /// Merges another entity type into this one.
+    ///
+    /// This will:
+    ///   - remove the other entity type from the `allOf`
+    ///   - merge the `properties` and `required` fields
+    ///   - merge the `links` field
+    ///
+    /// # Notes
+    ///
+    /// - This does not validate the resulting entity type.
+    /// - The `required` field may have a different order after merging.
+    ///
+    /// # Errors
+    ///
+    /// - [`DoesNotInheritFrom`] if the other entity type is not in the `allOf` field
+    ///
+    /// [`DoesNotInheritFrom`]: MergeEntityTypeError::NotInAllOf
+    pub fn merge_parent(&mut self, other: Self) -> Result<(), MergeEntityTypeError> {
+        self.inherits_from.elements.remove(
+            self.inherits_from
+                .all_of()
+                .iter()
+                .position(|x| x.url == other.id)
+                .ok_or_else(|| {
+                    MergeEntityTypeError::NotInAllOf(other.id.clone(), self.id.clone())
+                })?,
+        );
+
+        self.inherits_from
+            .elements
+            .extend(other.inherits_from.elements);
+
+        self.property_object
+            .properties
+            .extend(other.property_object.properties);
+
+        self.property_object.required = self
+            .property_object
+            .required
+            .drain(..)
+            .chain(other.property_object.required)
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+
+        self.links.0.extend(other.links.0);
+
+        Ok(())
     }
 
     #[must_use]
@@ -281,7 +334,9 @@ mod tests {
             None,
         );
 
-        test_property_type_references(&entity_type, []);
+        test_property_type_references(&entity_type, [
+            "https://blockprotocol.org/@alice/types/property-type/built-at/v/1",
+        ]);
 
         test_link_mappings(&entity_type, [
             (

--- a/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/raw.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/entity_type/raw.rs
@@ -1,14 +1,10 @@
-use std::{
-    collections::{HashMap, HashSet},
-    str::FromStr,
-};
+use std::{collections::HashMap, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 #[cfg(target_arch = "wasm32")]
 use tsify::Tsify;
 
 use crate::{
-    ontology::entity_type::error::MergeEntityTypeError,
     raw,
     url::{BaseUrl, ParseVersionedUrlError, VersionedUrl},
     ParseEntityTypeError,
@@ -54,56 +50,6 @@ pub struct EntityType {
     pub property_object: raw::Object<raw::ValueOrArray<raw::PropertyTypeReference>>,
     #[serde(flatten)]
     pub links: raw::Links,
-}
-
-impl EntityType {
-    /// Merges another entity type into this one.
-    ///
-    /// This will:
-    ///   - remove the other entity type from the `allOf`
-    ///   - merge the `properties` and `required` fields
-    ///   - merge the `links` field
-    ///
-    /// # Notes
-    ///
-    /// - This does not validate the resulting entity type.
-    /// - The `required` field may have a different order after merging.
-    ///
-    /// # Errors
-    ///
-    /// - [`DoesNotInheritFrom`] if the other entity type is not in the `allOf` field
-    ///
-    /// [`DoesNotInheritFrom`]: MergeEntityTypeError::NotInAllOf
-    pub fn merge_parent(&mut self, other: Self) -> Result<(), MergeEntityTypeError> {
-        self.all_of.elements.remove(
-            self.all_of
-                .elements
-                .iter()
-                .position(|x| x.url == other.id)
-                .ok_or_else(|| {
-                    MergeEntityTypeError::NotInAllOf(other.id.clone(), self.id.clone())
-                })?,
-        );
-
-        self.all_of.elements.extend(other.all_of.elements);
-
-        self.property_object
-            .properties
-            .extend(other.property_object.properties);
-
-        self.property_object.required = self
-            .property_object
-            .required
-            .drain(..)
-            .chain(other.property_object.required)
-            .collect::<HashSet<_>>()
-            .into_iter()
-            .collect();
-
-        self.links.links.extend(other.links.links);
-
-        Ok(())
-    }
 }
 
 impl TryFrom<EntityType> for super::EntityType {
@@ -226,23 +172,17 @@ mod tests {
             crate::test_data::entity_type::BUILDING_V1,
             None,
         );
-        let church: EntityType = check_serialization_from_str::<EntityType, raw::EntityType>(
+        let mut church: EntityType = check_serialization_from_str::<EntityType, raw::EntityType>(
             crate::test_data::entity_type::CHURCH_V1,
             None,
         );
 
-        let building_repr = raw::EntityType::from(building);
-        let mut church_repr = raw::EntityType::from(church);
-
-        church_repr
-            .merge_parent(building_repr)
+        church
+            .merge_parent(building)
             .expect("merging entity types failed");
 
-        let church_closure =
-            EntityType::try_from(church_repr).expect("entity type closure is not valid");
-
         assert!(
-            church_closure.properties().contains_key(
+            church.properties().contains_key(
                 &BaseUrl::new(
                     "https://blockprotocol.org/@alice/types/property-type/built-at/".to_owned()
                 )
@@ -250,13 +190,13 @@ mod tests {
             )
         );
         assert!(
-            church_closure.properties().contains_key(
+            church.properties().contains_key(
                 &BaseUrl::new(
                     "https://blockprotocol.org/@alice/types/property-type/number-bells/".to_owned()
                 )
                 .expect("invalid url")
             )
         );
-        assert!(church_closure.inherits_from().all_of().is_empty());
+        assert!(church.inherits_from().all_of().is_empty());
     }
 }

--- a/libs/@blockprotocol/type-system/crate/src/ontology/mod.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/mod.rs
@@ -37,7 +37,8 @@ pub use shared::{
 // Re-export the repr contents so they're nicely grouped and so that they're easier to import in
 // a non-ambiguous way where they don't get confused with their non repr counterparts.
 // For example, `import crate::raw` lets you then use `raw::DataType`
-pub mod raw {
+#[allow(unreachable_pub, unused_imports)]
+pub(crate) mod raw {
     pub use super::{
         data_type::raw::{DataType, DataTypeReference},
         entity_type::{

--- a/libs/@blockprotocol/type-system/crate/src/ontology/property_type/mod.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/property_type/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 pub use error::ParsePropertyTypeError;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     url::{BaseUrl, VersionedUrl},
@@ -12,7 +13,8 @@ pub(in crate::ontology) mod raw;
 #[cfg(target_arch = "wasm32")]
 mod wasm;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "raw::PropertyType", into = "raw::PropertyType")]
 pub struct PropertyType {
     id: VersionedUrl,
     title: String,

--- a/libs/@blockprotocol/type-system/crate/src/ontology/shared/all_of/mod.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/shared/all_of/mod.rs
@@ -3,7 +3,7 @@ pub(in crate::ontology) mod raw;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AllOf<T> {
-    elements: Vec<T>,
+    pub elements: Vec<T>,
 }
 
 impl<T> AllOf<T> {

--- a/libs/@blockprotocol/type-system/crate/src/ontology/shared/object/mod.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/shared/object/mod.rs
@@ -7,8 +7,8 @@ use crate::{url::BaseUrl, ValidateUrl, ValidationError};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Object<T, const MIN: usize = 0> {
-    properties: HashMap<BaseUrl, T>,
-    required: Vec<BaseUrl>,
+    pub(crate) properties: HashMap<BaseUrl, T>,
+    pub(crate) required: Vec<BaseUrl>,
 }
 
 impl<T: ValidateUrl, const MIN: usize> Object<T, MIN> {

--- a/libs/@blockprotocol/type-system/crate/src/ontology/shared/object/mod.rs
+++ b/libs/@blockprotocol/type-system/crate/src/ontology/shared/object/mod.rs
@@ -12,15 +12,6 @@ pub struct Object<T, const MIN: usize = 0> {
 }
 
 impl<T: ValidateUrl, const MIN: usize> Object<T, MIN> {
-    /// Creates a new `Object` without validating.
-    #[must_use]
-    pub fn new_unchecked(properties: HashMap<BaseUrl, T>, required: Vec<BaseUrl>) -> Self {
-        Self {
-            properties,
-            required,
-        }
-    }
-
     /// Creates a new `Object` with the given properties and required properties.
     ///
     /// # Errors
@@ -58,6 +49,17 @@ impl<T: ValidateUrl, const MIN: usize> Object<T, MIN> {
         }
 
         Ok(())
+    }
+}
+
+impl<T, const MIN: usize> Object<T, MIN> {
+    /// Creates a new `Object` without validating.
+    #[must_use]
+    pub fn new_unchecked(properties: HashMap<BaseUrl, T>, required: Vec<BaseUrl>) -> Self {
+        Self {
+            properties,
+            required,
+        }
     }
 
     #[must_use]


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

As a quick solution to distinguish between format validation and content validation, the raw module should be made private and the serde implementation should use that internally. This greatly improves the DX around the types.

## 🔍 What does this change?

- Make the `raw` module internal
- move `merge_parent` from `raw::EntityType` to `EntityType`
- Implement `Serialize` and `Deserialize` on `DataType`, `PropertyType`, and `EntityType` via the `raw::` representation
- Make the inheritance field public as this is required downstream. I expect to also make the other fields public but not in this PR as the downstream PR for this PR is already big enough.
- Remove the bound on `ValidateUrl` to read the properties and required field on `Object`

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph