### PR TITLE
BP-110: Update ontology type meta-schemas

### DIFF
--- a/apps/site/public/types/modules/graph/0.3/schema/data-type.json
+++ b/apps/site/public/types/modules/graph/0.3/schema/data-type.json
@@ -20,54 +20,45 @@
     "description": {
       "type": "string"
     },
-    "type": {
-      "type": "string"
+    "allOf": {
+      "$comment": "Present if this data type has a parent data type.",
+      "type": "array",
+      "items": {
+        "$ref": "https://blockprotocol.org/types/modules/graph/0.3/schema/data-type-reference"
+      },
+      "minItems": 1
     }
   },
-  "required": ["$schema", "kind", "$id", "title", "type"],
-  "$comment": "The following `oneOf` only ensures, that no custom data types are allowed yet",
+  "required": ["$schema", "kind", "$id", "title", "description"],
   "oneOf": [
     {
-      "properties": {
-        "$id": {
-          "const": "https://blockprotocol.org/@blockprotocol/types/data-type/null/v/1"
-        }
-      }
+      "$ref": "#/$defs/ValueConstraint"
     },
     {
       "properties": {
-        "$id": {
-          "const": "https://blockprotocol.org/@blockprotocol/types/data-type/boolean/v/1"
-        }
-      }
-    },
-    {
-      "properties": {
-        "$id": {
-          "const": "https://blockprotocol.org/@blockprotocol/types/data-type/number/v/1"
-        }
-      }
-    },
-    {
-      "properties": {
-        "$id": {
-          "const": "https://blockprotocol.org/@blockprotocol/types/data-type/text/v/1"
-        }
-      }
-    },
-    {
-      "properties": {
-        "$id": {
-          "const": "https://blockprotocol.org/@blockprotocol/types/data-type/object/v/1"
-        }
-      }
-    },
-    {
-      "properties": {
-        "$id": {
-          "const": "https://blockprotocol.org/@blockprotocol/types/data-type/empty-list/v/1"
-        }
-      }
+        "anyOf": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ValueConstraint"
+          },
+          "minItems": 1
+        },
+        "type": false
+      },
+      "required": ["anyOf"]
     }
-  ]
+  ],
+  "$defs": {
+    "ValueConstraint": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["null", "boolean", "number", "string", "array", "string"]
+        },
+        "anyOf": false
+      },
+      "required": ["type"]
+    }
+  }
 }

--- a/apps/site/public/types/modules/graph/0.3/schema/entity-type.json
+++ b/apps/site/public/types/modules/graph/0.3/schema/entity-type.json
@@ -21,31 +21,31 @@
     "title": {
       "type": "string"
     },
+    "titlePlural": {
+      "type": "string"
+    },
+    "inverse": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "titlePlural": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
     "description": {
       "type": "string"
     },
     "allOf": {
-      "$comment": "Present if this entity type is a link entity type.",
+      "$comment": "Present if this entity type is a parent entity type.",
       "type": "array",
       "items": {
-        "type": "object",
-        "properties": {
-          "$ref": {
-            "$comment": "The versioned URL of a entity type (the $id of the entity type's schema)",
-            "type": "string"
-          }
-        },
-        "required": ["$ref"],
-        "additionalProperties": false
+        "$ref": "https://blockprotocol.org/types/modules/graph/0.3/schema/entity-type-reference"
       },
-      "maxItems": 1
-    },
-    "examples": {
-      "$comment": "Example Entity instances",
-      "type": "array",
-      "items": {
-        "type": "object"
-      }
+      "minItems": 1
     },
     "properties": {
       "$ref": "https://blockprotocol.org/types/modules/graph/0.3/schema/property-type-object"
@@ -69,10 +69,6 @@
             "type": {
               "const": "array"
             },
-            "ordered": {
-              "type": "boolean",
-              "default": false
-            },
             "items": {
               "$ref": "#/$defs/oneOfEntityTypeReference"
             },
@@ -85,14 +81,28 @@
               "minimum": 0
             }
           },
-          "required": ["type", "ordered", "items"],
+          "required": ["type", "items"],
           "additionalProperties": false
         }
       }
+    },
+    "labelProperty": {
+      "$ref": "https://blockprotocol.org/types/modules/graph/0.3/schema/base-url"
+    },
+    "icon": {
+      "type": "string"
     }
   },
   "additionalProperties": false,
-  "required": ["$schema", "kind", "type", "$id", "title", "properties"],
+  "required": [
+    "$schema",
+    "kind",
+    "type",
+    "$id",
+    "title",
+    "description",
+    "properties"
+  ],
   "$defs": {
     "oneOfEntityTypeReference": {
       "description": "Specifies a set of entity types inside a oneOf",

--- a/apps/site/public/types/modules/graph/0.3/schema/property-type.json
+++ b/apps/site/public/types/modules/graph/0.3/schema/property-type.json
@@ -28,7 +28,7 @@
       }
     }
   },
-  "required": ["$schema", "kind", "$id", "title", "oneOf"],
+  "required": ["$schema", "kind", "$id", "title", "description", "oneOf"],
   "additionalProperties": false,
   "$defs": {
     "propertyValues": {


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

The ontology types are outdated. This updates the schemas so it reflects a more up-to-date state.

## 🔍 What does this change?

**Entity type**:
- Make `description` required
- Change `allOf` from `maxItems` to `minItems` (if specified we want at least one element, and we don’t limit the upper limit)
- Add `titlePlural`
- Add `labelProperty`
- Add `icon`
- Add `inverse: { title, titlePlural }`
- Remove `ordered`

**Property type**:
- Make `description` required

**Data type**:
- Make `description` required
- Add `ValueConstraint` (required type as enum)
- Add `oneOf` over `ValueConstraint` or `anyOf: ValueConstraint[]`
- Add `allOf`