### PR TITLE
H-2305: Remove `GitHub Blocks` from planned environments

### DIFF
--- a/apps/site/src/_pages/docs/1_blocks/01_environments.mdx
+++ b/apps/site/src/_pages/docs/1_blocks/01_environments.mdx
@@ -19,10 +19,6 @@ The [Block Protocol for Wordpress](https://blockprotocol.org/wordpress) plugin a
 
 ### Planned environments
 
-#### GitHub Blocks
-
-We aim to ensure that blocks developed in accordance with the Block Protocol spec can be used within GitHub markdown READMEs interactively, and elsewhere on _GitHub.com_. Currently blocks are only available for use within GitHub as part of the _GitHub Next_ early release program. We are in the early stages of determining what possible support might look like.
-
 #### Figma
 
 **We are planning support for Block Protocol blocks in both _Figma_ and _Figjam_.** Development has not yet begun. If you are interested in getting involved, please let us know on [our Discord](https://blockprotocol.org/discord).

--- a/apps/site/src/_pages/docs/3_services.mdx
+++ b/apps/site/src/_pages/docs/3_services.mdx
@@ -4,7 +4,7 @@
 
 Providers may offer third-party **services**, external to the Block Protocol, which blocks can reach out to and utilize, to provide additional or improved functionality.
 
-An example service is the **OpenAI ChatGPT** API, also known as _GPT-3.5 Turbo_.
+Example services include the **OpenAI ChatGPT** APIs, also known as _GPT-3.5 Turbo_, _GPT-4_ and _GPT-4.5 Turbo_.
 
 The Block Protocol defines a standardized way for blocks to access external services. If an embedding application directly integrates with that service, it can take over handling of the request. If it does not, the block will fall back to processing the request via the Block Protocol itself, which supports a number of different services. These include many of _OpenAI_ and _Mapbox_'s public current public APIs.
 

--- a/apps/site/src/components/pages/home/supported-applications.tsx
+++ b/apps/site/src/components/pages/home/supported-applications.tsx
@@ -12,11 +12,7 @@ import { ReactNode } from "react";
 
 import supportedApplicationsFullImage from "../../../../public/assets/new-home/supported-applications-full-min.webp";
 import { FadeInOnViewport } from "../../fade-in-on-viewport";
-import {
-  FontAwesomeIcon,
-  HashIcon,
-  WordPressIcon,
-} from "../../icons";
+import { FontAwesomeIcon, HashIcon, WordPressIcon } from "../../icons";
 import { ArrowUpRightFromSquareIcon } from "../../icons/arrow-up-right-from-square-icon";
 import { BoxesStackedIcon } from "../../icons/boxes-stacked-icon";
 import { BrowserIcon } from "../../icons/browser-icon";
@@ -183,7 +179,7 @@ export const SupportedApplications = () => {
               >
                 Planned
               </Typography>
-
+              <Stack gap={2.5} flexDirection="row" justifyContent="center">
                 <IconButtonWithTooltip
                   href="/docs/blocks/environments#figma"
                   label="Figma"
@@ -291,8 +287,8 @@ export const SupportedApplications = () => {
               >
                 Rather than develop blocks separately for multiple platforms,
                 build your block once and let users access them in{" "}
-                <strong>HASH, WordPress</strong> and{" "}<strong>Figma
-                </strong> (planned).
+                <strong>HASH, WordPress</strong> and <strong>Figma</strong>{" "}
+                (planned).
               </Typography>
 
               <Box>

--- a/apps/site/src/components/pages/home/supported-applications.tsx
+++ b/apps/site/src/components/pages/home/supported-applications.tsx
@@ -14,7 +14,6 @@ import supportedApplicationsFullImage from "../../../../public/assets/new-home/s
 import { FadeInOnViewport } from "../../fade-in-on-viewport";
 import {
   FontAwesomeIcon,
-  GithubIcon,
   HashIcon,
   WordPressIcon,
 } from "../../icons";
@@ -182,22 +181,8 @@ export const SupportedApplications = () => {
                 }}
                 variant="bpSmallCaps"
               >
-                Coming soon
+                Planned
               </Typography>
-
-              <Stack gap={2.5} flexDirection="row" justifyContent="center">
-                <IconButtonWithTooltip
-                  href="/docs/blocks/environments#github-blocks"
-                  label="GitHub Blocks"
-                  icon={
-                    <GithubIcon
-                      sx={{
-                        fill: ({ palette }) => palette.gray[90],
-                        fontSize: 54,
-                      }}
-                    />
-                  }
-                />
 
                 <IconButtonWithTooltip
                   href="/docs/blocks/environments#figma"
@@ -306,8 +291,8 @@ export const SupportedApplications = () => {
               >
                 Rather than develop blocks separately for multiple platforms,
                 build your block once and let users access them in{" "}
-                <strong>HASH, WordPress, GitHub Blocks</strong> and{" "}
-                <strong>Figma</strong> (coming soon).
+                <strong>HASH, WordPress</strong> and{" "}<strong>Figma
+                </strong> (planned).
               </Typography>
 
               <Box>


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Following the end of GitHub Next's `GitHub Blocks` experiment, planned support from the Block Protocol has been scrapped.
