### PR TITLE
H-6436: Fix frontend build

### DIFF
--- a/apps/site/vercel-install.sh
+++ b/apps/site/vercel-install.sh
@@ -5,10 +5,17 @@ set -euxo pipefail
 # Change to the root directory
 pushd "$(git rev-parse --show-toplevel)"
 
-# Install dependencies
+# Install just
 curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sh -s -- --to /usr/local/bin
+
+# Install an isolated Rust toolchain so it doesn't clash with Vercel's /rust install
+export RUSTUP_HOME="$PWD/.vercel-rustup"
+export CARGO_HOME="$PWD/.vercel-cargo"
+export PATH="$CARGO_HOME/bin:$PATH"
+export RUSTUP_INIT_SKIP_PATH_CHECK=yes
+
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2023-10-08
-source "$HOME/.cargo/env"
+source "$CARGO_HOME/env"
 
 # Run `yarn`
 yarn install

--- a/apps/site/vercel-install.sh
+++ b/apps/site/vercel-install.sh
@@ -14,7 +14,7 @@ export CARGO_HOME="$PWD/.vercel-cargo"
 export PATH="$CARGO_HOME/bin:$PATH"
 export RUSTUP_INIT_SKIP_PATH_CHECK=yes
 
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2023-10-08
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly-2025-10-08
 source "$CARGO_HOME/env"
 
 # Run `yarn`


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Updates `vercel-install.sh` to avoid clashes with Vercel Rust installation, which was causing builds to fail.

# Demo

<img width="308" height="42" alt="Screenshot 2026-04-20 at 17 38 27" src="https://github.com/user-attachments/assets/32e878cb-0713-4af0-8a95-7b054af1beaf" />


Deployed preview site: https://blockprotocol-evwokmqfh.stage.hash.ai/