### PR TITLE
BP-72: Fix non-temporal `stdlib` functions

### DIFF
--- a/libs/@blockprotocol/graph/src/non-temporal/stdlib.ts
+++ b/libs/@blockprotocol/graph/src/non-temporal/stdlib.ts
@@ -119,18 +119,11 @@ export const getDataTypesReferencedByPropertyType =
 export const getIncomingLinksForEntity = (
   subgraph: Subgraph,
   entityId: EntityId,
-) =>
-  getIncomingLinksForEntityGeneral<false>(subgraph, entityId, undefined, true);
+) => getIncomingLinksForEntityGeneral<false>(subgraph, entityId);
 export const getLeftEntityForLinkEntity = (
   subgraph: Subgraph,
   entityId: EntityId,
-) =>
-  getLeftEntityForLinkEntityGeneral<false>(
-    subgraph,
-    entityId,
-    undefined,
-    true,
-  )?.pop();
+) => getLeftEntityForLinkEntityGeneral<false>(subgraph, entityId)?.pop();
 export const getOutgoingLinkAndTargetEntities = <
   LinkAndRightEntities extends LinkEntityAndRightEntity[] = LinkEntityAndRightEntity[],
 >(
@@ -146,18 +139,11 @@ export const getOutgoingLinkAndTargetEntities = <
 export const getOutgoingLinksForEntity = (
   subgraph: Subgraph,
   entityId: EntityId,
-) =>
-  getOutgoingLinksForEntityGeneral<false>(subgraph, entityId, undefined, true);
+) => getOutgoingLinksForEntityGeneral<false>(subgraph, entityId);
 export const getRightEntityForLinkEntity = (
   subgraph: Subgraph,
   entityId: EntityId,
-) =>
-  getRightEntityForLinkEntityGeneral<false>(
-    subgraph,
-    entityId,
-    undefined,
-    true,
-  )?.pop();
+) => getRightEntityForLinkEntityGeneral<false>(subgraph, entityId)?.pop();
 export const getDataTypeById = getDataTypeByIdGeneral;
 export const getDataTypeByVertexId = getDataTypeByVertexIdGeneral;
 export const getDataTypes = getDataTypesGeneral;

--- a/libs/@blockprotocol/graph/src/shared/stdlib/subgraph/edge/link-entity.ts
+++ b/libs/@blockprotocol/graph/src/shared/stdlib/subgraph/edge/link-entity.ts
@@ -56,7 +56,6 @@ export const getOutgoingLinksForEntity = <Temporal extends boolean>(
   subgraph: Subgraph<Temporal>,
   entityId: EntityId,
   interval?: Temporal extends true ? TimeInterval : undefined,
-  forceNonTemporal?: boolean,
 ): Entity<Temporal>[] => {
   const searchInterval =
     interval !== undefined
@@ -82,7 +81,7 @@ export const getOutgoingLinksForEntity = <Temporal extends boolean>(
       )
     ) {
       for (const outwardEdge of outwardEdges) {
-        if (!forceNonTemporal && isTemporalSubgraph(subgraph)) {
+        if (isTemporalSubgraph(subgraph)) {
           const outwardEdgeTemporal = outwardEdge as OutwardEdge<true>;
           if (isOutgoingLinkEdge(outwardEdgeTemporal)) {
             const { entityId: linkEntityId, interval: edgeInterval } =
@@ -146,7 +145,6 @@ export const getIncomingLinksForEntity = <Temporal extends boolean>(
   subgraph: Subgraph<Temporal>,
   entityId: EntityId,
   interval?: Temporal extends true ? TimeInterval : undefined,
-  forceNonTemporal?: boolean,
 ): Entity<Temporal>[] => {
   const searchInterval =
     interval !== undefined
@@ -171,7 +169,7 @@ export const getIncomingLinksForEntity = <Temporal extends boolean>(
       )
     ) {
       for (const outwardEdge of outwardEdges) {
-        if (!forceNonTemporal && isTemporalSubgraph(subgraph)) {
+        if (isTemporalSubgraph(subgraph)) {
           const outwardEdgeTemporal = outwardEdge as OutwardEdge<true>;
           if (isIncomingLinkEdge(outwardEdgeTemporal)) {
             const { entityId: linkEntityId, interval: edgeInterval } =
@@ -235,9 +233,8 @@ export const getLeftEntityForLinkEntity = <Temporal extends boolean>(
   subgraph: Subgraph<Temporal>,
   entityId: EntityId,
   interval?: Temporal extends true ? TimeInterval : undefined,
-  forceNonTemporal?: boolean,
 ): Entity<Temporal>[] | undefined => {
-  if (!forceNonTemporal && isTemporalSubgraph(subgraph)) {
+  if (isTemporalSubgraph(subgraph)) {
     const searchInterval =
       interval !== undefined
         ? interval
@@ -310,9 +307,8 @@ export const getRightEntityForLinkEntity = <Temporal extends boolean>(
   subgraph: Subgraph<Temporal>,
   entityId: EntityId,
   interval?: Temporal extends true ? TimeInterval : undefined,
-  forceNonTemporal?: boolean,
 ): Entity<Temporal>[] | undefined => {
-  if (!forceNonTemporal && isTemporalSubgraph(subgraph)) {
+  if (isTemporalSubgraph(subgraph)) {
     const searchInterval =
       interval !== undefined
         ? interval


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The `@blockprotocol/graph` packages exposes 'temporal' and default functions. The temporal functions are meant to be for consumers who need to know about temporal versioning.

In #1349 we updated some functions to force them to behave internally as if the subgraph was not a temporal one, but for _some_ of these functions the distinction is important, because the temporal subgraph has a different edge shape to the non-temporal ones. The only function that needs to be forced into 'non-temporal' mode is the one where the return shape depends on whether it's temporal or not, which these don't (apart from missing some fields on the entity internally, which is fine).

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
