### PR TITLE
H-6531: Update `uuid`

### DIFF
--- a/.changeset/light-beans-hunt.md
+++ b/.changeset/light-beans-hunt.md
@@ -1,0 +1,5 @@
+---
+"@blockprotocol/core": patch
+---
+
+Update uuid

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -84,7 +84,7 @@
     "slugify": "^1.6.5",
     "twind": "^0.16.17",
     "unified": "^10.1.2",
-    "uuid": "^8.3.2"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@local/eslint-config": "0.0.0-private",
@@ -107,7 +107,6 @@
     "@types/react-slick": "^0.23.10",
     "@types/sanitize-html": "^2.6.2",
     "@types/trusted-types": "2.0.7",
-    "@types/uuid": "^8.3.4",
     "babel-plugin-inline-react-svg": "2.0.1",
     "babel-plugin-istanbul": "^6.1.1",
     "chalk": "5.2.0",

--- a/libs/@blockprotocol/core/package.json
+++ b/libs/@blockprotocol/core/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "es-module-lexer": "^0.10.5",
-    "uuid": "^8.3.2"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@local/eslint-config": "0.0.0-private",

--- a/libs/mock-block-dock/package.json
+++ b/libs/mock-block-dock/package.json
@@ -53,7 +53,7 @@
     "slate-react": "^0.83.1",
     "styled-jsx": "^5.1.0",
     "use-local-storage-state": "^18.1.1",
-    "uuid": "^8.3.2"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.21.0",

--- a/libs/wordpress-plugin/package.json
+++ b/libs/wordpress-plugin/package.json
@@ -44,7 +44,6 @@
     "@types/react": "19.0.1",
     "@types/react-dom": "19.0.2",
     "@types/sanitize-html": "2.8.1",
-    "@types/uuid": "8.3.4",
     "@types/wordpress__block-editor": "7.0.0",
     "@types/wordpress__blocks": "11.0.7",
     "@wordpress/api-fetch": "6.18.0",
@@ -61,7 +60,7 @@
     "sanitize-html": "2.12.1",
     "ts-loader": "9.4.1",
     "typescript": "4.8.4",
-    "uuid": "9.0.0",
+    "uuid": "14.0.0",
     "webpack": "5.106.2",
     "webpack-bundle-analyzer": "4.7.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4783,11 +4783,6 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
-"@types/uuid@^8.3.4":
-  version "8.3.4"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
-  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
-
 "@types/wait-on@5.3.4":
   version "5.3.4"
   resolved "https://registry.yarnpkg.com/@types/wait-on/-/wait-on-5.3.4.tgz#5ee270b3e073fb01073f9f044922c6893de8c4d2"
@@ -16542,6 +16537,11 @@ uuid@8.3.2, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+uuid@^14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.0.tgz#0af883220163d264ffe0c084f6b8a89b9666966d"
+  integrity sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==
 
 uvu@^0.5.0:
   version "0.5.3"


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Updates `uuid`, mainly as we use `@blockprotocol/core` elsewhere so want the dependency up to date.