### PR TITLE
H-6576: Fix `@blockprotocol/core` version

### DIFF
--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -17,7 +17,7 @@
     "start": "yarn exe scripts/start.ts"
   },
   "dependencies": {
-    "@blockprotocol/core": "0.1.4",
+    "@blockprotocol/core": "0.1.5",
     "@blockprotocol/graph": "0.3.5",
     "@blockprotocol/hook": "0.1.9",
     "@blockprotocol/service": "0.1.6",

--- a/libs/@blockprotocol/core/CHANGELOG.md
+++ b/libs/@blockprotocol/core/CHANGELOG.md
@@ -1,12 +1,16 @@
 # @blockprotocol/core
 
+## 0.1.5
+
+### Patch Changes
+
+- [#1565](https://github.com/blockprotocol/blockprotocol/pull/1565) [`a9652ee4`](https://github.com/blockprotocol/blockprotocol/commit/a9652ee48e8dcf01ae21f10dc4c2dbbd7f50ad39) Thanks [@CiaranMn](https://github.com/CiaranMn)! - Update uuid
+
 ## 0.1.4
 
 ### Patch Changes
 
 - [#1469](https://github.com/blockprotocol/blockprotocol/pull/1469) [`06bcdcad`](https://github.com/blockprotocol/blockprotocol/commit/06bcdcad0b0b36c39243337f701c8a927ad75977) Thanks [@CiaranMn](https://github.com/CiaranMn)! - Update to React 19
-
-- [#1565](https://github.com/blockprotocol/blockprotocol/pull/1565) [`a9652ee4`](https://github.com/blockprotocol/blockprotocol/commit/a9652ee48e8dcf01ae21f10dc4c2dbbd7f50ad39) Thanks [@CiaranMn](https://github.com/CiaranMn)! - Update uuid
 
 ## 0.1.3
 

--- a/libs/@blockprotocol/core/package.json
+++ b/libs/@blockprotocol/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blockprotocol/core",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Implementation of the Block Protocol Core specification for blocks and embedding applications",
   "keywords": [
     "blockprotocol",

--- a/libs/@blockprotocol/graph/package.json
+++ b/libs/@blockprotocol/graph/package.json
@@ -131,7 +131,7 @@
     "lint:tsc": "tsc --noEmit"
   },
   "dependencies": {
-    "@blockprotocol/core": "0.1.4",
+    "@blockprotocol/core": "0.1.5",
     "@blockprotocol/type-system": "0.1.1",
     "ajv": "^8.11.2",
     "ajv-formats": "^2.1.1",

--- a/libs/@blockprotocol/hook/package.json
+++ b/libs/@blockprotocol/hook/package.json
@@ -53,7 +53,7 @@
     "lint:tsc": "tsc --noEmit"
   },
   "dependencies": {
-    "@blockprotocol/core": "0.1.4",
+    "@blockprotocol/core": "0.1.5",
     "@blockprotocol/graph": "0.3.5"
   },
   "devDependencies": {

--- a/libs/@blockprotocol/service/package.json
+++ b/libs/@blockprotocol/service/package.json
@@ -54,7 +54,7 @@
     "lint:tsc": "tsc --noEmit"
   },
   "dependencies": {
-    "@blockprotocol/core": "0.1.4"
+    "@blockprotocol/core": "0.1.5"
   },
   "devDependencies": {
     "@local/eslint-config": "0.0.0-private",

--- a/libs/mock-block-dock/package.json
+++ b/libs/mock-block-dock/package.json
@@ -35,7 +35,7 @@
     "run-dev-server": "cross-env NODE_ENV=development webpack-dev-server --config dev/webpack.config.js"
   },
   "dependencies": {
-    "@blockprotocol/core": "0.1.4",
+    "@blockprotocol/core": "0.1.5",
     "@blockprotocol/graph": "0.3.5",
     "@blockprotocol/hook": "0.1.9",
     "@blockprotocol/service": "0.1.6",


### PR DESCRIPTION
## 🌟 What is the purpose of this PR?

Now that release is working again it turns out I published a version of `@blockprotocol/core` manually at some point. 

This PR fixes the versions up properly so that automatic publishing works again in future.