### PR TITLE
GEN-110: Fix data type schema

### DIFF
--- a/apps/site/public/types/modules/graph/0.3/schema/data-type.json
+++ b/apps/site/public/types/modules/graph/0.3/schema/data-type.json
@@ -54,7 +54,7 @@
       "properties": {
         "type": {
           "type": "string",
-          "enum": ["null", "boolean", "number", "string", "array", "string"]
+          "enum": ["null", "boolean", "number", "string", "array", "object"]
         },
         "anyOf": false
       },


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

https://github.com/blockprotocol/blockprotocol/pull/1427 had a typo and `string` was specified twice. Instead, `object` was missing.