### PR TITLE
H-1868: Remove `completeText` from the wordpress plugin

### DIFF
--- a/libs/wordpress-plugin/package.json
+++ b/libs/wordpress-plugin/package.json
@@ -31,7 +31,7 @@
     "@blockprotocol/core": "0.1.2",
     "@blockprotocol/graph": "0.2.2",
     "@blockprotocol/hook": "0.1.3",
-    "@blockprotocol/service": "0.1.3",
+    "@blockprotocol/service": "0.1.4",
     "@fortawesome/fontawesome-svg-core": "6.4.0",
     "@fortawesome/free-solid-svg-icons": "6.4.0",
     "@lit-labs/react": "1.1.1",

--- a/libs/wordpress-plugin/plugin/trunk/block/edit-or-preview/edit/service-callbacks.tsx
+++ b/libs/wordpress-plugin/plugin/trunk/block/edit-or-preview/edit/service-callbacks.tsx
@@ -126,17 +126,6 @@ export const constructServiceModuleCallbacks = (
         displayToast,
       ),
 
-    /** @todo: remove this when `@blockprotocol/service` is updated */
-    openaiCompleteText: async ({ data }) =>
-      callService(
-        {
-          providerName: "openai",
-          methodName: "completeText",
-          data,
-        },
-        displayToast,
-      ),
-
     /** Mapbox Geocoding API */
 
     mapboxForwardGeocoding: async ({ data }) =>

--- a/libs/wordpress-plugin/yarn.lock
+++ b/libs/wordpress-plugin/yarn.lock
@@ -1171,10 +1171,10 @@
     "@blockprotocol/core" "0.1.2"
     "@blockprotocol/graph" "0.2.2"
 
-"@blockprotocol/service@0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@blockprotocol/service/-/service-0.1.3.tgz#d3ab41b65ca807490e94bd946bfae727575696cc"
-  integrity sha512-APZEYr6cwCAfpABcBg3O4kTJkda7eZDsN7mjWahqXrDrIObVeI6mnnmVQH9lobvDLS/yOCXDUZOIeZPfzX8Zcg==
+"@blockprotocol/service@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@blockprotocol/service/-/service-0.1.4.tgz#1d17227682cc8ab68c5651c1ee4abb7ded9ce52d"
+  integrity sha512-5B+NNIsH1sahTM7FpDT1VQPePfzPmLqydvWKGGPlg6mL9Owziogglc398hXlB91yoJjLTCDDvXQ3ESpyKyWUow==
   dependencies:
     "@blockprotocol/core" "0.1.2"
 


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

<!-- Explain, at a high level, what this does and why. -->
<!-- Use the 'What does this change?' section to list more specific implementation details. -->

This PR removes `completeText` from the wordpress plugin service module, by upgrading `@blockprotocol/service` to the latest version.

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- H-1868

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] I am unsure / need advice

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph