### PR TITLE
H-2387: Fix `@blockprotocol/graph` to account for draftIds

### DIFF
--- a/.changeset/gorgeous-horses-pull.md
+++ b/.changeset/gorgeous-horses-pull.md
@@ -1,0 +1,5 @@
+---
+"@blockprotocol/graph": patch
+---
+
+account for draft entities when looking for a link's right entity in subgraph

--- a/libs/@blockprotocol/graph/src/shared/stdlib/subgraph/element/entity.ts
+++ b/libs/@blockprotocol/graph/src/shared/stdlib/subgraph/element/entity.ts
@@ -46,14 +46,24 @@ const getRevisionsForEntity = <Temporal extends boolean>(
     return entityRevisions;
   }
 
-  // check for the presence of draft versions of the entity in the subgraph
+  if (entityId.split("~")[2]) {
+    /**
+     * This entityId contains a draftId, and so we would have already found it via vertices[entityId] if it exists
+     */
+    return undefined;
+  }
+
+  /**
+   * We haven't found the exact entityId in the subgraph, but it might be qualified by a draftId
+   * – check for vertices which are keyed by a qualified version of the provided entityId
+   */
   const draftEntityIds = Object.keys(subgraph.vertices).filter((id) =>
     id.startsWith(`${entityId}~`),
   );
 
   if (draftEntityIds.length > 0) {
     /**
-     * Return a combined version of all the draft editions of this entity present in the subgraph.
+     * Return a combined object of all the draft editions of this entity present in the subgraph.
      * There may be multiple draft editions with the same timestamp, if:
      * 1. There are multiple draft series for the entity (i.e. multiple draftId where `${baseEntityId}~${draftId}`)
      * AND

--- a/libs/mock-block-dock/src/version.ts
+++ b/libs/mock-block-dock/src/version.ts
@@ -1,1 +1,1 @@
-export const MOCK_BLOCK_DOCK_VERSION = "0.1.6";
+export const MOCK_BLOCK_DOCK_VERSION = "0.1.9";


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Account for an entity potentially being keyed by an entityId that has a suffix indicating it's a draft – part of ongoing evolution of the spec to be reflected back into docs once stable. 

## 🔗 Related links

<!-- Add links to any context it is worth capturing (e.g. Issues, Discussions, Discord) -->
<!-- Mark any links which are not publicly accessible as _(internal)_ -->
<!-- Don't rely on links to explain the PR, especially internal ones: use the sections above -->

- Used in https://github.com/hashintel/hash/pull/4166

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

<!-- Confirm you have taken the necessary action to record a changeset or publish a change, as appropriate -->
<!-- Tick AT LEAST ONE box and delete the rest. Do not delete this section! see libs/README.md for info on publishing -->

This PR:


- [x] modifies an **npm**-publishable library and **I have added a changeset file(s)**

### 📜 Does this require a change to the docs?

<!-- If this adds a user facing feature or modifies how an existing feature is used, it likely needs a docs change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:


- [x] are in a state where docs changes are not _yet_ required but will be

### 🕸️ Does this require a change to the Turbo Graph?

<!-- If this adds or moves an existing package, modifies `scripts` in a `package.json`, it likely needs a turbo graph change. -->
<!-- Tick ONE box and delete the rest. Do not delete this section! -->

The changes in this PR:

- [x] do not affect the execution graph
