### PR TITLE
BP-106: Update and add `.nvmrc` files

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/gallium
+lts/hydrogen

--- a/apps/site/.nvmrc
+++ b/apps/site/.nvmrc
@@ -1,0 +1,1 @@
+lts/hydrogen

--- a/libs/@blockprotocol/design-system/.nvmrc
+++ b/libs/@blockprotocol/design-system/.nvmrc
@@ -1,0 +1,1 @@
+lts/hydrogen


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Makes `fnm` and other Node version managers function correctly, while correcting the existing declaration (16 gallium -> 18 hydrogen) for the BP root, user-facing website, and design system.