### PR TITLE
H-6570: Make some packages private

### DIFF
--- a/libs/@blockprotocol/graph/package.json
+++ b/libs/@blockprotocol/graph/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blockprotocol/graph",
   "version": "0.3.4",
+  "private": true,
   "description": "Implementation of the Block Protocol Graph service specification for blocks and embedding applications",
   "keywords": [
     "blockprotocol",

--- a/libs/block-scripts/package.json
+++ b/libs/block-scripts/package.json
@@ -1,6 +1,7 @@
 {
   "name": "block-scripts",
   "version": "0.3.5",
+  "private": true,
   "description": "Block development framework",
   "keywords": [
     "blockprotocol",

--- a/libs/block-template-custom-element/package.json
+++ b/libs/block-template-custom-element/package.json
@@ -1,6 +1,7 @@
 {
   "name": "block-template-custom-element",
   "version": "0.4.6",
+  "private": true,
   "description": "Block Protocol block template for a custom element-based block",
   "keywords": [
     "blockprotocol",

--- a/libs/mock-block-dock/package.json
+++ b/libs/mock-block-dock/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mock-block-dock",
   "version": "0.1.10",
+  "private": true,
   "description": "A mock embedding application for Block Protocol blocks",
   "keywords": [
     "blockprotocol",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

I want to publish a new version of `@blockprotocol/core` without publishing new versions of `@blockprotocol/graph` (which we're now publishing from the `hash` repo). This repo needs cleaning up to remove packages that are now developed elsewhere, but for now this PR makes some packages private to avoid publishing them.