### PR TITLE
BP-132: Strip `console.log` from prod Next.js environment

### DIFF
--- a/apps/site/next.config.js
+++ b/apps/site/next.config.js
@@ -8,6 +8,9 @@ const withBundleAnalyzer = (await import("@next/bundle-analyzer")).default({
 
 /** @type {import("next").NextConfig} */
 const nextConfig = {
+  compiler: {
+    removeConsole: process.env.NODE_ENV === "production",
+  },
   experimental: {
     // @see `deleteIsrFilesCreatedAfterNextBuild()` for rationale
     isrMemoryCacheSize: 0,

--- a/apps/site/next.config.js
+++ b/apps/site/next.config.js
@@ -9,7 +9,10 @@ const withBundleAnalyzer = (await import("@next/bundle-analyzer")).default({
 /** @type {import("next").NextConfig} */
 const nextConfig = {
   compiler: {
-    removeConsole: process.env.NODE_ENV === "production",
+    removeConsole:
+      process.env.NODE_ENV === "production"
+        ? { exclude: ["error", "warn"] }
+        : false,
   },
   experimental: {
     // @see `deleteIsrFilesCreatedAfterNextBuild()` for rationale


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

This PR configures the Next.js application to automatically strip `console.log` statements from production builds, improving performance and reducing bundle size when deployed to Vercel.

## 🔍 What does this change?

-   Adds the `compiler.removeConsole: process.env.NODE_ENV === "production"` option to `apps/site/next.config.js`.
    -   This leverages the Next.js SWC compiler to remove all `console.` statements (other than `console.warn` and `console.error`) during the build process when `NODE_ENV` is set to "production".
    -   Console logs will remain active during development.

## Pre-Merge Checklist 🚀

### 🚢 Has this modified a publishable library?

This PR:

-   [x] does not modify any publishable blocks or libraries, or modifications do not need publishing

### 📜 Does this require a change to the docs?

The changes in this PR:

-   [x] are internal and do not require a docs change

### 🕸️ Does this require a change to the Turbo Graph?

The changes in this PR:

-   [x] do not affect the execution graph

## ❓ How to test this?

1.  Checkout the branch.
2.  Build the `site` application in production mode (e.g., `NODE_ENV=production next build`).
3.  Inspect the generated JavaScript bundles to confirm `console.log` statements are absent.
4.  Alternatively, deploy to a Vercel preview environment and verify that console logs do not appear in the browser console for the production build.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc395502-10b2-4a03-afef-19fb8018a7a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bc395502-10b2-4a03-afef-19fb8018a7a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

