### PR TITLE
BP-79: Add 'icon' and 'labelProperty' to entity type metadata

### DIFF
--- a/.changeset/tall-otters-push.md
+++ b/.changeset/tall-otters-push.md
@@ -1,0 +1,5 @@
+---
+"@blockprotocol/graph": patch
+---
+
+add 'icon' and 'labelProperty' to entity type metadata

--- a/libs/@blockprotocol/graph/src/shared/types/ontology/entity-type.ts
+++ b/libs/@blockprotocol/graph/src/shared/types/ontology/entity-type.ts
@@ -11,7 +11,7 @@ import { OntologyElementMetadata } from "./metadata.js";
 export type EntityTypeWithMetadata = {
   schema: EntityType;
   metadata: OntologyElementMetadata & {
-    labelProperty?: BaseUrl;
+    labelProperty?: BaseUrl | null;
     icon?: string | null;
   };
 };

--- a/libs/@blockprotocol/graph/src/shared/types/ontology/entity-type.ts
+++ b/libs/@blockprotocol/graph/src/shared/types/ontology/entity-type.ts
@@ -1,4 +1,8 @@
-import { EntityType, VersionedUrl } from "@blockprotocol/type-system/slim";
+import {
+  BaseUrl,
+  EntityType,
+  VersionedUrl,
+} from "@blockprotocol/type-system/slim";
 
 import { QueryOperationInput } from "../entity.js";
 import { EntityTypeRootType, Subgraph } from "../subgraph.js";
@@ -6,7 +10,10 @@ import { OntologyElementMetadata } from "./metadata.js";
 
 export type EntityTypeWithMetadata = {
   schema: EntityType;
-  metadata: OntologyElementMetadata;
+  metadata: OntologyElementMetadata & {
+    labelProperty?: BaseUrl;
+    icon?: string | null;
+  };
 };
 
 export type QueryEntityTypesData = {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Adds two optional new fields to the metadata for Entity Types:
1. `icon`: a `string` representing the entity type's icon. either an emoji or a URL to an image file
2. `labelProperty`: a `BaseUrl` representing the property on an entity of the type that should be used to label it for display

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:

- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] require changes to docs which are **not** made in this PR


### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph

## 🐾 Next steps

Once merged, publish a new version of the library, and handle `labelProperty` in the type editor.
